### PR TITLE
[codex] チャンピオンthumbnailを表示する

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -109,7 +109,7 @@ ADTeemoは複数Discordギルドへの導入を想定する。プレイヤー本
 
 ### 5.1. 試合結果表示の拡張 (#28)
 
-PR #39で `CS/min` と `キル関与率` は実装済みである。LP deltaと現在ランク表示は #54、OP.GG試合詳細リンクと詳細データ取得は #53 で実装済みであり、詳細は [docs/ranked-lp.md](./docs/ranked-lp.md) と [docs/opgg.md](./docs/opgg.md) を参照する。OP.GG未公開Server Action依存の運用リスクは #56 で整理済みである。Embed表示項目とロール別優先順位は #55 と [docs/match-display.md](./docs/match-display.md) で設計し、ロール別metric groupとダメージ表示は #65、チャンピオンthumbnailは #66 で追跡する。OP.GGプロフィールリンクは表示対象外とし、詳細リンクが解決できる場合だけ表示する。
+PR #39で `CS/min` と `キル関与率` は実装済みである。LP deltaと現在ランク表示は #54、OP.GG試合詳細リンクと詳細データ取得は #53 で実装済みであり、詳細は [docs/ranked-lp.md](./docs/ranked-lp.md) と [docs/opgg.md](./docs/opgg.md) を参照する。OP.GG未公開Server Action依存の運用リスクは #56 で整理済みである。Embed表示項目とロール別優先順位は #55 と [docs/match-display.md](./docs/match-display.md) で設計し、ロール別metric groupとダメージ表示は #65、試合結果・単独試合中Embedのチャンピオンthumbnailは #66 で実装済みである。複数監視対象の試合中EmbedとアイコンURL解決失敗時はthumbnailを省略する。OP.GGプロフィールリンクは表示対象外とし、詳細リンクが解決できる場合だけ表示する。
 
 ### 5.2. デフォルト監視とopt-out (#34)
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -6,7 +6,7 @@ ADTeemoの詳細な未実装・改善作業はGitHub Issuesを正として追跡
 
 ## Open Issues
 
