### PR TITLE
fix(bot): 試合結果の表示名を日本語向けに調整する (#27)

### DIFF
--- a/api/src/riot_api.test.ts
+++ b/api/src/riot_api.test.ts
@@ -69,6 +69,54 @@ describe("riot_api.ts", () => {
     assertSpyCalls(fetchStub, 1);
   });
 
+  test("Match-v5が試合詳細を返すとき、participantのchampionIdをparseする", async () => {
+    Deno.env.set("RIOT_API_KEY", "test-key");
+    using fetchStub = stub(
+      globalThis,
+      "fetch",
+      () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              metadata: {
+                matchId: "JP1_12345",
+                participants: ["puuid-1"],
+              },
+              info: {
+                gameId: 12345,
+                gameCreation: 1_700_000_000_000,
+                gameDuration: 1800,
+                gameEndTimestamp: 1_700_001_800_000,
+                gameMode: "CLASSIC",
+                gameType: "MATCHED_GAME",
+                mapId: 11,
+                queueId: 420,
+                participants: [{
+                  puuid: "puuid-1",
+                  championId: 17,
+                  championName: "Teemo",
+                  teamId: 100,
+                  win: true,
+                  kills: 10,
+                  deaths: 2,
+                  assists: 8,
+                  totalMinionsKilled: 180,
+                  neutralMinionsKilled: 12,
+                  goldEarned: 12345,
+                }],
+              },
+            }),
+            { status: 200 },
+          ),
+        ),
+    );
+
+    const match = await riotApi.getMatchById("asia", "JP1_12345");
+
+    assertEquals(match?.info.participants[0].championId, 17);
+    assertSpyCalls(fetchStub, 1);
+  });
+
   test("Riot APIが429を返したあと成功するとき、再試行して結果を返す", async () => {
     Deno.env.set("RIOT_API_KEY", "test-key");
     let calls = 0;

--- a/api/src/riot_api.ts
+++ b/api/src/riot_api.ts
@@ -47,6 +47,7 @@ const matchSchema = z.object({
         riotIdGameName: z.string().optional(),
         riotIdTagline: z.string().optional(),
         summonerName: z.string().optional(),
+        championId: z.number().optional(),
         championName: z.string(),
         teamId: z.number(),
         win: z.boolean(),

--- a/api/src/riot_static_data.test.ts
+++ b/api/src/riot_static_data.test.ts
@@ -62,7 +62,7 @@ describe("riot_static_data.ts", () => {
         ),
     );
 
-    const name = await riotStaticData.getQueueNameById(420);
+    const name = await riotStaticData.getQueueNameById(420, "en_US");
 
     assertEquals(name, "5v5 Ranked Solo games");
     assertSpyCalls(getCacheStub, 1);
@@ -133,7 +133,7 @@ describe("riot_static_data.ts", () => {
       () => Promise.resolve(new Response(null, { status: 500 })),
     );
 
-    const name = await riotStaticData.getMapNameById(11);
+    const name = await riotStaticData.getMapNameById(11, "en_US");
 
     assertEquals(name, "Summoner's Rift");
     assertSpyCalls(fetchStub, 1);

--- a/api/src/riot_static_data.test.ts
+++ b/api/src/riot_static_data.test.ts
@@ -70,6 +70,46 @@ describe("riot_static_data.ts", () => {
     assertSpyCalls(fetchStub, 1);
   });
 
+  test("ja_JPの代表キューは日本語ユーザー向けの表示名を返す", async () => {
+    using getCacheStub = stub(
+      dbActions,
+      "getRiotStaticDataCache",
+      () => Promise.reject(new Error("cache should not be called")),
+    );
+    using fetchStub = stub(
+      globalThis,
+      "fetch",
+      () => Promise.reject(new Error("fetch should not be called")),
+    );
+
+    const name = await riotStaticData.getQueueNameById(420, "ja_JP");
+
+    assertEquals(name, "ランクソロ/デュオ");
+    assertSpyCalls(getCacheStub, 0);
+    assertSpyCalls(fetchStub, 0);
+  });
+
+  test("ja_JPの代表マップとゲームモードは日本語ユーザー向けの表示名を返す", async () => {
+    using getCacheStub = stub(
+      dbActions,
+      "getRiotStaticDataCache",
+      () => Promise.reject(new Error("cache should not be called")),
+    );
+    using fetchStub = stub(
+      globalThis,
+      "fetch",
+      () => Promise.reject(new Error("fetch should not be called")),
+    );
+
+    const map = await riotStaticData.getMapNameById(11, "ja_JP");
+    const mode = await riotStaticData.getGameModeName("CLASSIC", "ja_JP");
+
+    assertEquals(map, "サモナーズリフト");
+    assertEquals(mode, "クラシック");
+    assertSpyCalls(getCacheStub, 0);
+    assertSpyCalls(fetchStub, 0);
+  });
+
   test("キャッシュ更新に失敗した場合、古いDB値をfallbackとして返す", async () => {
     using _getCacheStub = stub(
       dbActions,

--- a/api/src/riot_static_data.ts
+++ b/api/src/riot_static_data.ts
@@ -36,6 +36,24 @@ const gameModesSchema = z.array(
   }).passthrough(),
 );
 
+const jaQueueNames: Record<number, string> = {
+  400: "ノーマルドラフト",
+  420: "ランクソロ/デュオ",
+  430: "ノーマルブラインド",
+  440: "ランクフレックス",
+  450: "ARAM",
+};
+
+const jaMapNames: Record<number, string> = {
+  11: "サモナーズリフト",
+  12: "ハウリングアビス",
+};
+
+const jaGameModeNames: Record<string, string> = {
+  ARAM: "ARAM",
+  CLASSIC: "クラシック",
+};
+
 function numberEnv(name: string, fallback: number) {
   const value = Number(Deno.env.get(name));
   return Number.isFinite(value) && value > 0 ? value : fallback;
@@ -52,6 +70,27 @@ function normalizeLocale(locale?: string) {
   const raw = locale ?? Deno.env.get("BOT_MESSAGE_LANG") ??
     Deno.env.get("API_MESSAGE_LANG") ?? "ja_JP";
   return raw.replace("-", "_").split(".")[0];
+}
+
+function localizedQueueName(queueId: number, locale?: string) {
+  if (locale && normalizeLocale(locale) === "ja_JP") {
+    return jaQueueNames[queueId] ?? null;
+  }
+  return null;
+}
+
+function localizedMapName(mapId: number, locale?: string) {
+  if (locale && normalizeLocale(locale) === "ja_JP") {
+    return jaMapNames[mapId] ?? null;
+  }
+  return null;
+}
+
+function localizedGameModeName(gameMode: string, locale?: string) {
+  if (locale && normalizeLocale(locale) === "ja_JP") {
+    return jaGameModeNames[gameMode] ?? null;
+  }
+  return null;
 }
 
 function isFresh(updatedAt: Date, now = Date.now()) {
@@ -185,17 +224,26 @@ async function getChampionNameById(championId: number, locale?: string) {
   return names[String(championId)] ?? null;
 }
 
-async function getQueueNameById(queueId: number) {
+async function getQueueNameById(queueId: number, locale?: string) {
+  const localizedName = localizedQueueName(queueId, locale);
+  if (localizedName) return localizedName;
+
   const names = await getQueues();
   return names[String(queueId)] ?? null;
 }
 
-async function getMapNameById(mapId: number) {
+async function getMapNameById(mapId: number, locale?: string) {
+  const localizedName = localizedMapName(mapId, locale);
+  if (localizedName) return localizedName;
+
   const names = await getMaps();
   return names[String(mapId)] ?? null;
 }
 
-async function getGameModeName(gameMode: string) {
+async function getGameModeName(gameMode: string, locale?: string) {
+  const localizedName = localizedGameModeName(gameMode, locale);
+  if (localizedName) return localizedName;
+
   const names = await getGameModes();
   return names[gameMode] ?? null;
 }

--- a/api/src/riot_static_data.ts
+++ b/api/src/riot_static_data.ts
@@ -73,21 +73,21 @@ function normalizeLocale(locale?: string) {
 }
 
 function localizedQueueName(queueId: number, locale?: string) {
-  if (locale && normalizeLocale(locale) === "ja_JP") {
+  if (normalizeLocale(locale) === "ja_JP") {
     return jaQueueNames[queueId] ?? null;
   }
   return null;
 }
 
 function localizedMapName(mapId: number, locale?: string) {
-  if (locale && normalizeLocale(locale) === "ja_JP") {
+  if (normalizeLocale(locale) === "ja_JP") {
     return jaMapNames[mapId] ?? null;
   }
   return null;
 }
 
 function localizedGameModeName(gameMode: string, locale?: string) {
-  if (locale && normalizeLocale(locale) === "ja_JP") {
+  if (normalizeLocale(locale) === "ja_JP") {
     return jaGameModeNames[gameMode] ?? null;
   }
   return null;

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -359,6 +359,54 @@ describe("match_tracking.ts", () => {
     assertEquals(embedFieldValue(resultEmbed, "チャンピオン"), "ティーモ");
   });
 
+  test("静的データのチャンピオン名取得に失敗したとき、Match-v5の既存名で結果通知を完了する", async () => {
+    const [championNameStub] = staticDataStubs.splice(0, 1);
+    championNameStub.restore();
+    const { client, editSpy } = clientWithSend();
+    using _championNameFailureStub = stub(
+      riotStaticData,
+      "getChampionNameById",
+      () => Promise.reject(new Error("Data Dragon failed")),
+    );
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [watcher({
+            lastState: "FETCHING_RESULT",
+            currentMatchId: "JP1_12345",
+            currentNotificationMessageId: "message-existing",
+          })],
+        }),
+    );
+    using _getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using _getMatchStub = stub(
+      riotApi,
+      "getMatchById",
+      () => Promise.resolve(match()),
+    );
+    using updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertSpyCalls(editSpy, 1);
+    const resultEmbed = firstEditedEmbed(editSpy);
+    assertEquals(embedFieldValue(resultEmbed, "チャンピオン"), "Teemo");
+    assertEquals(updateStub.calls.at(-1)?.args[2].lastState, "IDLE");
+    assertEquals(updateStub.calls.at(-1)?.args[2].currentMatchId, null);
+    assertEquals(updateStub.calls.at(-1)?.args[2].pendingResultMatchId, null);
+  });
+
   test("ja_JPの試合結果では代表キューとマップを日本語表示に寄せる", async () => {
     const { client, editSpy } = clientWithSend();
     using _getWatchersStub = stub(

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, spy, stub } from "@std/testing/mock";
-import type { Client } from "discord.js";
+import type { APIEmbedField, Client } from "discord.js";
 import type { MatchWatcher, RiotAccount } from "@adteemo/api/schema";
 import { riotApi } from "@adteemo/api/riot-api";
 import { riotStaticData } from "@adteemo/api/riot-static-data";
@@ -82,6 +82,7 @@ function match() {
       queueId: 420,
       participants: [{
         puuid: "puuid-1",
+        championId: 17,
         championName: "Teemo",
         teamId: 100,
         win: true,
@@ -117,6 +118,26 @@ function clientWithSend(
     },
   } as unknown as Client;
   return { client, sendSpy, editSpy };
+}
+
+function embedFieldValue(
+  embed: { data: { fields?: APIEmbedField[] } },
+  name: string,
+) {
+  return embed.data.fields?.find((field) => field.name === name)?.value;
+}
+
+function firstEditedEmbed(
+  editSpy: ReturnType<typeof clientWithSend>["editSpy"],
+) {
+  const calls = editSpy.calls as unknown as Array<{
+    args: [{ embeds: [{ data: { fields?: APIEmbedField[] } }] }];
+  }>;
+  const options = calls[0]?.args[0];
+  if (!options?.embeds[0]) {
+    throw new Error("edited embed was not found");
+  }
+  return options.embeds[0];
 }
 
 describe("match_tracking.ts", () => {
@@ -299,6 +320,82 @@ describe("match_tracking.ts", () => {
       updateStub.calls.at(-1)?.args[2].currentNotificationMessageId,
       null,
     );
+  });
+
+  test("ja_JPの試合結果ではchampionIdからチャンピオン名を表示する", async () => {
+    const { client, editSpy } = clientWithSend();
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [watcher({
+            lastState: "FETCHING_RESULT",
+            currentMatchId: "JP1_12345",
+            currentNotificationMessageId: "message-existing",
+          })],
+        }),
+    );
+    using _getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using _getMatchStub = stub(
+      riotApi,
+      "getMatchById",
+      () => Promise.resolve(match()),
+    );
+    using _updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    const resultEmbed = firstEditedEmbed(editSpy);
+    assertEquals(embedFieldValue(resultEmbed, "チャンピオン"), "ティーモ");
+  });
+
+  test("ja_JPの試合結果では代表キューとマップを日本語表示に寄せる", async () => {
+    const { client, editSpy } = clientWithSend();
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [watcher({
+            lastState: "FETCHING_RESULT",
+            currentMatchId: "JP1_12345",
+            currentNotificationMessageId: "message-existing",
+          })],
+        }),
+    );
+    using _getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using _getMatchStub = stub(
+      riotApi,
+      "getMatchById",
+      () => Promise.resolve(match()),
+    );
+    using _updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    const resultEmbed = firstEditedEmbed(editSpy);
+    assertEquals(embedFieldValue(resultEmbed, "キュー"), "ランクソロ/デュオ");
+    assertEquals(embedFieldValue(resultEmbed, "マップ"), "サモナーズリフト");
+    assertEquals(embedFieldValue(resultEmbed, "モード"), "クラシック");
   });
 
   test("結果取得待ちが一定時間を超えたとき、Match-v5を再試行せずIDLEへ戻す", async () => {

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -91,24 +91,37 @@ function isResultFetchTimedOut(
   return now.getTime() - startedAt.getTime() >= timeoutMs;
 }
 
+function fallbackChampionName(
+  championId: number | undefined,
+  fallbackName?: string,
+) {
+  if (fallbackName) return fallbackName;
+  if (championId === undefined) {
+    return messageHandler.formatMessage(
+      messageKeys.matchTracking.embed.fallback.unknownChampion,
+    );
+  }
+  return messageHandler.formatMessage(
+    messageKeys.matchTracking.embed.fallback.championId,
+    { id: championId },
+  );
+}
+
 async function championNameById(
   championId: number | undefined,
   fallbackName?: string,
 ) {
   if (championId === undefined) {
-    return fallbackName ?? messageHandler.formatMessage(
-      messageKeys.matchTracking.embed.fallback.unknownChampion,
-    );
+    return fallbackChampionName(championId, fallbackName);
   }
-  return await riotStaticData.getChampionNameById(
-    championId,
-    messageLocale(),
-  ) ??
-    fallbackName ??
-    messageHandler.formatMessage(
-      messageKeys.matchTracking.embed.fallback.championId,
-      { id: championId },
-    );
+  try {
+    return await riotStaticData.getChampionNameById(
+      championId,
+      messageLocale(),
+    ) ?? fallbackChampionName(championId, fallbackName);
+  } catch {
+    return fallbackChampionName(championId, fallbackName);
+  }
 }
 
 async function queueName(queueId: number | undefined) {

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -38,6 +38,11 @@ function numberEnv(name: string, fallback: number) {
   return Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
+function messageLocale() {
+  return (Deno.env.get("BOT_MESSAGE_LANG") ?? Deno.env.get("LC_MESSAGES") ??
+    Deno.env.get("LC_ALL") ?? "ja_JP").replace("-", "_").split(".")[0];
+}
+
 function matchIdForGame(account: RiotAccount, gameId: string | number) {
   return `${account.platform.toUpperCase()}_${gameId}`;
 }
@@ -86,13 +91,20 @@ function isResultFetchTimedOut(
   return now.getTime() - startedAt.getTime() >= timeoutMs;
 }
 
-async function championNameById(championId: number | undefined) {
+async function championNameById(
+  championId: number | undefined,
+  fallbackName?: string,
+) {
   if (championId === undefined) {
-    return messageHandler.formatMessage(
+    return fallbackName ?? messageHandler.formatMessage(
       messageKeys.matchTracking.embed.fallback.unknownChampion,
     );
   }
-  return await riotStaticData.getChampionNameById(championId) ??
+  return await riotStaticData.getChampionNameById(
+    championId,
+    messageLocale(),
+  ) ??
+    fallbackName ??
     messageHandler.formatMessage(
       messageKeys.matchTracking.embed.fallback.championId,
       { id: championId },
@@ -105,7 +117,7 @@ async function queueName(queueId: number | undefined) {
       messageKeys.matchTracking.embed.fallback.unknownQueue,
     );
   }
-  return await riotStaticData.getQueueNameById(queueId) ??
+  return await riotStaticData.getQueueNameById(queueId, messageLocale()) ??
     messageHandler.formatMessage(
       messageKeys.matchTracking.embed.fallback.queueId,
       { id: queueId },
@@ -113,7 +125,7 @@ async function queueName(queueId: number | undefined) {
 }
 
 async function mapName(mapId: number) {
-  return await riotStaticData.getMapNameById(mapId) ??
+  return await riotStaticData.getMapNameById(mapId, messageLocale()) ??
     messageHandler.formatMessage(
       messageKeys.matchTracking.embed.fallback.mapId,
       { id: mapId },
@@ -121,7 +133,8 @@ async function mapName(mapId: number) {
 }
 
 async function gameModeName(gameMode: string) {
-  return await riotStaticData.getGameModeName(gameMode) ?? gameMode;
+  return await riotStaticData.getGameModeName(gameMode, messageLocale()) ??
+    gameMode;
 }
 
 function currentStateFromWatcher(watcher: MatchWatcher): WatcherState {
@@ -324,8 +337,13 @@ async function buildMatchResultEmbed(
   }
 
   const cs = participant.totalMinionsKilled + participant.neutralMinionsKilled;
+  const champion = await championNameById(
+    participant.championId,
+    participant.championName,
+  );
   const queue = await queueName(match.info.queueId);
   const map = await mapName(match.info.mapId);
+  const mode = await gameModeName(match.info.gameMode);
   const result = participant.win
     ? messageHandler.formatMessage(messageKeys.matchTracking.embed.result.win)
     : messageHandler.formatMessage(messageKeys.matchTracking.embed.result.loss);
@@ -348,7 +366,7 @@ async function buildMatchResultEmbed(
         name: messageHandler.formatMessage(
           messageKeys.matchTracking.embed.field.champion,
         ),
-        value: participant.championName,
+        value: champion,
         inline: true,
       },
       {
@@ -385,6 +403,13 @@ async function buildMatchResultEmbed(
           messageKeys.matchTracking.embed.field.map,
         ),
         value: map,
+        inline: true,
+      },
+      {
+        name: messageHandler.formatMessage(
+          messageKeys.matchTracking.embed.field.mode,
+        ),
+        value: mode,
         inline: true,
       },
     )


### PR DESCRIPTION
## 概要

- 試合結果 Embed のチャンピオン名を `championId` から解決するようにしました。
- ja_JP 向けに代表的な queue/map/mode の表示名を日本語ユーザー向けに補正します。
- Match-v5 participant schema に `championId` を追加し、結果 Embed に mode も表示します。

Closes #27

## 事前レビュー

- 未知値は既存 fallback を維持しています。
- locale が ja_JP でない場合は既存 static data 取得へ戻るため、英語表示の既存挙動を壊しにくい構成です。

## 検証

- `deno test --allow-env --allow-read --allow-sys --allow-ffi --env-file=.env.example bot/src/features/match_tracking.test.ts api/src/riot_api.test.ts api/src/riot_static_data.test.ts`
- worker 側で `deno task fmt:check`, `deno task lint`, `deno task check`, `deno task test:all`, `git diff --check` 成功確認済み。