### PR TITLE
feat(bot): 監視対象一覧コマンドを追加する (#30)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -67,6 +67,7 @@
     - [x] Riot API 呼び出しを共有キュー化し、429 と rate limit headers を後続呼び出しに反映する。
     - [x] 試合監視通知を1試合1投稿の Embed 更新にし、試合中に gameId が変わるケースへ対応する。
     - [x] 試合監視通知の表示文言を messages 管理へ移し、Riot 公式 static data の名称をDBキャッシュする。
+    - [x] `/watch-list` でギルド内の有効な試合監視対象一覧を確認できるようにする。
     - [x] `deno task test:riot-live` を追加し、実 Riot API で Account-v1 / Spectator-v5 / Match-v5 の疎通確認を行う。
     - [x] Discord ギルド上で `/set-riot-id`、`/watch-match`、`/unwatch-match` の応答と監視状態更新を確認する。
     - [ ] Match-v5 で取得した戦績を既存 `matches` / `match_participants` に保存し、内部レート更新へ接続する。

--- a/api/src/db/actions.ts
+++ b/api/src/db/actions.ts
@@ -330,6 +330,15 @@ async function getEnabledMatchWatchers() {
   });
 }
 
+async function getEnabledMatchWatchersByGuild(guildId: string) {
+  return await db.query.matchWatchers.findMany({
+    where: and(
+      eq(matchWatchers.guildId, guildId),
+      eq(matchWatchers.enabled, true),
+    ),
+  });
+}
+
 async function updateMatchWatcherState(
   guildId: string,
   targetDiscordId: string,
@@ -393,6 +402,7 @@ export const dbActions = {
   upsertRiotStaticDataCache,
   upsertMatchWatcher,
   getEnabledMatchWatchers,
+  getEnabledMatchWatchersByGuild,
   updateMatchWatcherState,
   disableMatchWatcher,
   createAuthState,

--- a/api/src/routes/match_watchers.test.ts
+++ b/api/src/routes/match_watchers.test.ts
@@ -87,6 +87,43 @@ describe("routes/match_watchers.ts", () => {
     assertSpyCall(getStub, 0, { args: [] });
   });
 
+  test("ギルドIDを指定して有効な監視設定一覧を取得すると、そのギルドの監視設定だけを返す", async () => {
+    const createdAt = new Date("2026-01-01T00:00:00.000Z");
+    using getStub = stub(
+      dbActions,
+      "getEnabledMatchWatchersByGuild",
+      () =>
+        Promise.resolve([{
+          ...watcher,
+          enabled: true,
+          lastState: "IDLE" as const,
+          currentGameId: null,
+          currentMatchId: null,
+          currentNotificationMessageId: null,
+          pendingResultMatchId: null,
+          pendingResultNotificationMessageId: null,
+          pendingResultStartedAt: null,
+          gameStartedAt: null,
+          lastCheckedAt: null,
+          lastInGameNotifiedAt: null,
+          createdAt,
+          updatedAt: createdAt,
+        }]),
+    );
+
+    const res = await client["match-watchers"].enabled[":guildId"].$get({
+      param: { guildId: watcher.guildId },
+    });
+
+    assert(res.status === 200);
+    const body = await res.json();
+    assertEquals(
+      body.watchers.map((item: { guildId: string }) => item.guildId),
+      [watcher.guildId],
+    );
+    assertSpyCall(getStub, 0, { args: [watcher.guildId] });
+  });
+
   test("監視状態を更新すると、204 No Contentを返す", async () => {
     using updateStub = stub(
       dbActions,

--- a/api/src/routes/match_watchers.ts
+++ b/api/src/routes/match_watchers.ts
@@ -45,6 +45,11 @@ export const matchWatchersRoutes = new Hono()
     const watchers = await dbActions.getEnabledMatchWatchers();
     return c.json({ watchers }, 200);
   })
+  .get("/enabled/:guildId", async (c) => {
+    const { guildId } = c.req.param();
+    const watchers = await dbActions.getEnabledMatchWatchersByGuild(guildId);
+    return c.json({ watchers }, 200);
+  })
   .patch(
     "/:guildId/:targetDiscordId/state",
     zValidator("json", updateMatchWatcherStateSchema),

--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -125,6 +125,58 @@ describe("apiClient", () => {
     });
   });
 
+  describe("getEnabledMatchWatchersByGuild", () => {
+    test("ギルドIDを指定して監視設定を取得すると、日付フィールドをDateまたはnullへ変換する", async () => {
+      using fetchStub = stub(
+        globalThis,
+        "fetch",
+        () =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({
+                watchers: [{
+                  guildId: "guild-1",
+                  targetDiscordId: "target-1",
+                  requesterId: "requester-1",
+                  channelId: "channel-1",
+                  enabled: true,
+                  lastState: "IDLE",
+                  currentGameId: null,
+                  currentMatchId: null,
+                  currentNotificationMessageId: null,
+                  pendingResultMatchId: null,
+                  pendingResultNotificationMessageId: null,
+                  pendingResultStartedAt: null,
+                  gameStartedAt: null,
+                  lastCheckedAt: "2026-01-01T00:02:00.000Z",
+                  lastInGameNotifiedAt: null,
+                  createdAt: "2026-01-01T00:00:00.000Z",
+                  updatedAt: "2026-01-01T00:03:00.000Z",
+                }],
+              }),
+              { status: 200 },
+            ),
+          ),
+      );
+
+      const result = await apiClient.getEnabledMatchWatchersByGuild("guild-1");
+
+      assertEquals(result.success, true);
+      if (!result.success) return;
+      assertEquals(result.watchers[0].guildId, "guild-1");
+      assertEquals(
+        result.watchers[0].lastCheckedAt,
+        new Date("2026-01-01T00:02:00.000Z"),
+      );
+      assertEquals(result.watchers[0].gameStartedAt, null);
+      assertSpyCalls(fetchStub, 1);
+      assertEquals(
+        fetchStub.calls[0].args[0],
+        `${Deno.env.get("API_URL")}/match-watchers/enabled/guild-1`,
+      );
+    });
+  });
+
   describe("setMainRole", () => {
     const userId = "test-user";
     const guildId = "test-guild";

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -359,6 +359,27 @@ async function getEnabledMatchWatchers() {
   }
 }
 
+async function getEnabledMatchWatchersByGuild(guildId: string) {
+  try {
+    const res = await client["match-watchers"].enabled[":guildId"].$get({
+      param: { guildId },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Unexpected response: ${res}`);
+    }
+
+    const body = await res.json();
+    return {
+      success: true as const,
+      watchers: body.watchers.map(parseMatchWatcher),
+    };
+  } catch (error) {
+    console.error("Failed to communicate with API", error);
+    return { success: false as const, error: "Failed to communicate with API" };
+  }
+}
+
 async function updateMatchWatcherState(
   guildId: string,
   targetDiscordId: string,
@@ -407,5 +428,6 @@ export const apiClient = {
   watchMatch,
   unwatchMatch,
   getEnabledMatchWatchers,
+  getEnabledMatchWatchersByGuild,
   updateMatchWatcherState,
 };

--- a/bot/src/commands/watch-list.test.ts
+++ b/bot/src/commands/watch-list.test.ts
@@ -1,0 +1,108 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import { assertSpyCall, stub } from "@std/testing/mock";
+import {
+  CommandInteraction,
+  InteractionEditReplyOptions,
+  Message,
+} from "discord.js";
+import { type MatchWatcher } from "@adteemo/api/schema";
+import { apiClient } from "../api_client.ts";
+import { MockInteractionBuilder } from "../test_utils.ts";
+import { data, execute } from "./watch-list.ts";
+
+function watcher(
+  overrides: Partial<MatchWatcher> = {},
+): MatchWatcher {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  return {
+    guildId: "mock-guild-id",
+    targetDiscordId: "target-1",
+    requesterId: "requester-1",
+    channelId: "channel-1",
+    enabled: true,
+    lastState: "IDLE",
+    currentGameId: null,
+    currentMatchId: null,
+    currentNotificationMessageId: null,
+    pendingResultMatchId: null,
+    pendingResultNotificationMessageId: null,
+    pendingResultStartedAt: null,
+    gameStartedAt: null,
+    lastCheckedAt: null,
+    lastInGameNotifiedAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe("Command: watch-list", () => {
+  test("コマンド名とオプションが期待通りに設定されている", () => {
+    const json = data.toJSON();
+    assertEquals(json.name, "watch-list");
+    assertEquals(json.options, []);
+  });
+
+  test("ギルド内で実行すると、そのギルドの監視一覧APIを呼び出す", async () => {
+    const interaction = new MockInteractionBuilder("watch-list").build();
+    using listStub = stub(
+      apiClient,
+      "getEnabledMatchWatchersByGuild",
+      () => Promise.resolve({ success: true as const, watchers: [] }),
+    );
+
+    await execute(interaction as unknown as CommandInteraction);
+
+    assertSpyCall(listStub, 0, { args: ["mock-guild-id"] });
+  });
+
+  test("監視対象が0件の場合、分かりやすい空一覧メッセージを返す", async () => {
+    const interaction = new MockInteractionBuilder("watch-list").build();
+    using _listStub = stub(
+      apiClient,
+      "getEnabledMatchWatchersByGuild",
+      () => Promise.resolve({ success: true as const, watchers: [] }),
+    );
+    using editStub = stub(
+      interaction,
+      "editReply",
+      () => Promise.resolve({} as Message),
+    );
+
+    await execute(interaction as unknown as CommandInteraction);
+
+    const content =
+      (editStub.calls[0].args[0] as InteractionEditReplyOptions).content;
+    assert(typeof content === "string");
+    assertStringIncludes(content, "対象");
+  });
+
+  test("監視対象が多い場合でも、Discordのcontent制限内に収める", async () => {
+    const interaction = new MockInteractionBuilder("watch-list").build();
+    const watchers = Array.from({ length: 120 }, (_, index) =>
+      watcher({
+        targetDiscordId: `target-${index + 1}`,
+        requesterId: `requester-${index + 1}`,
+        channelId: `channel-${index + 1}`,
+      }));
+    using _listStub = stub(
+      apiClient,
+      "getEnabledMatchWatchersByGuild",
+      () => Promise.resolve({ success: true as const, watchers }),
+    );
+    using editStub = stub(
+      interaction,
+      "editReply",
+      () => Promise.resolve({} as Message),
+    );
+
+    await execute(interaction as unknown as CommandInteraction);
+
+    const content =
+      (editStub.calls[0].args[0] as InteractionEditReplyOptions).content;
+    assert(typeof content === "string");
+    assert(content.length <= 2000);
+    assert(content.includes("ほか"));
+  });
+});

--- a/bot/src/commands/watch-list.test.ts
+++ b/bot/src/commands/watch-list.test.ts
@@ -8,6 +8,7 @@ import {
 } from "discord.js";
 import { type MatchWatcher } from "@adteemo/api/schema";
 import { apiClient } from "../api_client.ts";
+import { messageHandler, messageKeys } from "../messages.ts";
 import { MockInteractionBuilder } from "../test_utils.ts";
 import { data, execute } from "./watch-list.ts";
 
@@ -74,8 +75,10 @@ describe("Command: watch-list", () => {
 
     const content =
       (editStub.calls[0].args[0] as InteractionEditReplyOptions).content;
-    assert(typeof content === "string");
-    assertStringIncludes(content, "対象");
+    assertEquals(
+      content,
+      messageHandler.formatMessage(messageKeys.matchTracking.watchList.empty),
+    );
   });
 
   test("監視対象が多い場合でも、Discordのcontent制限内に収める", async () => {
@@ -103,6 +106,17 @@ describe("Command: watch-list", () => {
       (editStub.calls[0].args[0] as InteractionEditReplyOptions).content;
     assert(typeof content === "string");
     assert(content.length <= 2000);
-    assert(content.includes("ほか"));
+    assertStringIncludes(
+      content,
+      messageHandler.formatMessage(
+        messageKeys.matchTracking.watchList.item,
+        {
+          position: 1,
+          targetId: "target-1",
+          channelId: "channel-1",
+        },
+      ),
+    );
+    assert(!content.includes("<@target-120>"));
   });
 });

--- a/bot/src/commands/watch-list.ts
+++ b/bot/src/commands/watch-list.ts
@@ -1,0 +1,94 @@
+import {
+  CommandInteraction,
+  MessageFlags,
+  SlashCommandBuilder,
+} from "discord.js";
+import type { MatchWatcher } from "@adteemo/api/schema";
+import { apiClient } from "../api_client.ts";
+import { messageHandler, messageKeys } from "../messages.ts";
+
+const DISCORD_CONTENT_LIMIT = 2000;
+
+export const data = new SlashCommandBuilder()
+  .setName("watch-list")
+  .setDescription("現在のLoL試合監視対象一覧を表示します。");
+
+function buildWatchListContent(watchers: MatchWatcher[]) {
+  if (watchers.length === 0) {
+    return messageHandler.formatMessage(
+      messageKeys.matchTracking.watchList.empty,
+    );
+  }
+
+  const header = messageHandler.formatMessage(
+    messageKeys.matchTracking.watchList.header,
+  );
+  const lines = watchers.map((watcher, index) => {
+    const position = index + 1;
+    return `${position}. <@${watcher.targetDiscordId}> (通知: <#${watcher.channelId}>)`;
+  });
+  const selected = [header];
+
+  for (const line of lines) {
+    const next = [...selected, line].join("\n");
+    if (next.length > DISCORD_CONTENT_LIMIT) break;
+    selected.push(line);
+  }
+
+  if (lines.length === selected.length - 1) {
+    return selected.join("\n");
+  }
+
+  while (selected.length > 1) {
+    const omitted = lines.length - (selected.length - 1);
+    const footer = messageHandler.formatMessage(
+      messageKeys.matchTracking.watchList.omitted,
+      { count: omitted },
+    );
+    const next = [...selected, footer].join("\n");
+    if (next.length <= DISCORD_CONTENT_LIMIT) {
+      return next;
+    }
+    selected.pop();
+  }
+
+  return `${header}\n${
+    messageHandler.formatMessage(
+      messageKeys.matchTracking.watchList.omitted,
+      { count: watchers.length },
+    )
+  }`;
+}
+
+export async function execute(interaction: CommandInteraction) {
+  if (!interaction.isChatInputCommand()) return;
+  if (!interaction.inGuild() || !interaction.guildId) {
+    await interaction.reply({
+      content: messageHandler.formatMessage(
+        messageKeys.common.info.guildOnlyCommand,
+      ),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const result = await apiClient.getEnabledMatchWatchersByGuild(
+    interaction.guildId,
+  );
+
+  if (!result.success) {
+    await interaction.editReply({
+      content: messageHandler.formatMessage(
+        messageKeys.matchTracking.watchList.error.fetch,
+        { error: result.error },
+      ),
+    });
+    return;
+  }
+
+  await interaction.editReply({
+    content: buildWatchListContent(result.watchers),
+  });
+}

--- a/bot/src/commands/watch-list.ts
+++ b/bot/src/commands/watch-list.ts
@@ -25,7 +25,14 @@ function buildWatchListContent(watchers: MatchWatcher[]) {
   );
   const lines = watchers.map((watcher, index) => {
     const position = index + 1;
-    return `${position}. <@${watcher.targetDiscordId}> (通知: <#${watcher.channelId}>)`;
+    return messageHandler.formatMessage(
+      messageKeys.matchTracking.watchList.item,
+      {
+        position,
+        targetId: watcher.targetDiscordId,
+        channelId: watcher.channelId,
+      },
+    );
   });
   const selected = [header];
 

--- a/messages/en_US/system.json
+++ b/messages/en_US/system.json
@@ -100,6 +100,14 @@
     }
   },
   "matchTracking": {
+    "watchList": {
+      "header": "Current match watchers:",
+      "empty": "There are no active match watchers in this server.",
+      "omitted": "...and {count} more",
+      "error": {
+        "fetch": "Could not fetch match watchers: {error}"
+      }
+    },
     "embed": {
       "active": {
         "startedTitle": "Match start detected",

--- a/messages/en_US/system.json
+++ b/messages/en_US/system.json
@@ -103,6 +103,7 @@
     "watchList": {
       "header": "Current match watchers:",
       "empty": "There are no active match watchers in this server.",
+      "item": "{position}. <@{targetId}> (Notification: <#{channelId}>)",
       "omitted": "...and {count} more",
       "error": {
         "fetch": "Could not fetch match watchers: {error}"

--- a/messages/ja_JP/system.json
+++ b/messages/ja_JP/system.json
@@ -104,6 +104,7 @@
     "watchList": {
       "header": "現在の試合監視対象:",
       "empty": "現在このサーバーで有効な試合監視対象はありません。",
+      "item": "{position}. <@{targetId}> (通知: <#{channelId}>)",
       "omitted": "...ほか {count} 件",
       "error": {
         "fetch": "試合監視対象一覧を取得できませんでした: {error}"

--- a/messages/ja_JP/system.json
+++ b/messages/ja_JP/system.json
@@ -101,6 +101,14 @@
     }
   },
   "matchTracking": {
+    "watchList": {
+      "header": "現在の試合監視対象:",
+      "empty": "現在このサーバーで有効な試合監視対象はありません。",
+      "omitted": "...ほか {count} 件",
+      "error": {
+        "fetch": "試合監視対象一覧を取得できませんでした: {error}"
+      }
+    },
     "embed": {
       "active": {
         "startedTitle": "試合開始を検知しました",

--- a/messages/ja_JP/teemo.json
+++ b/messages/ja_JP/teemo.json
@@ -107,5 +107,15 @@
     "error": {
       "failure": "うーん、なんだか身体の調子が悪いみたいだ…。 {error}"
     }
+  },
+  "matchTracking": {
+    "watchList": {
+      "header": "いま偵察中の隊員たち:",
+      "empty": "この拠点では、いま偵察対象の隊員はいないみたいだ。",
+      "omitted": "...ほか {count} 件、偵察中だよ",
+      "error": {
+        "fetch": "偵察対象の一覧を取りに行けなかったよ…。 {error}"
+      }
+    }
   }
 }

--- a/messages/ja_JP/teemo.json
+++ b/messages/ja_JP/teemo.json
@@ -112,6 +112,7 @@
     "watchList": {
       "header": "いま偵察中の隊員たち:",
       "empty": "この拠点では、いま偵察対象の隊員はいないみたいだ。",
+      "item": "{position}. <@{targetId}> (偵察先: <#{channelId}>)",
       "omitted": "...ほか {count} 件、偵察中だよ",
       "error": {
         "fetch": "偵察対象の一覧を取りに行けなかったよ…。 {error}"


### PR DESCRIPTION
## 概要

- `/watch-list` を追加し、実行ギルド内の有効な試合監視対象を一覧表示できるようにしました。
- API に guild 単位の enabled watcher 取得 route/action を追加しました。
- 0件表示と Discord content 2000文字制限内への省略表示を実装しました。

Closes #30

## 事前レビュー

- 表示対象は API 側で guildId + enabled=true に限定しています。
- Bot 文言は message catalog 管理にしています。
- 実 Discord 上での slash command 登録・手動操作確認は未実施です。

## 検証

- `deno test --allow-env --allow-read --env-file=.env.example bot/src/commands/watch-list.test.ts bot/src/api_client.test.ts`
- `deno test --allow-env --allow-read --allow-write --allow-sys --allow-ffi --env-file=.env.example api/src/routes/match_watchers.test.ts`
- `deno fmt --check bot/src/commands/watch-list.ts bot/src/commands/watch-list.test.ts messages/ja_JP/system.json messages/en_US/system.json messages/ja_JP/teemo.json`