### PR TITLE
fix[api]: Riot ID連携時に未登録ユーザーが永続化されない問題に備える

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -3,7 +3,7 @@
 このファイルは Codex が進捗管理しやすいよう、実装順に並べたチェックリストです。完了したタスクは `[x]` に更新してください。
 
 1. [x] `bot/src/commands/create-custom-game.ts`: `deferReply` 後に `reply` を再度呼び出しているパスを修正し、常に `editReply`/`followUp` を用いる。
-2. [ ] `api/src/routes/users.ts` + `api/src/db/actions.ts`: Riot ID 連携時にユーザーを確実に永続化するため `upsertUser` を組み込み、未登録でも 204 を返さないようにする。
+2. [x] `api/src/routes/users.ts` + `api/src/db/actions.ts`: Riot ID 連携時にユーザーを確実に永続化するため `upsertUser` を組み込み、未登録でも 204 を返さないようにする。
 3. [ ] 共通ロガーを導入し、API・Bot の主要エントリポイントから構造化ログを出力する（例: `api/src/app.ts`, `bot/src/main.ts`）。
 4. [ ] CI 要件定義を実施し、GitHub Actions で実行すべき検証（lint/fmt/check/test・デプロイ連携など）とトリガー条件を整理する。
 5. [ ] GitHub Actions を設定し、`deno lint`/`deno fmt --check`/`deno check`/テストを実行する CI ワークフロー（例: `.github/workflows/ci.yml`）を追加する。
@@ -22,3 +22,4 @@
 18. [ ] チーム分け時の戦力均等化ロジックと内部レート計算式を仕様に合わせて高度化する。
 19. [ ] Web サイトの要件定義を実施し、主要ユースケース・API 連携要件を整理する。
 20. [ ] 上記要件に基づき Web UI（管理者・参加者向け）を実装する。
+21. [ ] API 応答に含まれている `success` フラグを整理し、HTTP ステータスコードだけで成否を判定できるよう統一する方針を設計・実装する。

--- a/api/src/db/actions.ts
+++ b/api/src/db/actions.ts
@@ -130,16 +130,12 @@ async function updateUserRiotId(discordId: string, riotId: string) {
 }
 
 async function linkUserWithRiotId(discordId: string, riotId: string) {
-  const upsertPayload = userInsertSchema.parse({ discordId });
+  const payload = userInsertSchema.parse({ discordId, riotId });
 
-  await db.transaction(async (tx) => {
-    await tx.insert(users).values(upsertPayload).onConflictDoNothing()
-      .execute();
-
-    await tx.update(users).set({ riotId }).where(
-      eq(users.discordId, discordId),
-    ).execute();
-  });
+  await db.insert(users).values(payload).onConflictDoUpdate({
+    target: users.discordId,
+    set: { riotId },
+  }).execute();
 }
 
 async function createAuthState(state: string, discordId: string) {

--- a/api/src/db/actions.ts
+++ b/api/src/db/actions.ts
@@ -129,6 +129,19 @@ async function updateUserRiotId(discordId: string, riotId: string) {
     .execute();
 }
 
+async function linkUserWithRiotId(discordId: string, riotId: string) {
+  const upsertPayload = userInsertSchema.parse({ discordId });
+
+  await db.transaction(async (tx) => {
+    await tx.insert(users).values(upsertPayload).onConflictDoNothing()
+      .execute();
+
+    await tx.update(users).set({ riotId }).where(
+      eq(users.discordId, discordId),
+    ).execute();
+  });
+}
+
 async function createAuthState(state: string, discordId: string) {
   await db.insert(authStates).values({ state, discordId }).execute();
 }
@@ -145,5 +158,6 @@ export const dbActions = {
   getAuthState,
   deleteAuthState,
   updateUserRiotId,
+  linkUserWithRiotId,
   createAuthState,
 };

--- a/api/src/routes/auth.test.ts
+++ b/api/src/routes/auth.test.ts
@@ -77,9 +77,9 @@ describe("routes/auth.ts", () => {
           "getUserInfo",
           () => Promise.resolve({ sub: riotId }),
         );
-        using updateUserRiotIdStub = stub(
+        using linkUserWithRiotIdStub = stub(
           dbActions,
-          "updateUserRiotId",
+          "linkUserWithRiotId",
           () => Promise.resolve(),
         );
         using deleteAuthStateStub = stub(
@@ -103,7 +103,9 @@ describe("routes/auth.ts", () => {
         assertSpyCall(getAuthStateStub, 0, { args: [state] });
         assertSpyCall(exchangeCodeForTokensStub, 0, { args: [code] });
         assertSpyCall(getUserInfoStub, 0, { args: [accessToken] });
-        assertSpyCall(updateUserRiotIdStub, 0, { args: [discordId, riotId] });
+        assertSpyCall(linkUserWithRiotIdStub, 0, {
+          args: [discordId, riotId],
+        });
         assertSpyCall(deleteAuthStateStub, 0, { args: [state] });
       });
     });

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -63,7 +63,7 @@ export const authRoutes = new Hono()
         const { sub: riotId } = await rso.getUserInfo(accessToken);
 
         // 4. Update user's Riot ID in DB
-        await dbActions.updateUserRiotId(discordId, riotId);
+        await dbActions.linkUserWithRiotId(discordId, riotId);
 
         // 5. Clean up auth state
         await dbActions.deleteAuthState(state);

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -33,9 +33,10 @@ export const usersRoutes = new Hono()
         }, 404);
       }
 
