### PR TITLE
refactor(tests): Improve readability by localizing mocks

### DIFF
--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -2,7 +2,6 @@ import { assertEquals } from "jsr:@std/assert";
 import { describe, it } from "jsr:@std/testing/bdd";
 import { stub } from "jsr:@std/testing/mock";
 import * as apiClient from "./api_client.ts";
-import { hc } from "hono/client";
 
 // Hono's client internally uses `fetch`, so we need to stub `fetch`
 // to mock the API responses.

--- a/bot/src/commands/health.test.ts
+++ b/bot/src/commands/health.test.ts
@@ -1,152 +1,96 @@
 import { assertEquals } from "jsr:@std/assert";
 import { describe, it } from "jsr:@std/testing/bdd";
-import { spy, stub } from "jsr:@std/testing/mock";
-import {
-  type CommandInteraction,
-  type InteractionDeferReplyOptions,
-  type InteractionEditReplyOptions,
-  type MessagePayload,
-} from "npm:discord.js";
+import { stub } from "jsr:@std/testing/mock";
 import { execute } from "./health.ts";
+import { newMockInteractionBuilder } from "../test_utils.ts";
 
 describe("Health Command", () => {
   describe("execute", () => {
-    // Helper function to create spies and a mock interaction
-    const setupMocks = () => {
-      const deferReplySpy = spy(
-        (_options?: InteractionDeferReplyOptions) => Promise.resolve(),
-      );
-      const editReplySpy = spy(
-        (_options: string | MessagePayload | InteractionEditReplyOptions) =>
-          Promise.resolve(),
-      );
-      const interaction = {
-        isChatInputCommand: () => true,
-        deferReply: deferReplySpy,
-        editReply: editReplySpy,
-      } as unknown as CommandInteraction;
-      return { deferReplySpy, editReplySpy, interaction };
-    };
-
     it("APIが正常な時にコマンドを実行すると、APIからの成功メッセージで応答する", async () => {
-      const fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(
-              JSON.stringify({
-                ok: true,
-                message: "All systems operational.",
-              }),
-              {
-                status: 200,
-                headers: { "Content-Type": "application/json" },
-              },
-            ),
-          ),
+      const response = new Response(
+        JSON.stringify({
+          ok: true,
+          message: "All systems operational.",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
       );
-      const { deferReplySpy, editReplySpy, interaction } = setupMocks();
+      using _fetchStub = stub(globalThis, "fetch", () =>
+        Promise.resolve(response));
+      const interaction = newMockInteractionBuilder().build();
 
-      try {
-        await execute(interaction);
-        assertEquals(deferReplySpy.calls.length, 1);
-        assertEquals(editReplySpy.calls.length, 1);
-        assertEquals(
-          editReplySpy.calls[0].args[0],
-          "All systems operational.",
-        );
-      } finally {
-        fetchStub.restore();
-      }
+      await execute(interaction);
+
+      assertEquals(interaction.deferReply.calls.length, 1);
+      assertEquals(interaction.editReply.calls.length, 1);
+      assertEquals(
+        interaction.editReply.calls[0].args[0],
+        "All systems operational.",
+      );
     });
 
     it("APIがメッセージを返さない時にコマンドを実行すると、デフォルトの成功メッセージで応答する", async () => {
-      const fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(
-              JSON.stringify({ ok: true, message: null }),
-              {
-                status: 200,
-                headers: { "Content-Type": "application/json" },
-              },
-            ),
-          ),
+      const response = new Response(
+        JSON.stringify({ ok: true, message: null }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
       );
-      const { deferReplySpy, editReplySpy, interaction } = setupMocks();
+      using _fetchStub = stub(globalThis, "fetch", () =>
+        Promise.resolve(response));
+      const interaction = newMockInteractionBuilder().build();
 
-      try {
-        await execute(interaction);
-        assertEquals(deferReplySpy.calls.length, 1);
-        assertEquals(editReplySpy.calls.length, 1);
-        assertEquals(
-          editReplySpy.calls[0].args[0],
-          "The bot is healthy!",
-        );
-      } finally {
-        fetchStub.restore();
-      }
+      await execute(interaction);
+
+      assertEquals(interaction.deferReply.calls.length, 1);
+      assertEquals(interaction.editReply.calls.length, 1);
+      assertEquals(
+        interaction.editReply.calls[0].args[0],
+        "The bot is healthy!",
+      );
     });
 
     it("APIがエラーを返す時にコマンドを実行すると、APIのエラーを含んだメッセージで応答する", async () => {
-      const fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response("Internal Server Error", { status: 500 }),
-          ),
-      );
-      const { deferReplySpy, editReplySpy, interaction } = setupMocks();
+      const response = new Response("Internal Server Error", { status: 500 });
+      using _fetchStub = stub(globalThis, "fetch", () =>
+        Promise.resolve(response));
+      const interaction = newMockInteractionBuilder().build();
 
-      try {
-        await execute(interaction);
-        assertEquals(deferReplySpy.calls.length, 1);
-        assertEquals(editReplySpy.calls.length, 1);
-        assertEquals(
-          editReplySpy.calls[0].args[0],
-          "Failed to check the bot's health. API returned status 500",
-        );
-      } finally {
-        fetchStub.restore();
-      }
+      await execute(interaction);
+
+      assertEquals(interaction.deferReply.calls.length, 1);
+      assertEquals(interaction.editReply.calls.length, 1);
+      assertEquals(
+        interaction.editReply.calls[0].args[0],
+        "Failed to check the bot's health. API returned status 500",
+      );
     });
 
     it("APIとの通信に失敗した時にコマンドを実行すると、通信失敗を示すメッセージで応答する", async () => {
-      const fetchStub = stub(
-        globalThis,
-        "fetch",
-        () => Promise.reject(new Error("Network disconnect")),
-      );
-      const { deferReplySpy, editReplySpy, interaction } = setupMocks();
+      using _fetchStub = stub(globalThis, "fetch", () =>
+        Promise.reject(new Error("Network disconnect")));
+      const interaction = newMockInteractionBuilder().build();
 
-      try {
-        await execute(interaction);
-        assertEquals(deferReplySpy.calls.length, 1);
-        assertEquals(editReplySpy.calls.length, 1);
-        assertEquals(
-          editReplySpy.calls[0].args[0],
-          "Failed to check the bot's health. Failed to communicate with API",
-        );
-      } finally {
-        fetchStub.restore();
-      }
+      await execute(interaction);
+
+      assertEquals(interaction.deferReply.calls.length, 1);
+      assertEquals(interaction.editReply.calls.length, 1);
+      assertEquals(
+        interaction.editReply.calls[0].args[0],
+        "Failed to check the bot's health. Failed to communicate with API",
+      );
     });
 
     it("チャットインプットコマンドでないインタラクションで実行すると、何もせずに処理を中断する", async () => {
-      const deferReplySpy = spy(
-        (_options?: InteractionDeferReplyOptions) => Promise.resolve(),
-      );
-      const interaction = {
-        isChatInputCommand: () => false,
-        deferReply: deferReplySpy,
-      } as unknown as CommandInteraction;
+      const interaction = newMockInteractionBuilder()
+        .withIsChatInputCommand(false)
+        .build();
 
       await execute(interaction);
-      assertEquals(deferReplySpy.calls.length, 0);
+      assertEquals(interaction.deferReply.calls.length, 0);
     });
   });
 });