-- [ ] [#28 試合結果・試合中表示の拡張](https://github.com/akgm3i/ADTeemo/issues/28)
+- [x] [#28 試合結果・試合中表示の拡張](https://github.com/akgm3i/ADTeemo/issues/28)
   - [x] `CS/min` を試合結果Embedに表示する。
   - [x] `キル関与率` を試合結果Embedに表示する。
   - [x] [#53 OP.GG試合詳細リンク解決と詳細データ取得](https://github.com/akgm3i/ADTeemo/issues/53)
@@ -14,7 +14,7 @@ ADTeemoの詳細な未実装・改善作業はGitHub Issuesを正として追跡
   - [x] [#55 試合結果・試合中Embedの追加表示項目とロール別優先順位の設計](https://github.com/akgm3i/ADTeemo/issues/55)
   - [x] [#56 OP.GG未公開Server Action依存の運用リスク整理](https://github.com/akgm3i/ADTeemo/issues/56)
   - [x] [#65 ロール別metric groupとダメージ表示](https://github.com/akgm3i/ADTeemo/issues/65)
-  - [ ] [#66 試合結果・単独試合中Embedのチャンピオンthumbnail](https://github.com/akgm3i/ADTeemo/issues/66)
+  - [x] [#66 試合結果・単独試合中Embedのチャンピオンthumbnail](https://github.com/akgm3i/ADTeemo/issues/66)
 - [ ] [#34 デフォルト監視とopt-out](https://github.com/akgm3i/ADTeemo/issues/34)
   - [ ] Riot ID連携済みユーザーを既定監視候補にする。
   - [ ] opt-out / opt-inを永続化する。

--- a/api/src/riot_static_data.test.ts
+++ b/api/src/riot_static_data.test.ts
@@ -36,6 +36,81 @@ describe("riot_static_data.ts", () => {
     assertSpyCalls(fetchStub, 0);
   });
 
+  test("チャンピオン画像が未キャッシュの場合、取得したData Dragon versionと画像名からURLを返す", async () => {
+    using _getCacheStub = stub(
+      dbActions,
+      "getRiotStaticDataCache",
+      () => Promise.resolve(undefined),
+    );
+    using upsertCacheStub = stub(
+      dbActions,
+      "upsertRiotStaticDataCache",
+      () => Promise.resolve(),
+    );
+    using fetchStub = stub(
+      globalThis,
+      "fetch",
+      (input) => {
+        const url = String(input);
+        if (url.endsWith("/api/versions.json")) {
+          return Promise.resolve(
+            new Response(JSON.stringify(["16.12.1"]), { status: 200 }),
+          );
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: {
+                Teemo: {
+                  key: "17",
+                  name: "ティーモ",
+                  image: { full: "Teemo.png" },
+                },
+              },
+            }),
+            { status: 200 },
+          ),
+        );
+      },
+    );
+
+    const url = await riotStaticData.getChampionIconUrlById(17, "ja_JP");
+
+    assertEquals(
+      url,
+      "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
+    );
+    assertSpyCalls(fetchStub, 2);
+    assertSpyCalls(upsertCacheStub, 1);
+  });
+
+  test("チャンピオン画像のstatic data取得に失敗しキャッシュもない場合、エラーを返す", async () => {
+    using _getCacheStub = stub(
+      dbActions,
+      "getRiotStaticDataCache",
+      () => Promise.resolve(undefined),
+    );
+    using _upsertCacheStub = stub(
+      dbActions,
+      "upsertRiotStaticDataCache",
+      () => Promise.resolve(),
+    );
+    using _fetchStub = stub(
+      globalThis,
+      "fetch",
+      () => Promise.resolve(new Response(null, { status: 503 })),
+    );
+
+    let error: unknown;
+    try {
+      await riotStaticData.getChampionIconUrlById(17, "ja_JP");
+    } catch (caught) {
+      error = caught;
+    }
+
+    assertEquals(error instanceof Error, true);
+  });
+
   test("キュー名が未キャッシュの場合、公式static JSONを取得してDBへ保存する", async () => {
     using getCacheStub = stub(
       dbActions,

--- a/api/src/riot_static_data.test.ts
+++ b/api/src/riot_static_data.test.ts
@@ -11,9 +11,11 @@ describe("riot_static_data.ts", () => {
       "getRiotStaticDataCache",
       () =>
         Promise.resolve({
-          key: "champions:ja_JP",
+          key: "champions-data:ja_JP",
           version: "15.24.1",
-          value: JSON.stringify({ "17": "ティーモ" }),
+          value: JSON.stringify({
+            "17": { name: "ティーモ", imageFull: "Teemo.png" },
+          }),
           updatedAt: new Date(),
         }),
     );
@@ -36,16 +38,22 @@ describe("riot_static_data.ts", () => {
     assertSpyCalls(fetchStub, 0);
   });
 
-  test("チャンピオン画像が未キャッシュの場合、取得したData Dragon versionと画像名からURLを返す", async () => {
-    using _getCacheStub = stub(
+  test("チャンピオン名と画像URLを続けて解決するとき、単一の取得結果とキャッシュを共有する", async () => {
+    let cached: Awaited<
+      ReturnType<typeof dbActions.getRiotStaticDataCache>
+    >;
+    using getCacheStub = stub(
       dbActions,
       "getRiotStaticDataCache",
-      () => Promise.resolve(undefined),
+      () => Promise.resolve(cached),
     );
     using upsertCacheStub = stub(
       dbActions,
       "upsertRiotStaticDataCache",
-      () => Promise.resolve(),
+      (value) => {
+        cached = { ...value, updatedAt: new Date() };
+        return Promise.resolve();
+      },
     );
     using fetchStub = stub(
       globalThis,
@@ -74,14 +82,18 @@ describe("riot_static_data.ts", () => {
       },
     );
 
+    const name = await riotStaticData.getChampionNameById(17, "ja_JP");
     const url = await riotStaticData.getChampionIconUrlById(17, "ja_JP");
 
+    assertEquals(name, "ティーモ");
     assertEquals(
       url,
       "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
     );
     assertSpyCalls(fetchStub, 2);
+    assertSpyCalls(getCacheStub, 2);
     assertSpyCalls(upsertCacheStub, 1);
+    assertEquals(cached?.key, "champions-data:ja_JP");
   });
 
   test("チャンピオン画像のstatic data取得に失敗しキャッシュもない場合、エラーを返す", async () => {

--- a/api/src/riot_static_data.ts
+++ b/api/src/riot_static_data.ts
@@ -5,6 +5,7 @@ import { apiLogger } from "./logger.ts";
 const DEFAULT_STATIC_DATA_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const DATA_DRAGON_VERSIONS_URL =
   "https://ddragon.leagueoflegends.com/api/versions.json";
+const DATA_DRAGON_CDN_BASE = "https://ddragon.leagueoflegends.com/cdn";
 const RIOT_STATIC_DOCS_BASE = "https://static.developer.riotgames.com/docs/lol";
 
 const versionsSchema = z.array(z.string()).min(1);
@@ -14,6 +15,9 @@ const championDataSchema = z.object({
     z.object({
       key: z.string(),
       name: z.string(),
+      image: z.object({
+        full: z.string(),
+      }).optional(),
     }).passthrough(),
   ),
 }).passthrough();
@@ -115,14 +119,17 @@ const stringRecordSchema: z.ZodType<Record<string, string>> = z.record(
   z.string(),
 );
 
-async function cachedJson<T>(
+async function cachedVersionedJson<T>(
   key: string,
   schema: z.ZodType<T>,
   fetcher: () => Promise<{ version: string; value: T }>,
 ) {
   const cached = await dbActions.getRiotStaticDataCache(key);
   if (cached && isFresh(cached.updatedAt)) {
-    return parseCachedValue(cached.value, schema);
+    return {
+      version: cached.version,
+      value: parseCachedValue(cached.value, schema),
+    };
   }
 
   try {
@@ -132,7 +139,7 @@ async function cachedJson<T>(
       version: fetched.version,
       value: JSON.stringify(fetched.value),
     });
-    return fetched.value;
+    return fetched;
   } catch (error) {
     if (cached) {
       apiLogger.warn("riot_static_data.cache_refresh_failed", {
@@ -140,10 +147,21 @@ async function cachedJson<T>(
         version: cached.version,
         error: error instanceof Error ? error.message : String(error),
       });
-      return parseCachedValue(cached.value, schema);
+      return {
+        version: cached.version,
+        value: parseCachedValue(cached.value, schema),
+      };
     }
     throw error;
   }
+}
+
+async function cachedJson<T>(
+  key: string,
+  schema: z.ZodType<T>,
+  fetcher: () => Promise<{ version: string; value: T }>,
+) {
+  return (await cachedVersionedJson(key, schema, fetcher)).value;
 }
 
 async function getLatestDataDragonVersion() {
@@ -170,6 +188,29 @@ async function getChampionNames(locale?: string) {
         names[champion.key] = champion.name;
       }
       return { version, value: names };
+    },
+  );
+}
+
+async function getChampionIconFiles(locale?: string) {
+  const normalizedLocale = normalizeLocale(locale);
+  return await cachedVersionedJson(
+    `champion-icons:${normalizedLocale}`,
+    stringRecordSchema,
+    async () => {
+      const version = await getLatestDataDragonVersion();
+      const data = championDataSchema.parse(
+        await fetchJson(
+          `${DATA_DRAGON_CDN_BASE}/${version}/data/${normalizedLocale}/champion.json`,
+        ),
+      );
+      const files: Record<string, string> = {};
+      for (const champion of Object.values(data.data)) {
+        if (champion.image?.full) {
+          files[champion.key] = champion.image.full;
+        }
+      }
+      return { version, value: files };
     },
   );
 }
@@ -224,6 +265,14 @@ async function getChampionNameById(championId: number, locale?: string) {
   return names[String(championId)] ?? null;
 }
 
+async function getChampionIconUrlById(championId: number, locale?: string) {
+  const { version, value: files } = await getChampionIconFiles(locale);
+  const file = files[String(championId)];
+  return file
+    ? `${DATA_DRAGON_CDN_BASE}/${version}/img/champion/${file}`
+    : null;
+}
+
 async function getQueueNameById(queueId: number, locale?: string) {
   const localizedName = localizedQueueName(queueId, locale);
   if (localizedName) return localizedName;
@@ -250,6 +299,7 @@ async function getGameModeName(gameMode: string, locale?: string) {
 
 export const riotStaticData = {
   getChampionNameById,
+  getChampionIconUrlById,
   getQueueNameById,
   getMapNameById,
   getGameModeName,

--- a/api/src/riot_static_data.ts
+++ b/api/src/riot_static_data.ts
@@ -118,6 +118,13 @@ const stringRecordSchema: z.ZodType<Record<string, string>> = z.record(
   z.string(),
   z.string(),
 );
+const championCacheSchema = z.record(
+  z.string(),
+  z.object({
+    name: z.string(),
+    imageFull: z.string().nullable(),
+  }),
+);
 
 async function cachedVersionedJson<T>(
   key: string,
@@ -171,32 +178,11 @@ async function getLatestDataDragonVersion() {
   return versions[0];
 }
 
-async function getChampionNames(locale?: string) {
-  const normalizedLocale = normalizeLocale(locale);
-  return await cachedJson(
-    `champions:${normalizedLocale}`,
-    stringRecordSchema,
-    async () => {
-      const version = await getLatestDataDragonVersion();
-      const data = championDataSchema.parse(
-        await fetchJson(
-          `https://ddragon.leagueoflegends.com/cdn/${version}/data/${normalizedLocale}/champion.json`,
-        ),
-      );
-      const names: Record<string, string> = {};
-      for (const champion of Object.values(data.data)) {
-        names[champion.key] = champion.name;
-      }
-      return { version, value: names };
-    },
-  );
-}
-
-async function getChampionIconFiles(locale?: string) {
+async function getChampions(locale?: string) {
   const normalizedLocale = normalizeLocale(locale);
   return await cachedVersionedJson(
-    `champion-icons:${normalizedLocale}`,
-    stringRecordSchema,
+    `champions-data:${normalizedLocale}`,
+    championCacheSchema,
     async () => {
       const version = await getLatestDataDragonVersion();
       const data = championDataSchema.parse(
@@ -204,13 +190,17 @@ async function getChampionIconFiles(locale?: string) {
           `${DATA_DRAGON_CDN_BASE}/${version}/data/${normalizedLocale}/champion.json`,
         ),
       );
-      const files: Record<string, string> = {};
+      const champions: Record<
+        string,
+        { name: string; imageFull: string | null }
+      > = {};
       for (const champion of Object.values(data.data)) {
-        if (champion.image?.full) {
-          files[champion.key] = champion.image.full;
-        }
+        champions[champion.key] = {
+          name: champion.name,
+          imageFull: champion.image?.full ?? null,
+        };
       }
-      return { version, value: files };
+      return { version, value: champions };
     },
   );
 }
@@ -261,13 +251,13 @@ async function getGameModes() {
 }
 
 async function getChampionNameById(championId: number, locale?: string) {
-  const names = await getChampionNames(locale);
-  return names[String(championId)] ?? null;
+  const { value: champions } = await getChampions(locale);
+  return champions[String(championId)]?.name ?? null;
 }
 
 async function getChampionIconUrlById(championId: number, locale?: string) {
-  const { version, value: files } = await getChampionIconFiles(locale);
-  const file = files[String(championId)];
+  const { version, value: champions } = await getChampions(locale);
+  const file = champions[String(championId)]?.imageFull;
   return file
     ? `${DATA_DRAGON_CDN_BASE}/${version}/img/champion/${file}`
     : null;

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -233,44 +233,49 @@ async function resultEmbedFields(resultMatch: RiotMatch) {
 }
 
 describe("match_tracking.ts", () => {
-  const staticDataStubs: { restore(): void }[] = [];
+  const staticDataStubs: Partial<
+    Record<keyof typeof riotStaticData, { restore(): void }>
+  > = {};
+
+  function restoreStaticDataStub(method: keyof typeof riotStaticData) {
+    staticDataStubs[method]?.restore();
+    delete staticDataStubs[method];
+  }
 
   beforeEach(() => {
-    staticDataStubs.push(
-      stub(
-        riotStaticData,
-        "getChampionNameById",
-        () => Promise.resolve("ティーモ"),
-      ),
-      stub(
-        riotStaticData,
-        "getQueueNameById",
-        () => Promise.resolve("ランクソロ/デュオ"),
-      ),
-      stub(
-        riotStaticData,
-        "getMapNameById",
-        () => Promise.resolve("サモナーズリフト"),
-      ),
-      stub(
-        riotStaticData,
-        "getGameModeName",
-        () => Promise.resolve("クラシック"),
-      ),
-      stub(
-        riotStaticData,
-        "getChampionIconUrlById",
-        () =>
-          Promise.resolve(
-            "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
-          ),
-      ),
+    staticDataStubs.getChampionNameById = stub(
+      riotStaticData,
+      "getChampionNameById",
+      () => Promise.resolve("ティーモ"),
+    );
+    staticDataStubs.getQueueNameById = stub(
+      riotStaticData,
+      "getQueueNameById",
+      () => Promise.resolve("ランクソロ/デュオ"),
+    );
+    staticDataStubs.getMapNameById = stub(
+      riotStaticData,
+      "getMapNameById",
+      () => Promise.resolve("サモナーズリフト"),
+    );
+    staticDataStubs.getGameModeName = stub(
+      riotStaticData,
+      "getGameModeName",
+      () => Promise.resolve("クラシック"),
+    );
+    staticDataStubs.getChampionIconUrlById = stub(
+      riotStaticData,
+      "getChampionIconUrlById",
+      () =>
+        Promise.resolve(
+          "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
+        ),
     );
   });
 
   afterEach(() => {
-    for (const staticDataStub of staticDataStubs.splice(0)) {
-      staticDataStub.restore();
+    for (const method of Object.keys(staticDataStubs)) {
+      restoreStaticDataStub(method as keyof typeof riotStaticData);
     }
   });
 
@@ -461,8 +466,7 @@ describe("match_tracking.ts", () => {
   });
 
   test("共有試合中通知に複数監視対象を表示するとき、対象ごとのチャンピオンを表示し単一Riot IDをfooterに出さない", async () => {
-    const [championNameStub] = staticDataStubs.splice(0, 1);
-    championNameStub.restore();
+    restoreStaticDataStub("getChampionNameById");
     using _championNameByIdStub = stub(
       riotStaticData,
       "getChampionNameById",
@@ -1945,8 +1949,7 @@ describe("match_tracking.ts", () => {
   });
 
   test("チャンピオン画像URLの解決に失敗したとき、thumbnailなしでチャンピオン名を含む試合結果を送信する", async () => {
-    const iconStub = staticDataStubs.splice(4, 1)[0];
-    iconStub.restore();
+    restoreStaticDataStub("getChampionIconUrlById");
     using _iconFailureStub = stub(
       riotStaticData,
       "getChampionIconUrlById",
@@ -2614,8 +2617,7 @@ describe("match_tracking.ts", () => {
   });
 
   test("静的データのチャンピオン名取得に失敗したとき、Match-v5の既存名で結果通知を完了する", async () => {
-    const [championNameStub] = staticDataStubs.splice(0, 1);
-    championNameStub.restore();
+    restoreStaticDataStub("getChampionNameById");
     const { client, editSpy } = clientWithSend();
     using _championNameFailureStub = stub(
       riotStaticData,
@@ -2664,8 +2666,7 @@ describe("match_tracking.ts", () => {
   });
 
   test("静的データのモード名取得に失敗したとき、Match-v5の既存モードで結果通知を完了する", async () => {
-    const gameModeStub = staticDataStubs.splice(3, 1)[0];
-    gameModeStub.restore();
+    restoreStaticDataStub("getGameModeName");
     const { client, editSpy } = clientWithSend();
     using _gameModeFailureStub = stub(
       riotStaticData,

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -186,6 +186,7 @@ function editedEmbedJson(
             description?: string;
             fields?: { name: string; value: string }[];
             footer?: { text: string };
+            thumbnail?: { url: string };
           };
         }[];
       },
@@ -256,6 +257,14 @@ describe("match_tracking.ts", () => {
         "getGameModeName",
         () => Promise.resolve("クラシック"),
       ),
+      stub(
+        riotStaticData,
+        "getChampionIconUrlById",
+        () =>
+          Promise.resolve(
+            "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
+          ),
+      ),
     );
   });
 
@@ -303,6 +312,14 @@ describe("match_tracking.ts", () => {
       updateStub.calls[0].args[2].currentNotificationMessageId,
       "message-new",
     );
+    const sentOptions = sendSpy.calls[0].args[0] as {
+      embeds: { toJSON(): { thumbnail?: { url: string } } }[];
+    };
+    const sentEmbed = sentOptions.embeds[0].toJSON();
+    assertEquals(sentEmbed.thumbnail, {
+      url:
+        "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
+    });
   });
 
   test("ランク対象queueの試合開始を検知したとき、試合前ランクスナップショットを一時保存する", async () => {
@@ -508,6 +525,7 @@ describe("match_tracking.ts", () => {
       false,
     );
     assertEquals(editedEmbed.footer?.text, "JP1 Game 12345");
+    assertEquals(editedEmbed.thumbnail, undefined);
   });
 
   test("後続tickで同じ投稿IDの試合に監視対象が増えたとき、既存投稿を編集して対象者一覧を更新する", async () => {
@@ -1916,6 +1934,57 @@ describe("match_tracking.ts", () => {
 
     await matchTracker.processMatchWatchers(client);
 
+    assertEquals(
+      editedEmbedFieldValue(editSpy, 0, "チャンピオン"),
+      "ティーモ",
+    );
+    assertEquals(editedEmbedJson(editSpy, 0).thumbnail, {
+      url:
+        "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
+    });
+  });
+
+  test("チャンピオン画像URLの解決に失敗したとき、thumbnailなしでチャンピオン名を含む試合結果を送信する", async () => {
+    const iconStub = staticDataStubs.splice(4, 1)[0];
+    iconStub.restore();
+    using _iconFailureStub = stub(
+      riotStaticData,
+      "getChampionIconUrlById",
+      () => Promise.reject(new Error("Data Dragon failed")),
+    );
+    const { client, editSpy } = clientWithSend();
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [watcher({
+            lastState: "FETCHING_RESULT",
+            currentMatchId: "JP1_12345",
+            currentNotificationMessageId: "message-existing",
+          })],
+        }),
+    );
+    using _getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using _getMatchStub = stub(
+      apiClient,
+      "getMatchById",
+      () => Promise.resolve(match()),
+    );
+    using _updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertEquals(editedEmbedJson(editSpy, 0).thumbnail, undefined);
     assertEquals(
       editedEmbedFieldValue(editSpy, 0, "チャンピオン"),
       "ティーモ",

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -688,6 +688,18 @@ async function championNameById(
   }
 }
 
+async function championIconUrlById(championId: number | undefined) {
+  if (championId === undefined) return null;
+  try {
+    return await riotStaticData.getChampionIconUrlById(
+      championId,
+      messageLocale(),
+    );
+  } catch {
+    return null;
+  }
+}
+
 async function queueName(queueId: number | undefined) {
   if (queueId === undefined) {
     return messageHandler.formatMessage(
@@ -1124,6 +1136,9 @@ async function buildActiveGameEmbed(
   const targets = targetDetails?.length
     ? targetDetails
     : [{ targetDiscordId: watcher.targetDiscordId, champion }];
+  const thumbnailUrl = targets.length === 1
+    ? await championIconUrlById(participant?.championId)
+    : null;
   const description = messageHandler.formatMessage(
     messageKeys.matchTracking.embed.active.description,
     {
@@ -1165,7 +1180,7 @@ async function buildActiveGameEmbed(
       },
     );
 
-  return new EmbedBuilder()
+  const embed = new EmbedBuilder()
     .setTitle(title)
     .setDescription(description)
     .setColor(kind === "started" ? 0x2ecc71 : 0x3498db)
@@ -1207,6 +1222,10 @@ async function buildActiveGameEmbed(
       text: footerText,
     })
     .setTimestamp(new Date());
+  if (thumbnailUrl) {
+    embed.setThumbnail(thumbnailUrl);
+  }
+  return embed;
 }
 
 function buildResultPendingEmbed(watcher: MatchWatcher, matchId: string) {
@@ -1295,6 +1314,7 @@ async function buildMatchResultEmbed(
     participant.championId,
     participant.championName,
   );
+  const thumbnailUrl = await championIconUrlById(participant.championId);
   const teamKills = match.info.participants
     .filter((candidate) => candidate.teamId === participant.teamId)
     .reduce((sum, candidate) => sum + candidate.kills, 0);
@@ -1401,6 +1421,9 @@ async function buildMatchResultEmbed(
       ),
     })
     .setTimestamp(new Date(match.info.gameEndTimestamp ?? Date.now()));
+  if (thumbnailUrl) {
+    embed.setThumbnail(thumbnailUrl);
+  }
   if (rankValue) {
     embed.addFields({
       name: messageHandler.formatMessage(


### PR DESCRIPTION
## 概要

試合結果Embedと単独監視対象の試合中Embedに、対象チャンピオンのData Dragon画像をthumbnailとして表示します。

## 変更内容

- Data Dragonの最新versionとchampion image名から画像URLを解決
- 画像情報を既存のRiot static data cacheの仕組みで保持
- 試合結果Embedと単独監視対象の試合中Embedにthumbnailを設定
- 複数監視対象の統合Embedではthumbnailを省略
- static data取得またはURL解決に失敗しても、チャンピオン名を維持して通知を継続
- 回帰テストを追加し、SPEC.mdとTASKS.mdを同期

## 確認

- `deno task quality`
- 30 passed (272 steps), 3 ignored

Closes #66
Closes #28