### PR TITLE
feat[db]: ギルド別ユーザー情報の正規化と連携改善

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -7,7 +7,7 @@
 3. [ ] 共通ロガーを導入し、API・Bot の主要エントリポイントから構造化ログを出力する（例: `api/src/app.ts`, `bot/src/main.ts`）。
 4. [ ] CI 要件定義を実施し、GitHub Actions で実行すべき検証（lint/fmt/check/test・デプロイ連携など）とトリガー条件を整理する。
 5. [ ] GitHub Actions を設定し、`deno lint`/`deno fmt --check`/`deno check`/テストを実行する CI ワークフロー（例: `.github/workflows/ci.yml`）を追加する。
-6. [ ] `api/src/db/schema.ts` 等を拡張し、`users`・`custom_game_events` などに `guild_id` を追加。ユーザーと Riot ID の関連はギルド共通テーブルに正規化する。
+6. [x] `api/src/db/schema.ts` 等を拡張し、`custom_game_events` などに `guild_id` を追加。ユーザーと Riot ID の関連はギルド間で共通しているので、正規化する。
 7. [ ] ギルド固有設定テーブル（募集チャンネル、VC、ロールID など）と対応する API を設計・実装し、Bot 側で参照できるようにする。
 8. [ ] `api/src/db/actions.ts`/`custom_game_events` に募集メッセージのチャンネルIDを保存し、`bot/src/commands/split-teams.ts` から利用する。
 9. [ ] `bot/src/features/role-management.ts`: Bot がギルド参加時に必要ロールを自動作成または検出し、ID を保存するロジックを追加する。

--- a/api/src/db/actions.ts
+++ b/api/src/db/actions.ts
@@ -50,7 +50,8 @@ async function setMainRole(userId: string, guildId: string, role: Lane) {
 
     // ギルドが存在しない場合は作成する
     const guildPayload = guildInsertSchema.parse({ id: guildId });
-    await tx.insert(guilds).values(guildPayload).onConflictDoNothing().execute();
+    await tx.insert(guilds).values(guildPayload).onConflictDoNothing()
+      .execute();
 
     // ユーザーのギルドプロファイル（メインロール）を更新または作成する
     const profilePayload = userGuildProfileInsertSchema.parse({
@@ -87,7 +88,8 @@ async function createCustomGameEvent(event: {
 
     // ギルドが存在しない場合は作成する
     const guildPayload = guildInsertSchema.parse({ id: event.guildId });
-    await tx.insert(guilds).values(guildPayload).onConflictDoNothing().execute();
+    await tx.insert(guilds).values(guildPayload).onConflictDoNothing()
+      .execute();
 
     // カスタムゲームイベントを作成する
     const parsedEvent = customGameEventInsertSchema.parse(event);

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -1,13 +1,16 @@
-import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import {
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+} from "drizzle-orm/sqlite-core";
 import { type InferSelectModel, relations } from "drizzle-orm";
 
 export const lanes = ["Top", "Jungle", "Middle", "Bottom", "Support"] as const;
 export type Lane = (typeof lanes)[number];
 
-export const users = sqliteTable("users", {
-  discordId: text("discord_id").primaryKey(),
-  riotId: text("riot_id"),
-  mainRole: text("main_role", { enum: lanes }),
+export const guilds = sqliteTable("guilds", {
+  id: text("id").primaryKey(),
   createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(
     () => new Date(),
   ),
@@ -15,6 +18,35 @@ export const users = sqliteTable("users", {
     new Date()
   ),
 });
+
+export const users = sqliteTable("users", {
+  discordId: text("discord_id").primaryKey(),
+  riotId: text("riot_id"),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(
+    () => new Date(),
+  ),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).$onUpdate(() =>
+    new Date()
+  ),
+});
+
+export const userGuildProfiles = sqliteTable("user_guild_profiles", {
+  userId: text("user_id").notNull().references(() => users.discordId, {
+    onDelete: "cascade",
+  }),
+  guildId: text("guild_id").notNull().references(() => guilds.id, {
+    onDelete: "cascade",
+  }),
+  mainRole: text("main_role", { enum: lanes }).notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull().$defaultFn(
+    () => new Date(),
+  ),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).$onUpdate(() =>
+    new Date()
+  ),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.userId, table.guildId] }),
+}));
 
 export const matches = sqliteTable("matches", {
   id: text("id").primaryKey(), // Riot Match ID
@@ -44,7 +76,9 @@ export const matchParticipants = sqliteTable("match_participants", {
 export const customGameEvents = sqliteTable("custom_game_events", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   name: text("name").notNull(),
-  guildId: text("guild_id").notNull(),
+  guildId: text("guild_id").notNull().references(() => guilds.id, {
+    onDelete: "cascade",
+  }),
   creatorId: text("creator_id").notNull().references(() => users.discordId, {
     onDelete: "cascade",
   }),
@@ -65,7 +99,22 @@ export type Event = InferSelectModel<typeof customGameEvents>;
 export const usersRelations = relations(users, ({ many }) => ({
   matchParticipations: many(matchParticipants),
   createdCustomGameEvents: many(customGameEvents),
+  guildProfiles: many(userGuildProfiles),
 }));
+
+export const userGuildProfilesRelations = relations(
+  userGuildProfiles,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [userGuildProfiles.userId],
+      references: [users.discordId],
+    }),
+    guild: one(guilds, {
+      fields: [userGuildProfiles.guildId],
+      references: [guilds.id],
+    }),
+  }),
+);
 
 export const matchesRelations = relations(matches, ({ many }) => ({
   participants: many(matchParticipants),
@@ -100,5 +149,14 @@ export const customGameEventsRelations = relations(
       fields: [customGameEvents.creatorId],
       references: [users.discordId],
     }),
+    guild: one(guilds, {
+      fields: [customGameEvents.guildId],
+      references: [guilds.id],
+    }),
   }),
 );
+
+export const guildsRelations = relations(guilds, ({ many }) => ({
+  userProfiles: many(userGuildProfiles),
+  customGameEvents: many(customGameEvents),
+}));

--- a/api/src/routes/users.test.ts
+++ b/api/src/routes/users.test.ts
@@ -139,12 +139,10 @@ describe("routes/users.ts", () => {
 
           // Assert
           assert(res.status === 204);
-          assertEquals(await res.text(), "");
-          const call = setMainRoleStub.calls[0];
-          const args = call.args as unknown[];
-          assertEquals(args[0], userId);
-          assertEquals(args[1], guildId);
-          assertEquals(args[2], role);
+          assertSpyCalls(setMainRoleStub, 1);
+          assertSpyCall(setMainRoleStub, 0, {
+            args: [userId, guildId, role],
+          });
         },
       );
     });