--- a/bot/src/commands/set-main-role.test.ts
+++ b/bot/src/commands/set-main-role.test.ts
@@ -1,45 +1,14 @@
 import { assertEquals } from "jsr:@std/assert";
 import { describe, it } from "jsr:@std/testing/bdd";
-import { spy, stub } from "jsr:@std/testing/mock";
-import {
-  type CommandInteraction,
-  type InteractionDeferReplyOptions,
-  type InteractionEditReplyOptions,
-  type MessagePayload,
-} from "npm:discord.js";
+import { stub } from "jsr:@std/testing/mock";
 import { type Lane } from "@adteemo/api/schema";
 import { execute } from "./set-main-role.ts";
+import { newMockInteractionBuilder } from "../test_utils.ts";
 
 describe("Set Main Role Command", () => {
   describe("execute", () => {
-    // Helper function to create mocks
-    const setupMocks = (role: Lane | null) => {
-      const deferReplySpy = spy(
-        (_options?: InteractionDeferReplyOptions) => Promise.resolve(),
-      );
-      const editReplySpy = spy(
-        (_options: string | MessagePayload | InteractionEditReplyOptions) =>
-          Promise.resolve(),
-      );
-      const getStringSpy = spy((_name: string, _required?: boolean) => role);
-
-      const interaction = {
-        isChatInputCommand: () => true,
-        deferReply: deferReplySpy,
-        editReply: editReplySpy,
-        options: {
-          getString: getStringSpy,
-        },
-        user: {
-          id: "test-user-id",
-        },
-      } as unknown as CommandInteraction;
-
-      return { deferReplySpy, editReplySpy, getStringSpy, interaction };
-    };
-
     it("API呼び出しが成功した時にメインロールを設定すると、成功メッセージで応答する", async () => {
-      const fetchStub = stub(
+      using _fetchStub = stub(
         globalThis,
         "fetch",
         () =>
@@ -47,64 +16,48 @@ describe("Set Main Role Command", () => {
             new Response(JSON.stringify({ success: true }), { status: 200 }),
           ),
       );
-      const { deferReplySpy, editReplySpy, getStringSpy, interaction } =
-        setupMocks("Top");
-
-      try {
-        await execute(interaction);
-
-        assertEquals(deferReplySpy.calls.length, 1);
-        assertEquals(getStringSpy.calls[0].args[0], "role");
-        assertEquals(editReplySpy.calls.length, 1);
-        assertEquals(
-          editReplySpy.calls[0].args[0],
-          "Your main role has been set to **Top**.",
-        );
-      } finally {
-        fetchStub.restore();
-      }
-    });
-
-    it("API呼び出しが失敗した時にメインロールを設定すると、エラーメッセージで応答する", async () => {
-      const fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(
-              JSON.stringify({ success: false, error: "DB error" }),
-              {
-                status: 500,
-              },
-            ),
-          ),
-      );
-      const { deferReplySpy, editReplySpy, interaction } = setupMocks(
-        "Jungle",
-      );
-
-      try {
-        await execute(interaction);
-
-        assertEquals(deferReplySpy.calls.length, 1);
-        assertEquals(editReplySpy.calls.length, 1);
-        assertEquals(
-          editReplySpy.calls[0].args[0],
-          "Failed to set your main role. API returned status 500",
-        );
-      } finally {
-        fetchStub.restore();
-      }
-    });
-
-    it("チャットインプットコマンドでないインタラクションで実行すると、何もせずに処理を中断する", async () => {
-      const { deferReplySpy, interaction } = setupMocks("Top");
-      // deno-lint-ignore no-explicit-any
-      (interaction as any).isChatInputCommand = () => false;
+      const interaction = newMockInteractionBuilder()
+        .withStringOption(() => "Top")
+        .build();
 
       await execute(interaction);
 
-      assertEquals(deferReplySpy.calls.length, 0);
+      assertEquals(interaction.deferReply.calls.length, 1);
+      assertEquals(interaction.options.getString.calls[0].args[0], "role");
+      assertEquals(interaction.editReply.calls.length, 1);
+      assertEquals(
+        interaction.editReply.calls[0].args[0],
+        "Your main role has been set to **Top**.",
+      );
+    });
+
+    it("API呼び出しが失敗した時にメインロールを設定すると、エラーメッセージで応答する", async () => {
+      const fetchResponse = new Response(
+        JSON.stringify({ success: false, error: "DB error" }),
+        { status: 500 },
+      );
+      using _fetchStub = stub(globalThis, "fetch", () =>
+        Promise.resolve(fetchResponse));
+      const interaction = newMockInteractionBuilder()
+        .withStringOption(() => "Jungle")
+        .build();
+
+      await execute(interaction);
+
+      assertEquals(interaction.deferReply.calls.length, 1);
+      assertEquals(interaction.editReply.calls.length, 1);
+      assertEquals(
+        interaction.editReply.calls[0].args[0],
+        "Failed to set your main role. API returned status 500",
+      );
+    });
+
+    it("チャットインプットコマンドでないインタラクションで実行すると、何もせずに処理を中断する", async () => {
+      const interaction = newMockInteractionBuilder()
+        .withIsChatInputCommand(false)
+        .build();
+      await execute(interaction);
+      assertEquals(interaction.deferReply.calls.length, 0);
     });
   });
 });

