### PR TITLE
refactor(bot): split-teamsコマンドのメンテナンス性向上のためのリファクタリング

### DIFF
--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import { relations } from "drizzle-orm";
+import { type InferSelectModel, relations } from "drizzle-orm";
 
 export const lanes = ["Top", "Jungle", "Middle", "Bottom", "Support"] as const;
 export type Lane = (typeof lanes)[number];
@@ -52,6 +52,8 @@ export const customGameEvents = sqliteTable("custom_game_events", {
     () => new Date(),
   ),
 });
+
+export type Event = InferSelectModel<typeof customGameEvents>;
 
 // --- RELATIONS ---
 

--- a/bot/src/constants.ts
+++ b/bot/src/constants.ts
@@ -16,3 +16,14 @@ export const DISCORD_ROLES_TO_MANAGE = [
   "Custom",
 ] as const;
 export type DiscordRole = (typeof DISCORD_ROLES_TO_MANAGE)[number];
+
+export const TEAM_A_VC_NAME = "Red Team";
+export const TEAM_B_VC_NAME = "Blue Team";
+
+export const ROLE_EMOJIS: Record<Lane, string> = {
+  Top: "🇹",
+  Jungle: "🇯",
+  Middle: "🇲",
+  Bottom: "🇧",
+  Support: "🇸",
+};


### PR DESCRIPTION
`split-teams`コマンドの初期実装は、すべてのロジックが単一の`execute`関数内にあり、コードが長く複雑で、将来の機能拡張やデバッグが困難な状態でした。

この技術的負債を解消し、メンテナンス性を向上させるため、以下のリファクタリングを実施しました。

- **責務の分離:** ロジックを「イベント取得」「参加者検証」「チーム分割」などの独立した関数に分割し、各処理の役割を明確化。
- **可読性の向上:** 関数や処理の流れにコメントを追加し、コードの意図を理解しやすくした。
- **堅牢性の向上:** リファクタリングの過程で発見されたAPIレスポンスとDBスキーマ間の型の不整合を修正。