### PR TITLE
fix(bot): Riot ID未登録時の監視メッセージを分ける (#26)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -58,6 +58,7 @@
     - [x] `riot_accounts` を追加し、PUUID、Riot ID、platform、region をユーザー別に保存する。
     - [x] `match_watchers` を追加し、ギルド単位で指定メンバーの継続監視状態と通知チャンネルを保存する。
     - [x] `/watch-match @member` と `/unwatch-match @member` を実装する。
+    - [x] `/watch-match @member` で対象メンバーが Riot ID 未登録の場合に専用メッセージを返す。
     - [x] Riot Spectator-v5 で試合開始・試合中概要・終了を検知し、Discord に通知する。
     - [x] Riot Match-v5 で終了後の勝敗、KDA、CS、Gold を取得し、通知する。
     - [x] Spectator-v5 / Match-v5 の 404、429、5xx を考慮したリトライと backoff を実装する。

--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -125,6 +125,34 @@ describe("apiClient", () => {
     });
   });
 
+  describe("watchMatch", () => {
+    test("監視登録APIが404を返す場合、呼び出し側で未連携を識別できるステータスを返す", async () => {
+      using fetchStub = stub(
+        globalThis,
+        "fetch",
+        () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({ error: "Riot account not found" }),
+              { status: 404 },
+            ),
+          ),
+      );
+
+      const result = await apiClient.watchMatch({
+        guildId: "guild-1",
+        targetDiscordId: "target-1",
+        requesterId: "requester-1",
+        channelId: "channel-1",
+      });
+
+      assertEquals(result.success, false);
+      assertEquals(result.error, "Riot account not found");
+      assertEquals("status" in result ? result.status : undefined, 404);
+      assertSpyCalls(fetchStub, 1);
+    });
+  });
+
   describe("setMainRole", () => {
     const userId = "test-user";
     const guildId = "test-guild";

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -309,7 +309,11 @@ async function watchMatch(watcher: {
     if (!res.ok) {
       if (res.status === 404 || res.status === 409) {
         const body = await res.json();
-        return { success: false as const, error: body.error };
+        return {
+          success: false as const,
+          error: body.error,
+          status: res.status,
+        };
       }
       throw new Error(`Unexpected response: ${res}`);
     }

--- a/bot/src/commands/watch-match.test.ts
+++ b/bot/src/commands/watch-match.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, stub } from "@std/testing/mock";
 import { CommandInteraction } from "discord.js";
@@ -39,7 +39,7 @@ describe("Command: watch-match", () => {
     });
   });
 
-  test("未連携メンバーを指定すると、監視登録失敗を返す", async () => {
+  test("未連携メンバーを指定すると、Riot ID登録が必要な専用メッセージを返す", async () => {
     const interaction = new MockInteractionBuilder("watch-match")
       .withUser({ id: "requester-1" })
       .withUserOption("member", {
@@ -47,6 +47,11 @@ describe("Command: watch-match", () => {
         toString: () => "<@target-1>",
       })
       .build();
+    using editReplySpy = stub(
+      interaction,
+      "editReply",
+      () => Promise.resolve({} as never),
+    );
     using watchStub = stub(
       apiClient,
       "watchMatch",
@@ -54,11 +59,17 @@ describe("Command: watch-match", () => {
         Promise.resolve({
           success: false as const,
           error: "Riot account not found",
+          status: 404 as const,
         }),
     );
 
     await execute(interaction as unknown as CommandInteraction);
 
     assertSpyCall(watchStub, 0);
+    assertSpyCall(editReplySpy, 0);
+    const replyOptions = editReplySpy.calls[0].args[0] as { content: string };
+    assertStringIncludes(String(replyOptions.content), "<@target-1>");
+    assertStringIncludes(String(replyOptions.content), "Riot ID");
+    assertStringIncludes(String(replyOptions.content), "登録");
   });
 });

--- a/bot/src/commands/watch-match.ts
+++ b/bot/src/commands/watch-match.ts
@@ -41,7 +41,7 @@ export async function execute(interaction: CommandInteraction) {
   });
 
   if (!result.success) {
-    const content = result.status === 404
+    const content = "status" in result && result.status === 404
       ? messageHandler.formatMessage(
         messageKeys.matchTracking.watch.error.riotAccountRequired,
         { member: String(target) },

--- a/bot/src/commands/watch-match.ts
+++ b/bot/src/commands/watch-match.ts
@@ -41,13 +41,27 @@ export async function execute(interaction: CommandInteraction) {
   });
 
   if (!result.success) {
+    const content = result.status === 404
+      ? messageHandler.formatMessage(
+        messageKeys.matchTracking.watch.error.riotAccountRequired,
+        { member: String(target) },
+      )
+      : messageHandler.formatMessage(
+        messageKeys.matchTracking.watch.error.failure,
+        { member: String(target), error: result.error },
+      );
     await interaction.editReply({
-      content: `${target} の試合監視を開始できませんでした: ${result.error}`,
+      content,
     });
     return;
   }
 
   await interaction.editReply({
-    content: `${target} の試合監視を開始しました。このチャンネルに通知します。`,
+    content: messageHandler.formatMessage(
+      messageKeys.matchTracking.watch.success,
+      {
+        member: String(target),
+      },
+    ),
   });
 }

--- a/messages/en_US/system.json
+++ b/messages/en_US/system.json
@@ -100,6 +100,13 @@
     }
   },
   "matchTracking": {
+    "watch": {
+      "success": "Started watching {member}'s LoL matches. Notifications will be posted in this channel.",
+      "error": {
+        "failure": "Could not start watching {member}'s matches: {error}",
+        "riotAccountRequired": "To watch {member}'s matches, that member needs to register their Riot ID first. Ask them to run `/set-riot-id`."
+      }
+    },
     "embed": {
       "active": {
         "startedTitle": "Match start detected",

--- a/messages/ja_JP/system.json
+++ b/messages/ja_JP/system.json
@@ -101,6 +101,13 @@
     }
   },
   "matchTracking": {
+    "watch": {
+      "success": "{member} の試合監視を開始しました。このチャンネルに通知します。",
+      "error": {
+        "failure": "{member} の試合監視を開始できませんでした: {error}",
+        "riotAccountRequired": "{member} の試合監視を開始するには、対象メンバーのRiot ID登録が必要です。`/set-riot-id` で登録してもらってください。"
+      }
+    },
     "embed": {
       "active": {
         "startedTitle": "試合開始を検知しました",

--- a/messages/ja_JP/teemo.json
+++ b/messages/ja_JP/teemo.json
@@ -107,5 +107,14 @@
     "error": {
       "failure": "うーん、なんだか身体の調子が悪いみたいだ…。 {error}"
     }
+  },
+  "matchTracking": {
+    "watch": {
+      "success": "{member} の試合監視を開始したよ！ このチャンネルで偵察結果を知らせるね。",
+      "error": {
+        "failure": "{member} の試合監視を開始できなかったよ…。 {error}",
+        "riotAccountRequired": "{member} の試合を監視するには、まずRiot IDの登録が必要だよ。`/set-riot-id` で登録してもらってね。"
+      }
+    }
   }
 }


### PR DESCRIPTION
## 概要

- `/watch-match` で対象メンバーの Riot ID が未登録の場合、専用メッセージを返すようにしました。
- `apiClient.watchMatch` が 404/409 の HTTP status を呼び出し側へ返すようにし、未登録時だけ Bot 側で文言を出し分けます。
- system/en_US/teemo のメッセージキーを追加しました。

Closes #26

## 事前レビュー

- 差分確認済み。未登録時の分岐は 404 のみに限定し、409 など既存失敗は汎用失敗文を維持しています。
- ignored の `coverage/` と `data/` はコミット対象外です。

## 検証

- `deno test --allow-env --allow-read --env-file=.env.example bot/src/commands/watch-match.test.ts bot/src/api_client.test.ts messages/src/main.test.ts`
- worker 側で `deno task fmt:check`, `deno task lint`, `deno task check`, `deno task test:all` 成功確認済み。