+      await dbActions.upsertUser(discordId);
       await dbActions.updateUserRiotId(discordId, account.puuid);
 
-      return c.body(null, 204);
+      return c.json({ success: true });
     },
   )
   .put(

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -33,8 +33,7 @@ export const usersRoutes = new Hono()
         }, 404);
       }
 
-      await dbActions.upsertUser(discordId);
-      await dbActions.updateUserRiotId(discordId, account.puuid);
+      await dbActions.linkUserWithRiotId(discordId, account.puuid);
 
       return c.json({ success: true });
     },

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -22,9 +22,14 @@ async function linkAccountByRiotId(
     });
 
     if (!res.ok) {
-      const errorBody = await res.json();
+      const errorBody = await res.json().catch(() => null);
+      const error = errorBody && typeof errorBody === "object" &&
+          "error" in errorBody &&
+          typeof (errorBody as { error: unknown }).error === "string"
+        ? (errorBody as { error: string }).error
+        : `API Error: ${res.status} ${res.statusText}`;
       console.error(`API Error: ${res.status} ${res.statusText}`, errorBody);
-      return { success: false, error: errorBody.error };
+      return { success: false, error };
     }
 
     return { success: true };

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -11,12 +11,15 @@ if (!API_URL) {
 
 export const client: Client = hcWithType(API_URL);
 
+type ErrorPayload = { error: unknown };
+
+function hasErrorProperty(value: unknown): value is ErrorPayload {
+  return typeof value === "object" && value !== null && "error" in value;
+}
+
 function extractErrorMessage(payload: unknown): string | undefined {
-  if (payload && typeof payload === "object") {
-    const candidate = (payload as Record<string, unknown>).error;
-    if (typeof candidate === "string") {
-      return candidate;
-    }
+  if (hasErrorProperty(payload) && typeof payload.error === "string") {
+    return payload.error;
   }
   return undefined;
 }


### PR DESCRIPTION
Riot ID 連携 API が存在しないユーザーでも常に 204 を返していたため、Bot 側で成功と誤認しつつ実際にはレコードが作成されないケースがありました。Riot API でアカウントが得られた場合には必ず upsert を実行し、HTTP 200 とレスポンスボディで成功を通知することで整合性を担保します。Bot クライアント側もエラー本文の有無にかかわらず扱いやすいメッセージを返すよう調整しています。これによりタスクの要件を満たしつつ、後続で success フラグ整理の検討を進めやすくなります。