--- a/api/src/routes/users.test.ts
+++ b/api/src/routes/users.test.ts
@@ -7,6 +7,7 @@ import { dbActions } from "../db/actions.ts";
 import { riotApi } from "../riot_api.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 import { z } from "zod";
+import type { Lane } from "../db/schema.ts";
 
 describe("routes/users.ts", () => {
   const client = testClient(app);
@@ -116,39 +117,61 @@ describe("routes/users.ts", () => {
 
   describe("PUT /users/:userId/main-role", () => {
     const userId = "test-user-id";
+    const guildId = "test-guild-id";
 
     describe("正常系", () => {
-      test("有効なロールが指定されたとき、ユーザーのメインロールを設定して204 No Contentを返す", async () => {
-        // Arrange
-        const role = "Jungle";
-        using setMainRoleStub = stub(
-          dbActions,
-          "setMainRole",
-          () =>
-            Promise.resolve({
-              rows: [],
-              columns: [],
-              rowsAffected: 0,
-              lastInsertRowid: undefined,
-              columnTypes: [],
-              toJSON: () => ({}),
-            }),
-        );
+      test(
+        "有効なロールとギルドIDが指定されたとき、ユーザーのメインロールを設定して204 No Contentを返す",
+        async () => {
+          // Arrange
+          const role: Lane = "Jungle";
+          using setMainRoleStub = stub(
+            dbActions,
+            "setMainRole",
+            () => Promise.resolve(),
+          );
 
-        // Act
-        const res = await client.users[":userId"]["main-role"].$put({
-          param: { userId },
-          json: { role },
-        });
+          // Act
+          const res = await client.users[":userId"]["main-role"].$put({
+            param: { userId },
+            json: { guildId, role },
+          });
 
-        // Assert
-        assert(res.status === 204);
-        assertEquals(await res.text(), "");
-        assertSpyCall(setMainRoleStub, 0, { args: [userId, role] });
-      });
+          // Assert
+          assert(res.status === 204);
+          assertEquals(await res.text(), "");
+          const call = setMainRoleStub.calls[0];
+          const args = call.args as unknown[];
+          assertEquals(args[0], userId);
+          assertEquals(args[1], guildId);
+          assertEquals(args[2], role);
+        },
+      );
     });
 
     describe("異常系", () => {
+      test(
+        "ギルドIDが指定されていないとき、400エラーを返す",
+        async () => {
+          // Arrange
+          const role = "Jungle";
+          const req = new Request(
+            `http://localhost/users/${userId}/main-role`,
+            {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ role }),
+            },
+          );
+
+          // Act
+          const res = await app.request(req);
+
+          // Assert
+          assertEquals(res.status, 400);
+        },
+      );
+
       test("無効なロールが指定されたとき、400エラーを返す", async () => {
         // Arrange
         const role = "InvalidRole";

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -7,6 +7,7 @@ import { riotApi } from "../riot_api.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 
 const roleSchema = z.object({
+  guildId: z.string(),
   role: z.enum(lanes),
 });
 
@@ -43,8 +44,8 @@ export const usersRoutes = new Hono()
     zValidator("json", roleSchema),
     async (c) => {
       const { userId } = c.req.param();
-      const { role } = c.req.valid("json");
-      await dbActions.setMainRole(userId, role);
+      const { guildId, role } = c.req.valid("json");
+      await dbActions.setMainRole(userId, guildId, role);
       return c.body(null, 204);
     },
   );

--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -1,11 +1,6 @@
-import { assert, assertEquals } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
-import {
-  assertSpyCall,
-  assertSpyCallArgs,
-  assertSpyCalls,
-  stub,
-} from "@std/testing/mock";
+import { assertSpyCalls, stub } from "@std/testing/mock";
 import { apiClient } from "./api_client.ts";
 import { type Client } from "@adteemo/api/hc";
 import { type InferResponseType } from "@hono/hono";

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -58,11 +58,11 @@ async function checkHealth() {
   }
 }
 
-async function setMainRole(userId: string, role: Lane) {
+async function setMainRole(userId: string, guildId: string, role: Lane) {
   try {
     const res = await client.users[":userId"]["main-role"].$put({
       param: { userId: userId },
-      json: { role: role },
+      json: { guildId, role },
     });
 
     if (!res.ok) {

--- a/bot/src/commands/set-main-role.test.ts
+++ b/bot/src/commands/set-main-role.test.ts
@@ -44,17 +44,18 @@ describe("Set Main Role Command", () => {
       await execute(interaction);
 
       // Assert
-      assertSpyCall(deferSpy, 0);
-      const call = setMainRoleStub.calls[0];
-      const args = call.args as unknown[];
-      assertEquals(args[0], interaction.user.id);
-      assertEquals(args[1], guildId);
-      assertEquals(args[2], "Jungle");
+      assertSpyCalls(deferSpy, 1);
+      assertSpyCalls(setMainRoleStub, 1);
+      assertSpyCall(setMainRoleStub, 0, {
+        args: [interaction.user.id, guildId, "Jungle"],
+      });
+      assertSpyCalls(formatMessageSpy, 1);
       assertSpyCall(formatMessageSpy, 0, {
         args: [messageKeys.userManagement.setMainRole.success, {
           role: "Jungle",
         }],
       });
+      assertSpyCalls(editSpy, 1);
       assertSpyCall(editSpy, 0);
     });
 
@@ -77,18 +78,18 @@ describe("Set Main Role Command", () => {
       await execute(interaction);
 
       // Assert
-      assertSpyCall(deferSpy, 0);
-      const call = setMainRoleStub.calls[0];
-      const args = call.args as unknown[];
-      assertEquals(args[0], interaction.user.id);
-      assertEquals(args[1], guildId);
-      assertEquals(args[2], "Jungle");
+      assertSpyCalls(deferSpy, 1);
+      assertSpyCalls(setMainRoleStub, 1);
+      assertSpyCall(setMainRoleStub, 0, {
+        args: [interaction.user.id, guildId, "Jungle"],
+      });
+      assertSpyCalls(formatMessageSpy, 1);
       assertSpyCall(formatMessageSpy, 0, {
         args: [messageKeys.userManagement.setMainRole.failure, {
           error: "API error",
         }],
       });
-      assertSpyCall(editSpy, 0);
+      assertSpyCalls(editSpy, 1);
     });
 
     test("ChatInputCommandでないInteractionで実行すると、何もせずに処理を中断する", async () => {

--- a/bot/src/commands/set-main-role.test.ts
+++ b/bot/src/commands/set-main-role.test.ts
@@ -4,7 +4,6 @@ import { assertSpyCall, assertSpyCalls, spy, stub } from "@std/testing/mock";
 import { data, execute } from "./set-main-role.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 import { MockInteractionBuilder } from "../test_utils.ts";
-import { Lane } from "@adteemo/api/schema";
 import { apiClient } from "../api_client.ts";
 
 describe("Set Main Role Command", () => {
@@ -37,6 +36,7 @@ describe("Set Main Role Command", () => {
       const interaction = new MockInteractionBuilder("set-main-role")
         .withStringOption("role", "Jungle")
         .build();
+      const guildId = interaction.guild?.id ?? "";
       using deferSpy = spy(interaction, "deferReply");
       using editSpy = spy(interaction, "editReply");
 
@@ -45,9 +45,11 @@ describe("Set Main Role Command", () => {
 
       // Assert
       assertSpyCall(deferSpy, 0);
-      assertSpyCall(setMainRoleStub, 0, {
-        args: [interaction.user.id, "Jungle" as Lane],
-      });
+      const call = setMainRoleStub.calls[0];
+      const args = call.args as unknown[];
+      assertEquals(args[0], interaction.user.id);
+      assertEquals(args[1], guildId);
+      assertEquals(args[2], "Jungle");
       assertSpyCall(formatMessageSpy, 0, {
         args: [messageKeys.userManagement.setMainRole.success, {
           role: "Jungle",
@@ -67,6 +69,7 @@ describe("Set Main Role Command", () => {
       const interaction = new MockInteractionBuilder("set-main-role")
         .withStringOption("role", "Jungle")
         .build();
+      const guildId = interaction.guild?.id ?? "";
       using deferSpy = spy(interaction, "deferReply");
       using editSpy = spy(interaction, "editReply");
 
@@ -75,9 +78,11 @@ describe("Set Main Role Command", () => {
 
       // Assert
       assertSpyCall(deferSpy, 0);
-      assertSpyCall(setMainRoleStub, 0, {
-        args: [interaction.user.id, "Jungle" as Lane],
-      });
+      const call = setMainRoleStub.calls[0];
+      const args = call.args as unknown[];
+      assertEquals(args[0], interaction.user.id);
+      assertEquals(args[1], guildId);
+      assertEquals(args[2], "Jungle");
       assertSpyCall(formatMessageSpy, 0, {
         args: [messageKeys.userManagement.setMainRole.failure, {
           error: "API error",

--- a/bot/src/commands/set-main-role.ts
+++ b/bot/src/commands/set-main-role.ts
@@ -30,10 +30,21 @@ export async function execute(interaction: CommandInteraction) {
 
   const role = interaction.options.getString("role", true) as Lane;
   const userId = interaction.user.id;
+  const guildId = interaction.guild?.id;
+
+  if (!guildId) {
+    await interaction.reply({
+      content: messageHandler.formatMessage(
+        messageKeys.common.info.guildOnlyCommand,
+      ),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
 
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-  const result = await apiClient.setMainRole(userId, role);
+  const result = await apiClient.setMainRole(userId, guildId, role);
 
   if (result.success) {
     await interaction.editReply(


### PR DESCRIPTION
## 概要
- ギルド情報を独立テーブル化し、`user_guild_profiles` でユーザーとの関係を正規化
- `/users/:userId/main-role` でギルドIDを必須化し、Bot 側からもギルドIDを確実に送るよう統一
- 既存ユニットテストとスタイルガイドをギルドスコープ対応へ更新

## 目的
タスク6で求められていた「サーバーごとに独立したメインロールとイベント管理」を行えるようにするため、DB スキーマと API/Bot の連携フローを整理した。これにより、同一ユーザーが複数ギルドで別々の設定を持てる土台が整う。

## 変更内容
- schema: `guilds` と `user_guild_profiles` を追加、`custom_game_events.guild_id` を外部キー化
- db-actions: ギルド upsert → ユーザー upsert → プロフィール insert/update の順序に統一
- API/Bot: ギルド ID を常に付与するよう `/users/:userId/main-role` およびクライアントを更新
- テスト更新: 新たな契約に合わせたモック・期待値を調整、テストスタイルガイドを反映

## 影響範囲
- 既存メインロール更新処理はギルド ID なしでは動作しなくなるため、Bot 側の更新が必須
- 既存データにギルド ID を補完するマイグレーションは別途必要（この PR では未実施）

## 確認事項
- [x] `docker compose exec dev deno task test:all --env=.env.example -q`
- [ ] 既存データ移行（別途検討）
- [ ] DB インテグレーションテスト（今後の課題）
