### PR TITLE
perf(bot): 同一監視対象のRiot API取得を集約する (#31)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -69,6 +69,7 @@
     - [x] 試合監視通知の表示文言を messages 管理へ移し、Riot 公式 static data の名称をDBキャッシュする。
     - [x] `deno task test:riot-live` を追加し、実 Riot API で Account-v1 / Spectator-v5 / Match-v5 の疎通確認を行う。
     - [x] Discord ギルド上で `/set-riot-id`、`/watch-match`、`/unwatch-match` の応答と監視状態更新を確認する。
+    - [x] 同一tick内で同一監視対象の Riot account / active game 取得を重複させないようにする。
     - [ ] Match-v5 で取得した戦績を既存 `matches` / `match_participants` に保存し、内部レート更新へ接続する。
 37. [ ] 内部レートを全ギルド共有のプレイヤー評価として保存するスキーマと更新ロジックを設計する。
 38. [ ] チーム分け時の戦力均等化ロジックと内部レート計算式を仕様に合わせて高度化する。

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -538,6 +538,61 @@ describe("match_tracking.ts", () => {
     );
   });
 
+  test("同一matchIdの結果取得待ちが複数guildにあるとき、1回の処理ではRiot試合取得を共有しつつ各guildの通知と状態更新を継続する", async () => {
+    const { client, editSpy } = clientWithSend();
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [
+            watcher({
+              guildId: "guild-1",
+              lastState: "FETCHING_RESULT",
+              currentMatchId: "JP1_12345",
+              currentNotificationMessageId: "message-existing-1",
+              gameStartedAt: new Date(Date.now() - 120_000),
+            }),
+            watcher({
+              guildId: "guild-2",
+              channelId: "channel-2",
+              lastState: "FETCHING_RESULT",
+              currentMatchId: "JP1_12345",
+              currentNotificationMessageId: "message-existing-2",
+              gameStartedAt: new Date(Date.now() - 120_000),
+            }),
+          ],
+        }),
+    );
+    using getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using matchStub = stub(
+      riotApi,
+      "getMatchById",
+      () => Promise.resolve(match()),
+    );
+    using updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertSpyCalls(getAccountStub, 1);
+    assertSpyCalls(matchStub, 1);
+    assertSpyCalls(editSpy, 2);
+    assertSpyCalls(updateStub, 2);
+    assertEquals(updateStub.calls[0].args[0], "guild-1");
+    assertEquals(updateStub.calls[1].args[0], "guild-2");
+    assertEquals(updateStub.calls[0].args[2].pendingResultMatchId, null);
+    assertEquals(updateStub.calls[1].args[2].pendingResultMatchId, null);
+  });
+
   test("通知送信に失敗しても、試合開始の状態更新は継続する", async () => {
     const { client } = clientWithSend(() =>
       Promise.reject(new Error("Missing permissions"))

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -476,6 +476,68 @@ describe("match_tracking.ts", () => {
     assertSpyCalls(updateStub, 0);
   });
 
+  test("同一targetDiscordIdを複数guildで監視しているとき、1回の処理ではRiot取得を共有しつつ各guildの通知と状態更新を継続する", async () => {
+    let sendCount = 0;
+    const { client, sendSpy } = clientWithSend(() => {
+      sendCount += 1;
+      if (sendCount === 1) {
+        return Promise.reject(new Error("Missing permissions"));
+      }
+      return Promise.resolve({ id: `message-new-${sendCount}` });
+    });
+    using _loggerStub = stub(botLogger, "error", () => {});
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [
+            watcher({ guildId: "guild-1", channelId: "channel-1" }),
+            watcher({ guildId: "guild-2", channelId: "channel-2" }),
+          ],
+        }),
+    );
+    using getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using activeGameStub = stub(
+      riotApi,
+      "getActiveGameByPuuid",
+      () => Promise.resolve(activeGame()),
+    );
+    using updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertSpyCalls(getAccountStub, 1);
+    assertSpyCalls(activeGameStub, 1);
+    assertSpyCalls(sendSpy, 2);
+    assertSpyCalls(updateStub, 2);
+    assertEquals(updateStub.calls[0].args[0], "guild-1");
+    assertEquals(updateStub.calls[0].args[1], "target-1");
+    assertEquals(updateStub.calls[0].args[2].lastState, "IN_GAME");
+    assertEquals(updateStub.calls[0].args[2].currentGameId, "12345");
+    assertEquals(
+      updateStub.calls[0].args[2].currentNotificationMessageId,
+      null,
+    );
+    assertEquals(updateStub.calls[1].args[0], "guild-2");
+    assertEquals(updateStub.calls[1].args[1], "target-1");
+    assertEquals(updateStub.calls[1].args[2].lastState, "IN_GAME");
+    assertEquals(updateStub.calls[1].args[2].currentGameId, "12345");
+    assertEquals(
+      updateStub.calls[1].args[2].currentNotificationMessageId,
+      "message-new-2",
+    );
+  });
+
   test("通知送信に失敗しても、試合開始の状態更新は継続する", async () => {
     const { client } = clientWithSend(() =>
       Promise.reject(new Error("Missing permissions"))

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -24,6 +24,7 @@ type WatcherState = Parameters<typeof apiClient.updateMatchWatcherState>[2];
 type MatchWatcherProcessingContext = {
   riotAccountsByTargetDiscordId: Map<string, Promise<RiotAccountResult>>;
   activeGamesByRiotAccount: Map<string, Promise<ActiveGameResult>>;
+  matchesByRegionAndMatchId: Map<string, Promise<RiotMatch | null>>;
 };
 type WatcherMessage = {
   id?: string;
@@ -54,10 +55,15 @@ function activeGameCacheKey(account: RiotAccount) {
   return `${account.platform}:${account.puuid}`;
 }
 
+function matchCacheKey(account: RiotAccount, matchId: string) {
+  return `${account.region}:${matchId}`;
+}
+
 function createMatchWatcherProcessingContext(): MatchWatcherProcessingContext {
   return {
     riotAccountsByTargetDiscordId: new Map(),
     activeGamesByRiotAccount: new Map(),
+    matchesByRegionAndMatchId: new Map(),
   };
 }
 
@@ -83,6 +89,20 @@ function getActiveGameForAccount(
 
   const result = riotApi.getActiveGameByPuuid(account.platform, account.puuid);
   context.activeGamesByRiotAccount.set(cacheKey, result);
+  return result;
+}
+
+function getMatchForPendingResult(
+  context: MatchWatcherProcessingContext,
+  account: RiotAccount,
+  matchId: string,
+) {
+  const cacheKey = matchCacheKey(account, matchId);
+  const cached = context.matchesByRegionAndMatchId.get(cacheKey);
+  if (cached) return cached;
+
+  const result = riotApi.getMatchById(account.region, matchId);
+  context.matchesByRegionAndMatchId.set(cacheKey, result);
   return result;
 }
 
@@ -510,6 +530,7 @@ async function tryFetchAndNotifyResult(
   client: Client,
   watcher: MatchWatcher,
   account: RiotAccount,
+  context: MatchWatcherProcessingContext,
   pending: PendingResult,
   currentState: WatcherState = currentStateFromWatcher(watcher),
 ) {
@@ -536,7 +557,11 @@ async function tryFetchAndNotifyResult(
     return { status: "cleared" as const, messageId };
   }
 
-  const match = await riotApi.getMatchById(account.region, pending.matchId);
+  const match = await getMatchForPendingResult(
+    context,
+    account,
+    pending.matchId,
+  );
   if (!match) {
     await setWatcherState(watcher, {
       ...currentState,
@@ -592,6 +617,7 @@ async function processWatcher(
       client,
       watcher,
       account,
+      context,
       pending,
     );
     pendingStatus = result.status;
@@ -610,7 +636,7 @@ async function processWatcher(
         watcher.currentNotificationMessageId,
         buildResultPendingEmbed(watcher, matchId),
       );
-      await tryFetchAndNotifyResult(client, watcher, account, {
+      await tryFetchAndNotifyResult(client, watcher, account, context, {
         matchId,
         messageId,
         startedAt: watcher.gameStartedAt,
@@ -679,7 +705,7 @@ async function processWatcher(
       pendingResultStartedAt: watcher.gameStartedAt,
       lastCheckedAt: new Date(),
     });
-    await tryFetchAndNotifyResult(client, watcher, account, {
+    await tryFetchAndNotifyResult(client, watcher, account, context, {
       matchId: previousMatchId,
       messageId: previousMessageId,
       startedAt: watcher.gameStartedAt,

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -15,8 +15,16 @@ const RIOT_LONG_WINDOW_MS = 10 * 60 * 1000;
 type ActiveGame = NonNullable<
   Awaited<ReturnType<typeof riotApi.getActiveGameByPuuid>>
 >;
+type ActiveGameResult = Awaited<
+  ReturnType<typeof riotApi.getActiveGameByPuuid>
+>;
+type RiotAccountResult = Awaited<ReturnType<typeof apiClient.getRiotAccount>>;
 type RiotMatch = NonNullable<Awaited<ReturnType<typeof riotApi.getMatchById>>>;
 type WatcherState = Parameters<typeof apiClient.updateMatchWatcherState>[2];
+type MatchWatcherProcessingContext = {
+  riotAccountsByTargetDiscordId: Map<string, Promise<RiotAccountResult>>;
+  activeGamesByRiotAccount: Map<string, Promise<ActiveGameResult>>;
+};
 type WatcherMessage = {
   id?: string;
   edit?: (options: { embeds: EmbedBuilder[] }) => Promise<unknown>;
@@ -40,6 +48,42 @@ function numberEnv(name: string, fallback: number) {
 
 function matchIdForGame(account: RiotAccount, gameId: string | number) {
   return `${account.platform.toUpperCase()}_${gameId}`;
+}
+
+function activeGameCacheKey(account: RiotAccount) {
+  return `${account.platform}:${account.puuid}`;
+}
+
+function createMatchWatcherProcessingContext(): MatchWatcherProcessingContext {
+  return {
+    riotAccountsByTargetDiscordId: new Map(),
+    activeGamesByRiotAccount: new Map(),
+  };
+}
+
+function getRiotAccountForWatcher(
+  context: MatchWatcherProcessingContext,
+  targetDiscordId: string,
+) {
+  const cached = context.riotAccountsByTargetDiscordId.get(targetDiscordId);
+  if (cached) return cached;
+
+  const result = apiClient.getRiotAccount(targetDiscordId);
+  context.riotAccountsByTargetDiscordId.set(targetDiscordId, result);
+  return result;
+}
+
+function getActiveGameForAccount(
+  context: MatchWatcherProcessingContext,
+  account: RiotAccount,
+) {
+  const cacheKey = activeGameCacheKey(account);
+  const cached = context.activeGamesByRiotAccount.get(cacheKey);
+  if (cached) return cached;
+
+  const result = riotApi.getActiveGameByPuuid(account.platform, account.puuid);
+  context.activeGamesByRiotAccount.set(cacheKey, result);
+  return result;
 }
 
 function elapsedMinutes(activeGame: ActiveGame, now = Date.now()) {
@@ -522,8 +566,15 @@ async function tryFetchAndNotifyResult(
   return { status: "cleared" as const, messageId };
 }
 
-async function processWatcher(client: Client, watcher: MatchWatcher) {
-  const accountResult = await apiClient.getRiotAccount(watcher.targetDiscordId);
+async function processWatcher(
+  client: Client,
+  watcher: MatchWatcher,
+  context: MatchWatcherProcessingContext,
+) {
+  const accountResult = await getRiotAccountForWatcher(
+    context,
+    watcher.targetDiscordId,
+  );
   if (!accountResult.success) {
     botLogger.warn("match_tracking.riot_account_not_found", {
       guildId: watcher.guildId,
@@ -549,10 +600,7 @@ async function processWatcher(client: Client, watcher: MatchWatcher) {
     }
   }
 
-  const activeGame = await riotApi.getActiveGameByPuuid(
-    account.platform,
-    account.puuid,
-  );
+  const activeGame = await getActiveGameForAccount(context, account);
   if (!activeGame) {
     if (watcher.lastState === "IN_GAME" && watcher.currentGameId) {
       const matchId = matchIdForGame(account, watcher.currentGameId);
@@ -695,9 +743,10 @@ async function processMatchWatchers(client: Client) {
 
   warnIfRiotRequestBudgetRisk(result.watchers.length);
 
+  const context = createMatchWatcherProcessingContext();
   for (const watcher of result.watchers) {
     try {
-      await processWatcher(client, watcher);
+      await processWatcher(client, watcher, context);
     } catch (error) {
       botLogger.error("match_tracking.watcher_failed", {
         guildId: watcher.guildId,


### PR DESCRIPTION
## 概要

- `processMatchWatchers` 1 回ごとの処理 context を追加し、同一 `targetDiscordId` の Riot account 取得を共有します。
- 同一 Riot account の active game 取得も 1 tick 内で共有します。
- 通知と状態更新は guild watcher ごとに維持します。

Closes #31

## 事前レビュー

- cache は要件どおり 1 回の `processMatchWatchers` 実行内だけで、tick 跨ぎ TTL は入れていません。
- 片方の guild への通知失敗が他 guild の状態更新を止めないことをテストで確認しています。

## 検証

- `deno test --allow-env --allow-read --allow-sys --allow-ffi --env-file=.env.example bot/src/features/match_tracking.test.ts`
- worker 側で `deno task fmt:check`, `deno task lint`, `deno task check`, `deno task test:all` 成功確認済み。