### PR TITLE
feat(bot): 試合結果に追加戦績を表示する (#28)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -67,9 +67,13 @@
     - [x] Riot API 呼び出しを共有キュー化し、429 と rate limit headers を後続呼び出しに反映する。
     - [x] 試合監視通知を1試合1投稿の Embed 更新にし、試合中に gameId が変わるケースへ対応する。
     - [x] 試合監視通知の表示文言を messages 管理へ移し、Riot 公式 static data の名称をDBキャッシュする。
+    - [x] 試合結果 Embed に Match-v5 から計算できる `CS/min` と `キル関与率` を追加する。
     - [x] `deno task test:riot-live` を追加し、実 Riot API で Account-v1 / Spectator-v5 / Match-v5 の疎通確認を行う。
     - [x] Discord ギルド上で `/set-riot-id`、`/watch-match`、`/unwatch-match` の応答と監視状態更新を確認する。
     - [ ] Match-v5 で取得した戦績を既存 `matches` / `match_participants` に保存し、内部レート更新へ接続する。
+    - [ ] LP delta 表示は League-v4 または試合前後スナップショット比較の設計が必要なため、現行の Match-v5 / Spectator-v5 だけでは実装しない。
+    - [ ] OP.GG 等のプレイヤー外部戦績ページリンクは特定サービス URL の安定性に依存するため、実装時はリンク生成 helper と単体テストを用意してから導入する。
+    - [ ] 試合中の各プレイヤーロール表示は Spectator-v5 active game の参加者情報だけでは確定できず、現行 parse 対象にも `teamPosition` 相当がないため、別データ源または推定方針を設計してから導入する。
 37. [ ] 内部レートを全ギルド共有のプレイヤー評価として保存するスキーマと更新ロジックを設計する。
 38. [ ] チーム分け時の戦力均等化ロジックと内部レート計算式を仕様に合わせて高度化する。
 39. [ ] Discord/Riot API 呼び出しに対するリクエストキューや指数バックオフ等のレート制限対策を導入する。

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -119,6 +119,22 @@ function clientWithSend(
   return { client, sendSpy, editSpy };
 }
 
+function editedEmbedFieldValue(
+  editSpy: { calls: unknown[] },
+  callIndex: number,
+  fieldName: string,
+) {
+  const call = editSpy.calls[callIndex] as unknown as {
+    args: [
+      {
+        embeds: { toJSON(): { fields?: { name: string; value: string }[] } }[];
+      },
+    ];
+  };
+  const resultEmbed = call.args[0].embeds[0].toJSON();
+  return resultEmbed.fields?.find((field) => field.name === fieldName)?.value;
+}
+
 describe("match_tracking.ts", () => {
   const staticDataStubs: { restore(): void }[] = [];
 
@@ -298,6 +314,119 @@ describe("match_tracking.ts", () => {
     assertEquals(
       updateStub.calls.at(-1)?.args[2].currentNotificationMessageId,
       null,
+    );
+  });
+
+  test("試合結果EmbedにMatch-v5から計算できるCS/minとキル関与率を表示する", async () => {
+    const resultMatch = match();
+    resultMatch.info.participants.push({
+      puuid: "puuid-2",
+      championName: "Shen",
+      teamId: 100,
+      win: true,
+      kills: 20,
+      deaths: 4,
+      assists: 6,
+      totalMinionsKilled: 120,
+      neutralMinionsKilled: 0,
+      goldEarned: 10000,
+    });
+    const { client, editSpy } = clientWithSend();
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [watcher({
+            lastState: "IN_GAME",
+            currentGameId: "12345",
+            currentNotificationMessageId: "message-existing",
+          })],
+        }),
+    );
+    using _getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using _activeGameStub = stub(
+      riotApi,
+      "getActiveGameByPuuid",
+      () => Promise.resolve(null),
+    );
+    using _getMatchStub = stub(
+      riotApi,
+      "getMatchById",
+      () => Promise.resolve(resultMatch),
+    );
+    using _updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertEquals(
+      editedEmbedFieldValue(editSpy, 1, "CS/min"),
+      "6.4",
+    );
+    assertEquals(
+      editedEmbedFieldValue(editSpy, 1, "キル関与率"),
+      "60.0%",
+    );
+  });
+
+  test("試合結果Embedの追加戦績は試合時間やチームキルが不足してもfallback表示にする", async () => {
+    const resultMatch = match();
+    resultMatch.info.gameDuration = 0;
+    resultMatch.info.participants[0].kills = 0;
+    resultMatch.info.participants[0].assists = 0;
+    const { client, editSpy } = clientWithSend();
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [watcher({
+            lastState: "IN_GAME",
+            currentGameId: "12345",
+            currentNotificationMessageId: "message-existing",
+          })],
+        }),
+    );
+    using _getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using _activeGameStub = stub(
+      riotApi,
+      "getActiveGameByPuuid",
+      () => Promise.resolve(null),
+    );
+    using _getMatchStub = stub(
+      riotApi,
+      "getMatchById",
+      () => Promise.resolve(resultMatch),
+    );
+    using _updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertEquals(
+      editedEmbedFieldValue(editSpy, 1, "CS/min"),
+      "-",
+    );
+    assertEquals(
+      editedEmbedFieldValue(editSpy, 1, "キル関与率"),
+      "-",
     );
   });
 

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -124,6 +124,32 @@ async function gameModeName(gameMode: string) {
   return await riotStaticData.getGameModeName(gameMode) ?? gameMode;
 }
 
