### PR TITLE
test(bot): 複数監視対象の継続処理を固定する (#29)

### DIFF
--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -34,7 +34,7 @@ function watcher(overrides: Partial<MatchWatcher> = {}): MatchWatcher {
   };
 }
 
-function account(): RiotAccount {
+function account(overrides: Partial<RiotAccount> = {}): RiotAccount {
   const now = new Date("2026-01-01T00:00:00.000Z");
   return {
     discordId: "target-1",
@@ -45,6 +45,7 @@ function account(): RiotAccount {
     region: "asia",
     createdAt: now,
     updatedAt: now,
+    ...overrides,
   };
 }
 
@@ -474,6 +475,167 @@ describe("match_tracking.ts", () => {
     assertSpyCalls(activeGameStub, 1);
     assertSpyCalls(sendSpy, 0);
     assertSpyCalls(updateStub, 0);
+  });
+
+  test("複数の監視対象が返されたとき、全員分の状態確認と通知と状態更新を行う", async () => {
+    const { client, sendSpy } = clientWithSend();
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [
+            watcher(),
+            watcher({
+              targetDiscordId: "target-2",
+              requesterId: "requester-2",
+            }),
+          ],
+        }),
+    );
+    using getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      (discordId) =>
+        Promise.resolve({
+          success: true as const,
+          account: account({
+            discordId,
+            puuid: discordId === "target-2" ? "puuid-2" : "puuid-1",
+            gameName: discordId === "target-2" ? "Tristana" : "Teemo",
+          }),
+        }),
+    );
+    using activeGameStub = stub(
+      riotApi,
+      "getActiveGameByPuuid",
+      (_platform, puuid) =>
+        Promise.resolve(activeGame(puuid === "puuid-2" ? 67890 : 12345)),
+    );
+    using updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertSpyCalls(getAccountStub, 2);
+    assertSpyCall(getAccountStub, 0, { args: ["target-1"] });
+    assertSpyCall(getAccountStub, 1, { args: ["target-2"] });
+    assertSpyCalls(activeGameStub, 2);
+    assertSpyCall(activeGameStub, 0, { args: ["jp1", "puuid-1"] });
+    assertSpyCall(activeGameStub, 1, { args: ["jp1", "puuid-2"] });
+    assertSpyCalls(sendSpy, 2);
+    assertSpyCalls(updateStub, 2);
+    assertEquals(updateStub.calls[0].args[1], "target-1");
+    assertEquals(updateStub.calls[0].args[2].currentGameId, "12345");
+    assertEquals(updateStub.calls[1].args[1], "target-2");
+    assertEquals(updateStub.calls[1].args[2].currentGameId, "67890");
+  });
+
+  test("一部の監視対象でRiotアカウント取得に失敗しても、後続の監視対象を処理する", async () => {
+    const { client, sendSpy } = clientWithSend();
+    using _loggerStub = stub(botLogger, "error", () => {});
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [
+            watcher(),
+            watcher({ targetDiscordId: "target-2" }),
+          ],
+        }),
+    );
+    using getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      (discordId) => {
+        if (discordId === "target-1") {
+          throw new Error("Riot account fetch failed");
+        }
+        return Promise.resolve({
+          success: true as const,
+          account: account({ discordId, puuid: "puuid-2" }),
+        });
+      },
+    );
+    using activeGameStub = stub(
+      riotApi,
+      "getActiveGameByPuuid",
+      () => Promise.resolve(activeGame(67890)),
+    );
+    using updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertSpyCalls(getAccountStub, 2);
+    assertSpyCalls(activeGameStub, 1);
+    assertSpyCall(activeGameStub, 0, { args: ["jp1", "puuid-2"] });
+    assertSpyCalls(sendSpy, 1);
+    assertSpyCalls(updateStub, 1);
+    assertEquals(updateStub.calls[0].args[1], "target-2");
+    assertEquals(updateStub.calls[0].args[2].currentGameId, "67890");
+  });
+
+  test("一部の監視対象でRiot API処理に失敗しても、後続の監視対象を処理する", async () => {
+    const { client, sendSpy } = clientWithSend();
+    using _loggerStub = stub(botLogger, "error", () => {});
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [
+            watcher(),
+            watcher({ targetDiscordId: "target-2" }),
+          ],
+        }),
+    );
+    using getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      (discordId) =>
+        Promise.resolve({
+          success: true as const,
+          account: account({
+            discordId,
+            puuid: discordId === "target-2" ? "puuid-2" : "puuid-1",
+          }),
+        }),
+    );
+    using activeGameStub = stub(
+      riotApi,
+      "getActiveGameByPuuid",
+      (_platform, puuid) => {
+        if (puuid === "puuid-1") {
+          throw new Error("Riot API failed");
+        }
+        return Promise.resolve(activeGame(67890));
+      },
+    );
+    using updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertSpyCalls(getAccountStub, 2);
+    assertSpyCalls(activeGameStub, 2);
+    assertSpyCalls(sendSpy, 1);
+    assertSpyCalls(updateStub, 1);
+    assertEquals(updateStub.calls[0].args[1], "target-2");
+    assertEquals(updateStub.calls[0].args[2].currentGameId, "67890");
   });
 
   test("通知送信に失敗しても、試合開始の状態更新は継続する", async () => {

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -66,6 +66,12 @@ function activeGame(gameId = 12345) {
   };
 }
 
+function activeGameForPuuid(puuid: string, gameId = 12345) {
+  const game = activeGame(gameId);
+  game.participants[0].puuid = puuid;
+  return game;
+}
+
 function match() {
   return {
     metadata: {
@@ -511,7 +517,9 @@ describe("match_tracking.ts", () => {
       riotApi,
       "getActiveGameByPuuid",
       (_platform, puuid) =>
-        Promise.resolve(activeGame(puuid === "puuid-2" ? 67890 : 12345)),
+        Promise.resolve(
+          activeGameForPuuid(puuid, puuid === "puuid-2" ? 67890 : 12345),
+        ),
     );
     using updateStub = stub(
       apiClient,
@@ -555,7 +563,10 @@ describe("match_tracking.ts", () => {
       "getRiotAccount",
       (discordId) => {
         if (discordId === "target-1") {
-          throw new Error("Riot account fetch failed");
+          return Promise.resolve({
+            success: false as const,
+            error: "Riot account fetch failed",
+          });
         }
         return Promise.resolve({
           success: true as const,
@@ -566,7 +577,7 @@ describe("match_tracking.ts", () => {
     using activeGameStub = stub(
       riotApi,
       "getActiveGameByPuuid",
-      () => Promise.resolve(activeGame(67890)),
+      (_platform, puuid) => Promise.resolve(activeGameForPuuid(puuid, 67890)),
     );
     using updateStub = stub(
       apiClient,
@@ -619,7 +630,7 @@ describe("match_tracking.ts", () => {
         if (puuid === "puuid-1") {
           throw new Error("Riot API failed");
         }
-        return Promise.resolve(activeGame(67890));
+        return Promise.resolve(activeGameForPuuid(puuid, 67890));
       },
     );
     using updateStub = stub(


### PR DESCRIPTION
## 概要

- 複数 watcher が返された場合に全員分を処理することをテストで固定しました。
- 1人分の Riot account 取得や Riot API 処理が失敗しても、後続 watcher の処理が継続することを検証します。
- 既存実装が要件を満たしていたため、プロダクションコードは変更していません。

Closes #29

## 事前レビュー

- 追加はテストのみです。
- 既存の watcher ごとの `try/catch` により、失敗がループ全体へ波及しないことを確認しています。

## 検証

- `deno test --allow-env --allow-read --allow-sys --allow-ffi --env-file=.env.example bot/src/features/match_tracking.test.ts`
- worker 側で `deno task fmt:check`, `deno task lint`, `deno task check`, `deno task test:all` 成功確認済み。