--- a/bot/src/commands/setup-roles.test.ts
+++ b/bot/src/commands/setup-roles.test.ts
@@ -3,78 +3,25 @@ import { describe, it } from "jsr:@std/testing/bdd";
 import { spy } from "jsr:@std/testing/mock";
 import {
   Collection,
-  type CommandInteraction,
   DiscordAPIError,
-  type Guild,
-  type InteractionDeferReplyOptions,
-  type InteractionEditReplyOptions,
-  type InteractionReplyOptions,
-  type MessagePayload,
   RESTJSONErrorCodes,
+  type Guild,
+  type InteractionReplyOptions,
   type Role,
 } from "npm:discord.js";
 import { execute } from "./setup-roles.ts";
 import { DISCORD_ROLES_TO_MANAGE } from "../constants.ts";
+import { newMockInteractionBuilder } from "../test_utils.ts";
 
 describe("Setup Roles Command", () => {
-  // Helper to create a mock interaction and guild
-  const setupMocks = (
-    existingRoles: string[] = [],
-    roleCreateError?: Error,
-  ) => {
-    const deferReplySpy = spy((_o?: InteractionDeferReplyOptions) =>
-      Promise.resolve()
-    );
-    const editReplySpy = spy((
-      _o: string | MessagePayload | InteractionEditReplyOptions,
-    ) => Promise.resolve());
-    const replySpy = spy((_o: string | InteractionReplyOptions) =>
-      Promise.resolve()
-    );
-
-    const mockRoles = new Collection<string, Role>(
-      existingRoles.map((name, i) => [
-        `role_id_${i}`,
-        { name } as Role,
-      ]),
-    );
-
-    const rolesCreateSpy = spy((options?: { name: string }) => {
-      if (roleCreateError) return Promise.reject(roleCreateError);
-      return Promise.resolve({ name: options?.name } as Role);
-    });
-
-    const mockGuild = {
-      id: "mock-guild-id",
-      roles: {
-        cache: mockRoles,
-        create: rolesCreateSpy,
-      },
-    } as unknown as Guild;
-
-    const interaction = {
-      isChatInputCommand: () => true,
-      deferReply: deferReplySpy,
-      editReply: editReplySpy,
-      reply: replySpy,
-      guild: mockGuild,
-    } as unknown as CommandInteraction;
-
-    return {
-      deferReplySpy,
-      editReplySpy,
-      replySpy,
-      interaction,
-      rolesCreateSpy,
-    };
-  };
-
   it("ギルド（サーバー）外でコマンドを実行すると、エラーメッセージを返信する", async () => {
-    const { replySpy, interaction } = setupMocks();
-    (interaction as { guild: Guild | null }).guild = null;
+    const interaction = newMockInteractionBuilder().withGuild(null).build();
+
     await execute(interaction);
-    assertEquals(replySpy.calls.length, 1);
-    const replyArgs = replySpy.calls[0].args[0] as InteractionReplyOptions;
+
+    assertEquals(interaction.reply.calls.length, 1);
+    const replyArgs = interaction.reply.calls[0]
+      .args[0] as InteractionReplyOptions;
     assertEquals(
       replyArgs.content,
       "This command can only be used in a server.",
@@ -83,30 +30,56 @@ describe("Setup Roles Command", () => {
   });
 
   it("不足しているロールがある場合にコマンドを実行すると、それらを作成して成功を報告する", async () => {
-    const { deferReplySpy, editReplySpy, interaction, rolesCreateSpy } =
-      setupMocks(["Top", "JG"]);
+    const existingRoles = ["Top", "JG"];
+    const rolesCreateSpy = spy(() => Promise.resolve({} as Role));
+    const mockGuild = {
+      id: "mock-guild-id",
+      roles: {
+        cache: new Collection<string, Role>(
+          existingRoles.map((name, i) => [`role_id_${i}`, { name } as Role]),
+        ),
+        create: rolesCreateSpy,
+      },
+    } as unknown as Guild;
+    const interaction = newMockInteractionBuilder()
+      .withGuild(mockGuild)
+      .build();
+
     await execute(interaction);
 
     const expectedToCreate = DISCORD_ROLES_TO_MANAGE.length - 2;
-    assertEquals(deferReplySpy.calls.length, 1);
+    assertEquals(interaction.deferReply.calls.length, 1);
     assertEquals(rolesCreateSpy.calls.length, expectedToCreate);
-    assertEquals(editReplySpy.calls.length, 1);
-    const replyMessage = editReplySpy.calls[0].args[0] as string;
+    assertEquals(interaction.editReply.calls.length, 1);
+    const replyMessage = interaction.editReply.calls[0].args[0] as string;
     assert(replyMessage.includes("✅ セットアップ完了！"));
     assert(replyMessage.includes(`作成したロール (${expectedToCreate}件)`));
     assert(replyMessage.includes("既存のロール (2件)"));
   });
 
   it("管理対象の全ロールが既に存在する場合にコマンドを実行すると、ロールを作成せずに成功を報告する", async () => {
-    const { deferReplySpy, editReplySpy, interaction, rolesCreateSpy } =
-      setupMocks([...DISCORD_ROLES_TO_MANAGE]);
+    const existingRoles = [...DISCORD_ROLES_TO_MANAGE];
+    const rolesCreateSpy = spy(() => Promise.resolve({} as Role));
+    const mockGuild = {
+      id: "mock-guild-id",
+      roles: {
+        cache: new Collection<string, Role>(
+          existingRoles.map((name, i) => [`role_id_${i}`, { name } as Role]),
+        ),
+        create: rolesCreateSpy,
+      },
+    } as unknown as Guild;
+    const interaction = newMockInteractionBuilder()
+      .withGuild(mockGuild)
+      .build();
+
     await execute(interaction);
 
-    assertEquals(deferReplySpy.calls.length, 1);
+    assertEquals(interaction.deferReply.calls.length, 1);
     assertEquals(rolesCreateSpy.calls.length, 0);
-    assertEquals(editReplySpy.calls.length, 1);
+    assertEquals(interaction.editReply.calls.length, 1);
     assertEquals(
-      editReplySpy.calls[0].args[0],
+      interaction.editReply.calls[0].args[0],
       "✅ 必要なロールはすべて存在しています。",
     );
   });
@@ -123,31 +96,49 @@ describe("Setup Roles Command", () => {
       "/guilds/id/roles",
       {},
     );
-    const { deferReplySpy, editReplySpy, interaction } = setupMocks(
-      [],
-      error,
-    );
+    const rolesCreateSpy = spy(() => Promise.reject(error));
+    const mockGuild = {
+      id: "mock-guild-id",
+      roles: {
+        cache: new Collection<string, Role>(),
+        create: rolesCreateSpy,
+      },
+    } as unknown as Guild;
+    const interaction = newMockInteractionBuilder()
+      .withGuild(mockGuild)
+      .build();
+
     await execute(interaction);
 
-    assertEquals(deferReplySpy.calls.length, 1);
-    assertEquals(editReplySpy.calls.length, 1);
+    assertEquals(interaction.deferReply.calls.length, 1);
+    assertEquals(interaction.editReply.calls.length, 1);
     assertEquals(
-      editReplySpy.calls[0].args[0],
+      interaction.editReply.calls[0].args[0],
       "❌ 権限エラー。\nThe bot lacks the 'Manage Roles' permission.",
     );
   });
 
   it("ロール作成中に不明なエラーが発生した場合、コマンドは不明なエラーとして処理する", async () => {
-    const { deferReplySpy, editReplySpy, interaction } = setupMocks(
-      [],
-      new Error("Some other error"),
+    const rolesCreateSpy = spy(() =>
+      Promise.reject(new Error("Some other error"))
     );
+    const mockGuild = {
+      id: "mock-guild-id",
+      roles: {
+        cache: new Collection<string, Role>(),
+        create: rolesCreateSpy,
+      },
+    } as unknown as Guild;
+    const interaction = newMockInteractionBuilder()
+      .withGuild(mockGuild)
+      .build();
+
     await execute(interaction);
 
-    assertEquals(deferReplySpy.calls.length, 1);
-    assertEquals(editReplySpy.calls.length, 1);
+    assertEquals(interaction.deferReply.calls.length, 1);
+    assertEquals(interaction.editReply.calls.length, 1);
     assert(
-      (editReplySpy.calls[0].args[0] as string).startsWith(
+      (interaction.editReply.calls[0].args[0] as string).startsWith(
         "❌ 不明なエラー。",
       ),
     );

--- a/bot/src/features/role-management.test.ts
+++ b/bot/src/features/role-management.test.ts
@@ -1,33 +1,39 @@
 import { assertEquals, assertExists } from "jsr:@std/assert";
 import { describe, it } from "jsr:@std/testing/bdd";
-import { Collection, DiscordAPIError } from "npm:discord.js";
-import type { Guild, Role, RoleCreateOptions } from "npm:discord.js";
+import { spy } from "jsr:@std/testing/mock";
+import {
+  Collection,
+  DiscordAPIError,
+  RESTJSONErrorCodes,
+  type Guild,
+  type Role,
+  type RoleCreateOptions,
+} from "npm:discord.js";
 import { ensureRoles } from "./role-management.ts";
 import { DISCORD_ROLES_TO_MANAGE } from "../constants.ts";
 
 describe("ensureRoles", () => {
   it("管理対象のロールが一つも存在しないギルドで実行すると、すべてのロールを作成する", async () => {
-    const createdRolesLog: RoleCreateOptions[] = [];
+    const createSpy = spy(
+      (options: RoleCreateOptions): Promise<Role> =>
+        Promise.resolve({ name: options.name } as Role),
+    );
     const mockGuild = {
       roles: {
         cache: new Collection<string, Role>(),
-        // Manual mock/spy for the 'create' function
-        create: (options: RoleCreateOptions) => {
-          createdRolesLog.push(options);
-          return Promise.resolve({ name: options.name } as Role);
-        },
+        create: createSpy,
       },
     } as unknown as Guild;
 
     const result = await ensureRoles(mockGuild);
 
-    // Assert that the create function was called for each required role
-    assertEquals(createdRolesLog.length, DISCORD_ROLES_TO_MANAGE.length);
+    assertEquals(createSpy.calls.length, DISCORD_ROLES_TO_MANAGE.length);
     for (const roleName of DISCORD_ROLES_TO_MANAGE) {
-      assertExists(createdRolesLog.find((role) => role.name === roleName));
+      assertExists(
+        createSpy.calls.find(({ args }) => args[0].name === roleName),
+      );
     }
 
-    // Assert the result summary is correct
     assertEquals(result.status, "SUCCESS");
     if (result.status === "SUCCESS") {
       assertEquals(
@@ -39,63 +45,66 @@ describe("ensureRoles", () => {
   });
 
   it("管理対象のロールが一部のみ存在するギルドで実行すると、不足しているロールのみを作成する", async () => {
-    const existingRoles = ["Top", "JG", "Custom"];
+    const existingRoleNames = ["Top", "JG", "Custom"];
     const rolesToCreate = DISCORD_ROLES_TO_MANAGE.filter(
-      (r) => !existingRoles.includes(r),
+      (r) => !existingRoleNames.includes(r),
     );
-
-    const createdRolesLog: RoleCreateOptions[] = [];
+    const createSpy = spy(
+      (options: RoleCreateOptions): Promise<Role> =>
+        Promise.resolve({ name: options.name } as Role),
+    );
     const mockGuild = {
       roles: {
         cache: new Collection<string, Role>(
-          existingRoles.map((name, i) => [
+          existingRoleNames.map((name, i) => [
             i.toString(),
             { name, id: i.toString() } as Role,
           ]),
         ),
-        create: (options: RoleCreateOptions) => {
-          createdRolesLog.push(options);
-          return Promise.resolve({ name: options.name } as Role);
-        },
+        create: createSpy,
       },
     } as unknown as Guild;
 
     const result = await ensureRoles(mockGuild);
 
-    // Assert that create was only called for the missing roles
-    assertEquals(createdRolesLog.length, rolesToCreate.length);
+    assertEquals(createSpy.calls.length, rolesToCreate.length);
     for (const roleName of rolesToCreate) {
-      assertExists(createdRolesLog.find((role) => role.name === roleName));
+      assertExists(
+        createSpy.calls.find(({ args }) => args[0].name === roleName),
+      );
     }
 
-    // Assert the result summary is correct
     assertEquals(result.status, "SUCCESS");
     if (result.status === "SUCCESS") {
       assertEquals(result.summary.created.sort(), rolesToCreate.sort());
-      assertEquals(result.summary.existing.sort(), existingRoles.sort());
+      assertEquals(
+        result.summary.existing.sort(),
+        existingRoleNames.sort(),
+      );
     }
   });
 
   it("管理対象のロールがすべて存在するギルドで実行すると、ロールを一つも作成しない", async () => {
-    const createdRolesLog: RoleCreateOptions[] = [];
+    const existingRoleNames = [...DISCORD_ROLES_TO_MANAGE];
+    const createSpy = spy(
+      (options: RoleCreateOptions): Promise<Role> =>
+        Promise.resolve({ name: options.name } as Role),
+    );
     const mockGuild = {
       roles: {
         cache: new Collection<string, Role>(
-          DISCORD_ROLES_TO_MANAGE.map((name, i) => [
+          existingRoleNames.map((name, i) => [
             i.toString(),
             { name, id: i.toString() } as Role,
           ]),
         ),
-        create: (options: RoleCreateOptions) => {
-          createdRolesLog.push(options);
-          return Promise.resolve({ name: options.name } as Role);
-        },
+        create: createSpy,
       },
     } as unknown as Guild;
 
     const result = await ensureRoles(mockGuild);
 
-    assertEquals(createdRolesLog.length, 0);
+    assertEquals(createSpy.calls.length, 0);
     assertEquals(result.status, "SUCCESS");
     if (result.status === "SUCCESS") {
       assertEquals(result.summary.created, []);
@@ -107,22 +116,21 @@ describe("ensureRoles", () => {
   });
 
   it("ロールの作成中に権限エラーが発生すると、PERMISSION_ERRORステータスを返す", async () => {
+    const error = new DiscordAPIError(
+      { message: "Missing Permissions", code: 50013 },
+      RESTJSONErrorCodes.MissingPermissions,
+      403,
+      "POST",
+      "/guilds/123/roles",
+      {},
+    );
+    const createSpy = spy(
+      (_options: RoleCreateOptions): Promise<Role> => Promise.reject(error),
+    );
     const mockGuild = {
       roles: {
         cache: new Collection<string, Role>(),
-        create: () => {
-          // Simulate a Discord API error for missing permissions
-          const errorPayload = { message: "Missing Permissions", code: 50013 };
-          const error = new DiscordAPIError(
-            errorPayload,
-            50013,
-            403,
-            "POST",
-            "/guilds/123/roles",
-            {},
-          );
-          return Promise.reject(error);
-        },
+        create: createSpy,
       },
     } as unknown as Guild;
 

--- a/bot/src/test_utils.ts
+++ b/bot/src/test_utils.ts
@@ -1,0 +1,136 @@
+import { spy, type Spy } from "jsr:@std/testing/mock";
+import {
+  Collection,
+  SlashCommandBuilder,
+  type CacheType,
+  type ChatInputCommandInteraction,
+  type Client,
+  type CommandInteraction,
+  type CommandInteractionOptionResolver,
+  type Guild,
+  type InteractionDeferReplyOptions,
+  type InteractionEditReplyOptions,
+  type MessagePayload,
+  type Role,
+  type RoleManager,
+  type Snowflake,
+} from "npm:discord.js";
+import type { Command } from "./types.ts";
+
+type MockOptions = {
+  isChatInputCommand: boolean;
+  commandName: string;
+  guild: Partial<Guild> | null;
+  client: Partial<Client> & { commands: Collection<string, Command> };
+  replied: boolean;
+  deferred: boolean;
+  user: { id: string };
+  options: {
+    getString?: (name: string, required?: boolean) => string | null;
+  };
+};
+
+export function newMockInteractionBuilder(commandName = "test-command") {
+  const props: MockOptions = {
+    commandName,
+    isChatInputCommand: true,
+    guild: {
+      id: "mock-guild-id",
+      roles: {
+        cache: new Collection<Snowflake, Role>(),
+        create: spy(() => Promise.resolve({} as Role)),
+      } as unknown as RoleManager, // This cast is necessary for a partial mock
+    } as Partial<Guild>,
+    client: {
+      commands: new Collection<string, Command>(),
+    },
+    replied: false,
+    deferred: false,
+    user: { id: "test-user-id" },
+    options: {},
+  };
+
+  const builder = {
+    withCommandName(name: string) {
+      props.commandName = name;
+      return this;
+    },
+
+    withIsChatInputCommand(is: boolean) {
+      props.isChatInputCommand = is;
+      return this;
+    },
+
+    withClient(
+      client: Partial<Client> & { commands: Collection<string, Command> },
+    ) {
+      props.client = client;
+      return this;
+    },
+
+    withGuild(guild: Partial<Guild> | null) {
+      props.guild = guild;
+      return this;
+    },
+
+    withStringOption(
+      fn: (name: string, required?: boolean) => string | null,
+    ) {
+      props.options.getString = fn;
+      return this;
+    },
+
+    setReplied(replied: boolean) {
+      props.replied = replied;
+      return this;
+    },
+
+    build() {
+      const interaction = {
+        isChatInputCommand: (): this is ChatInputCommandInteraction<CacheType> =>
+          props.isChatInputCommand,
+        commandName: props.commandName,
+        deferReply: spy(
+          (_o?: InteractionDeferReplyOptions) => Promise.resolve(),
+        ),
+        editReply: spy(
+          (_o: string | MessagePayload | InteractionEditReplyOptions) =>
+            Promise.resolve(),
+        ),
+        followUp: spy(
+          (_o: string | MessagePayload | InteractionEditReplyOptions) =>
+            Promise.resolve(),
+        ),
+        reply: spy(
+          (_o: string | MessagePayload | InteractionEditReplyOptions) =>
+            Promise.resolve(),
+        ),
+        guild: props.guild,
+        client: props.client,
+        replied: props.replied,
+        deferred: props.deferred,
+        user: props.user,
+        options: {
+          getString: spy(
+            (name: string, required?: boolean) =>
+              props.options.getString?.(name, required),
+          ),
+        },
+      };
+
+      return interaction as unknown as CommandInteraction & {
+        deferReply: Spy;
+        editReply: Spy;
+        followUp: Spy;
+        reply: Spy;
+        guild: typeof props.guild;
+        client: typeof props.client;
+        options: {
+          getString: Spy<CommandInteractionOptionResolver["getString"]>;
+        };
+      };
+    },
+  };
+
+  return builder;
+}


### PR DESCRIPTION
Refactors the command tests to remove shared `setupTest` helper functions.

Mocks and stubs are now created locally within each individual test case. This makes the dependencies of each test more explicit and improves readability, as tests only create the mocks they specifically need.

This change continues to use the `newMockInteractionBuilder` and the `using` keyword for clean and maintainable test setup.