### PR TITLE
[codex] 試合通知に外部戦績リンクを追加

### DIFF
--- a/bot/src/features/external_profile_links.test.ts
+++ b/bot/src/features/external_profile_links.test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import {
+  buildOpGgSummonerUrl,
+  formatProfileLinks,
+} from "./external_profile_links.ts";
+
+describe("external_profile_links.ts", () => {
+  test("JP1のRiot IDからOP.GGのサモナーページURLを生成する", () => {
+    assertEquals(
+      buildOpGgSummonerUrl({
+        gameName: "Hide on bush",
+        tagLine: "JP1",
+        platform: "jp1",
+      }),
+      "https://www.op.gg/summoners/jp/Hide%20on%20bush-JP1",
+    );
+  });
+
+  test("URLに使えない文字を含むRiot IDでもOP.GGのパスとしてエンコードする", () => {
+    assertEquals(
+      buildOpGgSummonerUrl({
+        gameName: "てえも/ADC",
+        tagLine: "JP#1",
+        platform: "jp1",
+      }),
+      "https://www.op.gg/summoners/jp/%E3%81%A6%E3%81%88%E3%82%82%2FADC-JP%231",
+    );
+  });
+
+  test("OP.GGで扱う地域へ変換できないplatformの場合、リンクを生成しない", () => {
+    assertEquals(
+      buildOpGgSummonerUrl({
+        gameName: "Teemo",
+        tagLine: "PBE",
+        platform: "pbe1",
+      }),
+      null,
+    );
+  });
+
+  test("Riot IDが空の場合、戦績リンク表示を生成しない", () => {
+    assertEquals(
+      formatProfileLinks({
+        gameName: " ",
+        tagLine: "JP1",
+        platform: "jp1",
+      }),
+      null,
+    );
+  });
+});

--- a/bot/src/features/external_profile_links.ts
+++ b/bot/src/features/external_profile_links.ts
@@ -1,0 +1,44 @@
+type ProfileAccount = {
+  gameName: string;
+  tagLine: string;
+  platform: string;
+};
+
+const OP_GG_REGION_BY_PLATFORM: Record<string, string> = {
+  BR1: "br",
+  EUN1: "eune",
+  EUW1: "euw",
+  JP1: "jp",
+  KR: "kr",
+  LA1: "lan",
+  LA2: "las",
+  NA1: "na",
+  OC1: "oce",
+  PH2: "ph",
+  RU: "ru",
+  SG2: "sg",
+  TH2: "th",
+  TR1: "tr",
+  TW2: "tw",
+  VN2: "vn",
+};
+
+export function buildOpGgSummonerUrl(account: ProfileAccount) {
+  const gameName = account.gameName.trim();
+  const tagLine = account.tagLine.trim();
+  const platform = account.platform.trim().toUpperCase();
+  const region = OP_GG_REGION_BY_PLATFORM[platform];
+
+  if (!gameName || !tagLine || !region) return null;
+
+  return `https://www.op.gg/summoners/${region}/${
+    encodeURIComponent(`${gameName}-${tagLine}`)
+  }`;
+}
+
+export function formatProfileLinks(account: ProfileAccount) {
+  const opGgUrl = buildOpGgSummonerUrl(account);
+  if (!opGgUrl) return null;
+
+  return `[OP.GG](${opGgUrl})`;
+}

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -1862,6 +1862,95 @@ describe("match_tracking.ts", () => {
     );
   });
 