+function formatCsPerMinute(cs: number, gameDurationSeconds: number) {
+  if (!Number.isFinite(cs) || !Number.isFinite(gameDurationSeconds)) return "-";
+  if (cs < 0 || gameDurationSeconds <= 0) return "-";
+  return (cs / (gameDurationSeconds / 60)).toFixed(1);
+}
+
+function formatKillParticipation(
+  participantKills: number,
+  participantAssists: number,
+  teamKills: number,
+) {
+  if (
+    !Number.isFinite(participantKills) ||
+    !Number.isFinite(participantAssists) ||
+    !Number.isFinite(teamKills) ||
+    participantKills < 0 ||
+    participantAssists < 0 ||
+    teamKills <= 0
+  ) {
+    return "-";
+  }
+  return `${
+    (((participantKills + participantAssists) / teamKills) * 100).toFixed(1)
+  }%`;
+}
+
 function currentStateFromWatcher(watcher: MatchWatcher): WatcherState {
   return {
     lastState: watcher.lastState === "FETCHING_RESULT"
@@ -324,6 +350,15 @@ async function buildMatchResultEmbed(
   }
 
   const cs = participant.totalMinionsKilled + participant.neutralMinionsKilled;
+  const teamKills = match.info.participants
+    .filter((candidate) => candidate.teamId === participant.teamId)
+    .reduce((sum, candidate) => sum + candidate.kills, 0);
+  const csPerMinute = formatCsPerMinute(cs, match.info.gameDuration);
+  const killParticipation = formatKillParticipation(
+    participant.kills,
+    participant.assists,
+    teamKills,
+  );
   const queue = await queueName(match.info.queueId);
   const map = await mapName(match.info.mapId);
   const result = participant.win
@@ -364,6 +399,20 @@ async function buildMatchResultEmbed(
           messageKeys.matchTracking.embed.field.cs,
         ),
         value: String(cs),
+        inline: true,
+      },
+      {
+        name: messageHandler.formatMessage(
+          messageKeys.matchTracking.embed.field.csPerMinute,
+        ),
+        value: csPerMinute,
+        inline: true,
+      },
+      {
+        name: messageHandler.formatMessage(
+          messageKeys.matchTracking.embed.field.killParticipation,
+        ),
+        value: killParticipation,
         inline: true,
       },
       {

--- a/messages/en_US/system.json
+++ b/messages/en_US/system.json
@@ -130,6 +130,8 @@
         "elapsed": "Elapsed",
         "kda": "KDA",
         "cs": "CS",
+        "csPerMinute": "CS/min",
+        "killParticipation": "Kill Participation",
         "gold": "Gold"
       },
       "fallback": {

--- a/messages/ja_JP/system.json
+++ b/messages/ja_JP/system.json
@@ -131,6 +131,8 @@
         "elapsed": "経過時間",
         "kda": "KDA",
         "cs": "CS",
+        "csPerMinute": "CS/min",
+        "killParticipation": "キル関与率",
         "gold": "Gold"
       },
       "fallback": {


### PR DESCRIPTION
## 概要

- Match-v5 から安全に計算できる `CS/min` と `キル関与率` を試合結果 Embed に追加しました。
- 試合時間 0 秒やチームキル 0 など、計算不能な場合は `-` に fallback します。
- LP delta、外部戦績リンク、試合中ロール表示は現行データだけでは確定できないため、未実装理由と次アクションを `TASKS.md` に残しました。

Refs #28

## 事前レビュー

- 追加計算は Match-v5 既存 participant 情報だけを使い、外部サービス取得は追加していません。
- ゼロ除算/不完全データは fallback で壊れないことを確認しています。

## 検証

- `deno test --allow-env --allow-read --allow-sys --allow-ffi --env-file=.env.example bot/src/features/match_tracking.test.ts api/src/riot_api.test.ts`
- worker 側で `deno task fmt:check`, `deno task lint`, `deno task check`, `deno task test:all` 成功確認済み。