+  test("試合結果Embedに外部戦績ページへのリンクを表示する", async () => {
+    const { client, editSpy } = clientWithSend();
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [watcher({
+            lastState: "IN_GAME",
+            currentGameId: "12345",
+            currentNotificationMessageId: "message-existing",
+          })],
+        }),
+    );
+    using _getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using _activeGameStub = stub(
+      riotApi,
+      "getActiveGameByPuuid",
+      () => Promise.resolve(null),
+    );
+    using _getMatchStub = stub(
+      riotApi,
+      "getMatchById",
+      () => Promise.resolve(match()),
+    );
+    using _updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertEquals(
+      editedEmbedFieldValue(editSpy, 1, "戦績リンク"),
+      "[OP.GG](https://www.op.gg/summoners/jp/Teemo-JP1)",
+    );
+  });
+
+  test("試合中Embedに外部戦績ページへのリンクを表示する", async () => {
+    const { client, sendSpy } = clientWithSend();
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [watcher()],
+        }),
+    );
+    using _getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using _activeGameStub = stub(
+      riotApi,
+      "getActiveGameByPuuid",
+      () => Promise.resolve(activeGame()),
+    );
+    using _updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    const sentMessage = sendSpy.calls[0].args[0] as {
+      embeds: {
+        data: {
+          fields?: { name: string; value: string }[];
+        };
+      }[];
+    };
+    const profileLinks = sentMessage.embeds[0].data.fields?.find((field) =>
+      field.name === "戦績リンク"
+    )?.value;
+    assertEquals(
+      profileLinks,
+      "[OP.GG](https://www.op.gg/summoners/jp/Teemo-JP1)",
+    );
+  });
+
   test("試合結果Embedの追加戦績は試合時間やチームキルが不足してもfallback表示にする", async () => {
     const resultMatch = match();
     resultMatch.info.gameDuration = 0;

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -5,6 +5,7 @@ import { riotStaticData } from "@adteemo/api/riot-static-data";
 import { apiClient } from "../api_client.ts";
 import { botLogger } from "../logger.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
+import { formatProfileLinks } from "./external_profile_links.ts";
 
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 const DEFAULT_IN_GAME_NOTIFY_INTERVAL_MS = 300_000;
@@ -52,6 +53,7 @@ type PendingResult = {
 type ActiveGameTargetDetail = {
   targetDiscordId: string;
   champion: string;
+  profileLinks: string | null;
 };
 
 function numberEnv(name: string, fallback: number) {
@@ -585,6 +587,7 @@ async function activeGameTargetDetails(
       details.push({
         targetDiscordId,
         champion: await championNameById(undefined),
+        profileLinks: null,
       });
       continue;
     }
@@ -595,6 +598,7 @@ async function activeGameTargetDetails(
     details.push({
       targetDiscordId,
       champion: await championNameById(participant?.championId),
+      profileLinks: formatProfileLinks(accountResult.account),
     });
   }
   return details;
@@ -624,6 +628,27 @@ function formatKillParticipation(
   return `${
     (((participantKills + participantAssists) / teamKills) * 100).toFixed(1)
   }%`;
+}
+
+function profileLinksField(
+  targets: Pick<ActiveGameTargetDetail, "targetDiscordId" | "profileLinks">[],
+) {
+  const links = targets
+    .filter((target) => target.profileLinks)
+    .map((target) =>
+      targets.length === 1
+        ? target.profileLinks!
+        : `<@${target.targetDiscordId}>: ${target.profileLinks}`
+    );
+  if (links.length === 0) return null;
+
+  return {
+    name: messageHandler.formatMessage(
+      messageKeys.matchTracking.embed.field.profileLinks,
+    ),
+    value: links.join("\n"),
+    inline: false,
+  };
 }
 
 function currentStateFromWatcher(watcher: MatchWatcher): WatcherState {
@@ -683,9 +708,11 @@ async function buildActiveGameEmbed(
     : messageHandler.formatMessage(
       messageKeys.matchTracking.embed.active.progressTitle,
     );
-  const targets = targetDetails?.length
-    ? targetDetails
-    : [{ targetDiscordId: watcher.targetDiscordId, champion }];
+  const targets = targetDetails?.length ? targetDetails : [{
+    targetDiscordId: watcher.targetDiscordId,
+    champion,
+    profileLinks: formatProfileLinks(account),
+  }];
   const description = messageHandler.formatMessage(
     messageKeys.matchTracking.embed.active.description,
     {
@@ -727,7 +754,8 @@ async function buildActiveGameEmbed(
       },
     );
 
-  return new EmbedBuilder()
+  const profileLinkField = profileLinksField(targets);
+  const embed = new EmbedBuilder()
     .setTitle(title)
     .setDescription(description)
     .setColor(kind === "started" ? 0x2ecc71 : 0x3498db)
@@ -764,7 +792,11 @@ async function buildActiveGameEmbed(
         ),
         inline: true,
       },
-    )
+    );
+  if (profileLinkField) {
+    embed.addFields(profileLinkField);
+  }
+  return embed
     .setFooter({
       text: footerText,
     })
@@ -868,10 +900,11 @@ async function buildMatchResultEmbed(
   const queue = await queueName(match.info.queueId);
   const map = await mapName(match.info.mapId);
   const mode = await gameModeName(match.info.gameMode);
+  const profileLinks = formatProfileLinks(account);
   const result = participant.win
     ? messageHandler.formatMessage(messageKeys.matchTracking.embed.result.win)
     : messageHandler.formatMessage(messageKeys.matchTracking.embed.result.loss);
-  return new EmbedBuilder()
+  const embed = new EmbedBuilder()
     .setTitle(
       messageHandler.formatMessage(
         messageKeys.matchTracking.embed.result.title,
@@ -950,7 +983,17 @@ async function buildMatchResultEmbed(
         value: mode,
         inline: true,
       },
-    )
+    );
+  if (profileLinks) {
+    embed.addFields({
+      name: messageHandler.formatMessage(
+        messageKeys.matchTracking.embed.field.profileLinks,
+      ),
+      value: profileLinks,
+      inline: false,
+    });
+  }
+  return embed
     .setFooter({
       text: messageHandler.formatMessage(
         messageKeys.matchTracking.embed.footer.matchWithRiotId,

--- a/messages/en_US/system.json
+++ b/messages/en_US/system.json
@@ -150,7 +150,8 @@
         "cs": "CS",
         "csPerMinute": "CS/min",
         "killParticipation": "Kill Participation",
-        "gold": "Gold"
+        "gold": "Gold",
+        "profileLinks": "Profile Links"
       },
       "fallback": {
         "unknownChampion": "Unknown champion",

--- a/messages/ja_JP/system.json
+++ b/messages/ja_JP/system.json
@@ -150,7 +150,8 @@
         "cs": "CS",
         "csPerMinute": "CS/min",
         "killParticipation": "キル関与率",
-        "gold": "Gold"
+        "gold": "Gold",
+        "profileLinks": "戦績リンク"
       },
       "fallback": {
         "unknownChampion": "チャンピオン不明",

--- a/messages/ja_JP/teemo.json
+++ b/messages/ja_JP/teemo.json
@@ -211,7 +211,8 @@
         "cs": "CS",
         "csPerMinute": "CS/min",
         "killParticipation": "キル関与率",
-        "gold": "Gold"
+        "gold": "Gold",
+        "profileLinks": "戦績リンク"
       },
       "fallback": {
         "unknownChampion": "知らないチャンピオン",


### PR DESCRIPTION
## 概要

Refs #28

試合中通知と試合結果通知から外部戦績ページを開けるように、OP.GGのサモナーページリンクを追加しました。

## 変更内容

- Riot ID と platform から OP.GG のサモナーページURLを生成するhelperを追加
- 試合中Embedと試合結果Embedに「戦績リンク」フィールドを追加
- OP.GGで扱えないplatformや空のRiot IDではリンクを表示しないfallbackを追加
- ja_JP / teemo / en_US のメッセージキーを同期
- helper単体テストとEmbed表示テストを追加

## 検証

- `deno task quality`

## 補足

LP増減表示はLeague-v4の前後スナップショット保存設計が必要なため、このPRには含めていません。