### PR TITLE
[codex] refactor(api): Riot静的データ取得をBackend APIへ集約する

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -48,6 +48,20 @@ ADTeemoの詳細な未実装・改善作業はGitHub Issuesを正として追跡
   - [ ] 参加者確定、チーム分け、VC移動までのイベント状態遷移を設計する。
   - [ ] Message Componentsでキャンセル、再マッチング、次ゲームを操作できるようにする。
   - [ ] 募集チャンネル、VC、ロールIDなどのギルド設定を永続化する。
+- [ ] [#69 Botの外部サービス・DB直接依存をBackend APIへ集約する](https://github.com/akgm3i/ADTeemo/issues/69)
+  - [ ] [#72 Riot静的データ取得をBackend APIへ集約する](https://github.com/akgm3i/ADTeemo/issues/72)
+  - [ ] [#73 OP.GG試合詳細の解決・保存をBackend APIへ集約する](https://github.com/akgm3i/ADTeemo/issues/73)
+- [ ] [#71 Backend/Botの依存注入と試合監視モジュールを段階的に整理する](https://github.com/akgm3i/ADTeemo/issues/71)
+  - [ ] [#76 DB factoryとDB actions factoryを導入する](https://github.com/akgm3i/ADTeemo/issues/76)
+  - [ ] [#78 createAppとroute factoryでBackend依存を注入する](https://github.com/akgm3i/ADTeemo/issues/78)
+  - [ ] [#79 DB actionsをドメイン別repositoryへ分割する](https://github.com/akgm3i/ADTeemo/issues/79)
+  - [ ] [#75 API client factoryと共通transport処理を導入する](https://github.com/akgm3i/ADTeemo/issues/75)
+  - [ ] [#74 API clientをBackend resource別clientへ分割する](https://github.com/akgm3i/ADTeemo/issues/74)
+  - [ ] [#77 record-match参加者取得をmatch trackingから分離する](https://github.com/akgm3i/ADTeemo/issues/77)
+  - [ ] [#80 match trackingの純粋な状態・通知判定を抽出する](https://github.com/akgm3i/ADTeemo/issues/80)
+  - [ ] [#81 match trackingのEmbed生成とDiscord通知境界を分離する](https://github.com/akgm3i/ADTeemo/issues/81)
+  - [ ] [#82 MatchTrackingServiceへ監視オーケストレーションを集約する](https://github.com/akgm3i/ADTeemo/issues/82)
+  - [ ] [#83 match tracking workerとrate-budget監視をinstance化する](https://github.com/akgm3i/ADTeemo/issues/83)
 
 ## Issue化前の技術課題
 

--- a/api/deno.json
+++ b/api/deno.json
@@ -3,7 +3,6 @@
   "exports": {
     ".": "./src/app.ts",
     "./hc": "./src/hc.ts",
-    "./riot-static-data": "./src/riot_static_data.ts",
     "./schema": "./src/db/schema.ts",
     "./validators": "./src/validators.ts"
   },

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -6,6 +6,7 @@ import { matchesRoutes } from "./routes/matches.ts";
 import { matchWatchersRoutes } from "./routes/match_watchers.ts";
 import { authRoutes } from "./routes/auth.ts";
 import { riotRoutes } from "./routes/riot.ts";
+import { riotStaticDataRoutes } from "./routes/riot_static_data.ts";
 import { apiLogger } from "./logger.ts";
 
 export const requestLoggingMiddleware = createMiddleware(async (c, next) => {
@@ -55,6 +56,7 @@ const app = new Hono()
   .route("/events", eventsRoutes)
   .route("/matches", matchesRoutes)
   .route("/match-watchers", matchWatchersRoutes)
+  .route("/riot/static-data", riotStaticDataRoutes)
   .route("/riot", riotRoutes)
   .route("/auth", authRoutes);
 

--- a/api/src/riot_static_data.test.ts
+++ b/api/src/riot_static_data.test.ts
@@ -225,4 +225,96 @@ describe("riot_static_data.ts", () => {
     assertEquals(name, "Summoner's Rift");
     assertSpyCalls(fetchStub, 1);
   });
+
+  test("複数の静的データ識別子を解決するとき、種別ごとに単一のキャッシュ読み込みから表示データを返す", async () => {
+    // Arrange
+    using getCacheStub = stub(
+      dbActions,
+      "getRiotStaticDataCache",
+      (key) => {
+        const values: Record<string, string> = {
+          "champions-data:en_US": JSON.stringify({
+            "17": { name: "Teemo", imageFull: "Teemo.png" },
+            "18": { name: "Tristana", imageFull: null },
+          }),
+          queues: JSON.stringify({ "420": "5v5 Ranked Solo games" }),
+          maps: JSON.stringify({ "11": "Summoner's Rift" }),
+          gameModes: JSON.stringify({ CLASSIC: "Classic" }),
+        };
+        return Promise.resolve({
+          key,
+          version: key.startsWith("champions-data:")
+            ? "16.12.1"
+            : "static.developer.riotgames.com",
+          value: values[key],
+          updatedAt: new Date(),
+        });
+      },
+    );
+    using fetchStub = stub(
+      globalThis,
+      "fetch",
+      () => Promise.reject(new Error("fetch should not be called")),
+    );
+
+    // Act
+    const result = await riotStaticData.resolve({
+      locale: "en_US",
+      championIds: [17, 18, 17],
+      queueIds: [420, 420],
+      mapIds: [11],
+      gameModes: ["CLASSIC"],
+    });
+
+    // Assert
+    assertEquals(result, {
+      champions: {
+        "17": {
+          name: "Teemo",
+          iconUrl:
+            "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
+        },
+        "18": { name: "Tristana", iconUrl: null },
+      },
+      queues: { "420": "5v5 Ranked Solo games" },
+      maps: { "11": "Summoner's Rift" },
+      gameModes: { CLASSIC: "Classic" },
+    });
+    assertSpyCalls(getCacheStub, 4);
+    assertSpyCalls(fetchStub, 0);
+  });
+
+  test("未知の識別子を含む静的データを解決するとき、対応する値をnullで返す", async () => {
+    // Arrange
+    using _getCacheStub = stub(
+      dbActions,
+      "getRiotStaticDataCache",
+      (key) =>
+        Promise.resolve({
+          key,
+          version: key.startsWith("champions-data:")
+            ? "16.12.1"
+            : "static.developer.riotgames.com",
+          value: "{}",
+          updatedAt: new Date(),
+        }),
+    );
+
+    // Act
+    const result = await riotStaticData.resolve({
+      locale: "en_US",
+      championIds: [999],
+      queueIds: [999],
+      mapIds: [999],
+      gameModes: ["UNKNOWN"],
+    });
+
+    // Assert
+    assertEquals(result, {
+      champions: { "999": { name: null, iconUrl: null } },
+      queues: { "999": null },
+      maps: { "999": null },
+      gameModes: { UNKNOWN: null },
+    });
+  });
 });

--- a/api/src/riot_static_data.test.ts
+++ b/api/src/riot_static_data.test.ts
@@ -1,7 +1,8 @@
 import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
-import { assertSpyCalls, stub } from "@std/testing/mock";
+import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
 import { dbActions } from "./db/actions.ts";
+import { apiLogger } from "./logger.ts";
 import { riotStaticData } from "./riot_static_data.ts";
 
 describe("riot_static_data.ts", () => {
@@ -282,6 +283,59 @@ describe("riot_static_data.ts", () => {
     });
     assertSpyCalls(getCacheStub, 4);
     assertSpyCalls(fetchStub, 0);
+  });
+
+  test("一部の静的データ取得に失敗したとき、失敗した種別だけnullにして取得済みデータを返す", async () => {
+    // Arrange
+    using _getCacheStub = stub(
+      dbActions,
+      "getRiotStaticDataCache",
+      (key) =>
+        Promise.resolve(
+          key === "champions-data:en_US"
+            ? {
+              key,
+              version: "16.12.1",
+              value: JSON.stringify({
+                "17": { name: "Teemo", imageFull: "Teemo.png" },
+              }),
+              updatedAt: new Date(),
+            }
+            : undefined,
+        ),
+    );
+    using _fetchStub = stub(
+      globalThis,
+      "fetch",
+      () => Promise.resolve(new Response(null, { status: 503 })),
+    );
+    using warnStub = stub(apiLogger, "warn", () => {});
+
+    // Act
+    const result = await riotStaticData.resolve({
+      locale: "en_US",
+      championIds: [17],
+      queueIds: [420],
+    });
+
+    // Assert
+    assertEquals(result, {
+      champions: {
+        "17": {
+          name: "Teemo",
+          iconUrl:
+            "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
+        },
+      },
+      queues: { "420": null },
+      maps: {},
+      gameModes: {},
+    });
+    assertSpyCall(warnStub, 0, {
+      args: ["riot_static_data.resolve_queues_failed", {
+        error: "Failed to fetch Riot static data: 503",
+      }],
+    });
   });
 
   test("未知の識別子を含む静的データを解決するとき、対応する値をnullで返す", async () => {

--- a/api/src/riot_static_data.ts
+++ b/api/src/riot_static_data.ts
@@ -58,6 +58,24 @@ const jaGameModeNames: Record<string, string> = {
   CLASSIC: "クラシック",
 };
 
+export type RiotStaticDataResolveInput = {
+  locale?: string;
+  championIds?: number[];
+  queueIds?: number[];
+  mapIds?: number[];
+  gameModes?: string[];
+};
+
+export type RiotStaticDataResolveResult = {
+  champions: Record<
+    string,
+    { name: string | null; iconUrl: string | null }
+  >;
+  queues: Record<string, string | null>;
+  maps: Record<string, string | null>;
+  gameModes: Record<string, string | null>;
+};
+
 function numberEnv(name: string, fallback: number) {
   const value = Number(Deno.env.get(name));
   return Number.isFinite(value) && value > 0 ? value : fallback;
@@ -287,10 +305,83 @@ async function getGameModeName(gameMode: string, locale?: string) {
   return names[gameMode] ?? null;
 }
 
+function unique<T>(values: T[] | undefined) {
+  return [...new Set(values ?? [])];
+}
+
+async function resolve(
+  input: RiotStaticDataResolveInput,
+): Promise<RiotStaticDataResolveResult> {
+  const championIds = unique(input.championIds);
+  const queueIds = unique(input.queueIds);
+  const mapIds = unique(input.mapIds);
+  const gameModes = unique(input.gameModes);
+
+  const needsQueues = queueIds.some((queueId) =>
+    localizedQueueName(queueId, input.locale) === null
+  );
+  const needsMaps = mapIds.some((mapId) =>
+    localizedMapName(mapId, input.locale) === null
+  );
+  const needsGameModes = gameModes.some((gameMode) =>
+    localizedGameModeName(gameMode, input.locale) === null
+  );
+
+  const [championData, queueNames, mapNames, gameModeNames] = await Promise.all(
+    [
+      championIds.length > 0
+        ? getChampions(input.locale)
+        : Promise.resolve(null),
+      needsQueues ? getQueues() : Promise.resolve(null),
+      needsMaps ? getMaps() : Promise.resolve(null),
+      needsGameModes ? getGameModes() : Promise.resolve(null),
+    ],
+  );
+
+  const champions: RiotStaticDataResolveResult["champions"] = {};
+  for (const championId of championIds) {
+    const champion = championData?.value[String(championId)];
+    champions[String(championId)] = {
+      name: champion?.name ?? null,
+      iconUrl: champion?.imageFull && championData
+        ? `${DATA_DRAGON_CDN_BASE}/${championData.version}/img/champion/${champion.imageFull}`
+        : null,
+    };
+  }
+
+  const queues: RiotStaticDataResolveResult["queues"] = {};
+  for (const queueId of queueIds) {
+    queues[String(queueId)] = localizedQueueName(queueId, input.locale) ??
+      queueNames?.[String(queueId)] ?? null;
+  }
+
+  const maps: RiotStaticDataResolveResult["maps"] = {};
+  for (const mapId of mapIds) {
+    maps[String(mapId)] = localizedMapName(mapId, input.locale) ??
+      mapNames?.[String(mapId)] ?? null;
+  }
+
+  const resolvedGameModes: RiotStaticDataResolveResult["gameModes"] = {};
+  for (const gameMode of gameModes) {
+    resolvedGameModes[gameMode] = localizedGameModeName(
+      gameMode,
+      input.locale,
+    ) ?? gameModeNames?.[gameMode] ?? null;
+  }
+
+  return {
+    champions,
+    queues,
+    maps,
+    gameModes: resolvedGameModes,
+  };
+}
+
 export const riotStaticData = {
   getChampionNameById,
   getChampionIconUrlById,
   getQueueNameById,
   getMapNameById,
   getGameModeName,
+  resolve,
 };

--- a/api/src/riot_static_data.ts
+++ b/api/src/riot_static_data.ts
@@ -309,6 +309,20 @@ function unique<T>(values: T[] | undefined) {
   return [...new Set(values ?? [])];
 }
 
+async function resolveResource<T>(
+  resource: string,
+  load: () => Promise<T>,
+): Promise<T | null> {
+  try {
+    return await load();
+  } catch (error) {
+    apiLogger.warn(`riot_static_data.resolve_${resource}_failed`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
 async function resolve(
   input: RiotStaticDataResolveInput,
 ): Promise<RiotStaticDataResolveResult> {
@@ -330,11 +344,15 @@ async function resolve(
   const [championData, queueNames, mapNames, gameModeNames] = await Promise.all(
     [
       championIds.length > 0
-        ? getChampions(input.locale)
+        ? resolveResource("champions", () => getChampions(input.locale))
         : Promise.resolve(null),
-      needsQueues ? getQueues() : Promise.resolve(null),
-      needsMaps ? getMaps() : Promise.resolve(null),
-      needsGameModes ? getGameModes() : Promise.resolve(null),
+      needsQueues
+        ? resolveResource("queues", getQueues)
+        : Promise.resolve(null),
+      needsMaps ? resolveResource("maps", getMaps) : Promise.resolve(null),
+      needsGameModes
+        ? resolveResource("game_modes", getGameModes)
+        : Promise.resolve(null),
     ],
   );
 

--- a/api/src/routes/riot_static_data.test.ts
+++ b/api/src/routes/riot_static_data.test.ts
@@ -1,0 +1,101 @@
+import { assertEquals } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
+import app from "../app.ts";
+import { riotStaticData } from "../riot_static_data.ts";
+
+describe("POST /riot/static-data/resolve", () => {
+  test("ロケールと識別子群を指定したとき、解決した静的表示データをまとめて返す", async () => {
+    // Arrange
+    const resolved = {
+      champions: {
+        "17": { name: "ティーモ", iconUrl: "https://example.com/Teemo.png" },
+      },
+      queues: { "420": "ランクソロ/デュオ" },
+      maps: { "11": "サモナーズリフト" },
+      gameModes: { CLASSIC: "クラシック" },
+    };
+    using resolveStub = stub(
+      riotStaticData,
+      "resolve",
+      () => Promise.resolve(resolved),
+    );
+
+    // Act
+    const res = await app.request("/riot/static-data/resolve", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        locale: "ja_JP",
+        championIds: [17],
+        queueIds: [420],
+        mapIds: [11],
+        gameModes: ["CLASSIC"],
+      }),
+    });
+
+    // Assert
+    assertEquals(res.status, 200);
+    assertEquals(await res.json(), resolved);
+    assertSpyCall(resolveStub, 0, {
+      args: [{
+        locale: "ja_JP",
+        championIds: [17],
+        queueIds: [420],
+        mapIds: [11],
+        gameModes: ["CLASSIC"],
+      }],
+    });
+  });
+
+  test("負の識別子を指定したとき、静的データを解決せず400を返す", async () => {
+    // Arrange
+    using resolveStub = stub(
+      riotStaticData,
+      "resolve",
+      () =>
+        Promise.resolve({
+          champions: {},
+          queues: {},
+          maps: {},
+          gameModes: {},
+        }),
+    );
+
+    // Act
+    const res = await app.request("/riot/static-data/resolve", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ championIds: [-1] }),
+    });
+
+    // Assert
+    assertEquals(res.status, 400);
+    assertEquals(await res.json(), {
+      error: "Invalid Riot static data resolve request",
+    });
+    assertSpyCalls(resolveStub, 0);
+  });
+
+  test("静的データの取得に失敗したとき、successを含まないエラーと502を返す", async () => {
+    // Arrange
+    using _resolveStub = stub(
+      riotStaticData,
+      "resolve",
+      () => Promise.reject(new Error("Failed to fetch Riot static data: 503")),
+    );
+
+    // Act
+    const res = await app.request("/riot/static-data/resolve", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ championIds: [17] }),
+    });
+
+    // Assert
+    assertEquals(res.status, 502);
+    assertEquals(await res.json(), {
+      error: "Failed to fetch Riot static data: 503",
+    });
+  });
+});

--- a/api/src/routes/riot_static_data.ts
+++ b/api/src/routes/riot_static_data.ts
@@ -1,0 +1,37 @@
+import { Hono } from "@hono/hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { riotStaticData } from "../riot_static_data.ts";
+
+const riotStaticDataResolveSchema = z.object({
+  locale: z.string().trim().min(1).max(32).optional(),
+  championIds: z.array(z.number().int().nonnegative()).max(20).default([]),
+  queueIds: z.array(z.number().int().nonnegative()).max(10).default([]),
+  mapIds: z.array(z.number().int().nonnegative()).max(10).default([]),
+  gameModes: z.array(z.string().trim().min(1).max(64)).max(10).default([]),
+});
+
+function errorMessage(error: unknown) {
+  return error instanceof Error
+    ? error.message
+    : "Failed to resolve Riot static data";
+}
+
+export const riotStaticDataRoutes = new Hono().post(
+  "/resolve",
+  zValidator("json", riotStaticDataResolveSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ error: "Invalid Riot static data resolve request" }, 400);
+    }
+  }),
+  async (c) => {
+    try {
+      const result = await riotStaticData.resolve(c.req.valid("json"));
+      return c.json(result, 200);
+    } catch (error) {
+      return c.json({ error: errorMessage(error) }, 502);
+    }
+  },
+);
+
+export type RiotStaticDataRoutes = typeof riotStaticDataRoutes;

--- a/bot/deno.json
+++ b/bot/deno.json
@@ -4,7 +4,7 @@
     ".": "./src/main.ts"
   },
   "tasks": {
-    "dev": "DATABASE_URL=file:../data/sqlite.db deno run -A --watch --env=../.env.dev src/main.ts",
+    "dev": "deno run -A --watch --env=../.env.dev src/main.ts",
     "test": "deno test -A"
   },
   "compilerOptions": {

--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -294,6 +294,76 @@ describe("apiClient", () => {
     });
   });
 
+  describe("resolveRiotStaticData", () => {
+    test("静的データの解決を依頼したとき、Backend APIからバッチ解決結果を返す", async () => {
+      // Arrange
+      const payload = {
+        locale: "ja_JP",
+        championIds: [17, 18],
+        queueIds: [420],
+        mapIds: [11],
+        gameModes: ["CLASSIC"],
+      };
+      const data = {
+        champions: {
+          "17": {
+            name: "ティーモ",
+            iconUrl:
+              "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
+          },
+          "18": { name: "トリスターナ", iconUrl: null },
+        },
+        queues: { "420": "ランクソロ/デュオ" },
+        maps: { "11": "サモナーズリフト" },
+        gameModes: { CLASSIC: "クラシック" },
+      };
+      using fetchStub = stub(
+        globalThis,
+        "fetch",
+        () =>
+          Promise.resolve(
+            new Response(JSON.stringify(data), { status: 200 }),
+          ),
+      );
+
+      // Act
+      const result = await apiClient.resolveRiotStaticData(payload);
+
+      // Assert
+      assertEquals(result, { success: true, data });
+      assertSpyCalls(fetchStub, 1);
+      const [url, init] = fetchStub.calls[0].args;
+      assertEquals(
+        url,
+        `${Deno.env.get("API_URL")}/riot/static-data/resolve`,
+      );
+      assertEquals(init?.method, "POST");
+      assertEquals(init?.body, JSON.stringify(payload));
+    });
+
+    test("Backend APIが静的データを解決できないとき、呼び出し側がfallbackできる失敗結果を返す", async () => {
+      // Arrange
+      const error = "Failed to resolve Riot static data";
+      using fetchStub = stub(
+        globalThis,
+        "fetch",
+        () =>
+          Promise.resolve(
+            new Response(JSON.stringify({ error }), { status: 502 }),
+          ),
+      );
+
+      // Act
+      const result = await apiClient.resolveRiotStaticData({
+        championIds: [17],
+      });
+
+      // Assert
+      assertEquals(result, { success: false, error });
+      assertSpyCalls(fetchStub, 1);
+    });
+  });
+
   describe("watchMatch", () => {
     test("監視登録APIが404を返す場合、呼び出し側で未連携を識別できるステータスを返す", async () => {
       using fetchStub = stub(

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -308,6 +308,25 @@ export type FinalizedRankSnapshot = {
   losses: number | null;
   fetchedAt: Date;
 };
+export type RiotStaticDataResolveInput = {
+  locale?: string;
+  championIds?: number[];
+  queueIds?: number[];
+  mapIds?: number[];
+  gameModes?: string[];
+};
+export type RiotStaticDataResolveData = {
+  champions: Record<
+    string,
+    { name: string | null; iconUrl: string | null }
+  >;
+  queues: Record<string, string | null>;
+  maps: Record<string, string | null>;
+  gameModes: Record<string, string | null>;
+};
+export type RiotStaticDataResolveResult =
+  | { success: true; data: RiotStaticDataResolveData }
+  | { success: false; error: string };
 
 function parseRankSnapshot(
   snapshot: Omit<FinalizedRankSnapshot, "fetchedAt"> & {
@@ -422,6 +441,27 @@ async function upsertExternalMatchDetail(
   } catch (error) {
     console.error("Failed to communicate with API", error);
     return { success: false as const, error: "Failed to communicate with API" };
+  }
+}
+
+async function resolveRiotStaticData(
+  payload: RiotStaticDataResolveInput,
+): Promise<RiotStaticDataResolveResult> {
+  try {
+    const res = await client.riot["static-data"].resolve.$post({
+      json: payload,
+    });
+
+    if (!res.ok) {
+      const body = await res.json();
+      return { success: false, error: body.error };
+    }
+
+    const data = await res.json();
+    return { success: true, data };
+  } catch (error) {
+    console.error("Failed to communicate with API", error);
+    return { success: false, error: "Failed to communicate with API" };
   }
 }
 
@@ -580,6 +620,7 @@ export const apiClient = {
   upsertPendingRankSnapshots,
   finalizeRankSnapshots,
   upsertExternalMatchDetail,
+  resolveRiotStaticData,
   getLoginUrl,
   watchMatch,
   unwatchMatch,

--- a/bot/src/component_boundary.test.ts
+++ b/bot/src/component_boundary.test.ts
@@ -1,0 +1,62 @@
+import { assertEquals } from "@std/assert";
+import { test } from "@std/testing/bdd";
+
+async function runtimeTypeScriptFiles(directory: URL): Promise<URL[]> {
+  const files: URL[] = [];
+  for await (const entry of Deno.readDir(directory)) {
+    const url = new URL(entry.name, directory);
+    if (entry.isDirectory) {
+      files.push(
+        ...await runtimeTypeScriptFiles(new URL(`${entry.name}/`, directory)),
+      );
+    } else if (
+      entry.isFile && entry.name.endsWith(".ts") &&
+      !entry.name.endsWith(".test.ts") && entry.name !== "test_utils.ts"
+    ) {
+      files.push(url);
+    }
+  }
+  return files;
+}
+
+test("Bot実行環境がBackend内部実装とDB設定に依存しない", async () => {
+  // Arrange
+  const violations: string[] = [];
+  const sourceDirectory = new URL("./", import.meta.url);
+  for (const file of await runtimeTypeScriptFiles(sourceDirectory)) {
+    const source = await Deno.readTextFile(file);
+    if (source.includes("@adteemo/api/riot-static-data")) {
+      violations.push(`Backend内部実装をimportしている: ${file.pathname}`);
+    }
+  }
+
+  const botConfig = JSON.parse(
+    await Deno.readTextFile(new URL("../deno.json", import.meta.url)),
+  );
+  if (String(botConfig.tasks?.dev ?? "").includes("DATABASE_URL")) {
+    violations.push("botのdev taskにDATABASE_URLが設定されている");
+  }
+
+  const apiConfig = JSON.parse(
+    await Deno.readTextFile(new URL("../../api/deno.json", import.meta.url)),
+  );
+  if ("./riot-static-data" in (apiConfig.exports ?? {})) {
+    violations.push("API workspaceがriot-static-data内部実装を公開している");
+  }
+
+  const compose = await Deno.readTextFile(
+    new URL("../../docker-compose.yml", import.meta.url),
+  );
+  const botService = compose.match(
+    /\n[ ]{2}bot:\n([\s\S]*?)(?=\n[ ]{2}[a-z][\w-]*:|\n[ ]{2}# ---)/,
+  )?.[1] ?? "";
+  if (botService.includes("prod-db-data:/app/data")) {
+    violations.push("bot serviceがDB volumeをmountしている");
+  }
+  if (botService.includes("DATABASE_URL")) {
+    violations.push("bot serviceにDATABASE_URLが設定されている");
+  }
+
+  // Act / Assert
+  assertEquals(violations, []);
+});

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -3,7 +3,6 @@ import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, spy, stub } from "@std/testing/mock";
 import type { Client } from "discord.js";
 import type { MatchWatcher, RiotAccount } from "@adteemo/api/schema";
-import { riotStaticData } from "@adteemo/api/riot-static-data";
 import { apiClient } from "../api_client.ts";
 import { botLogger } from "../logger.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
@@ -136,6 +135,29 @@ function leagueEntries(leaguePoints = 19) {
   }];
 }
 
+function resolvedRiotStaticData() {
+  return {
+    success: true as const,
+    data: {
+      champions: {
+        "17": {
+          name: "ティーモ",
+          iconUrl:
+            "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
+        },
+        "18": {
+          name: "トリスターナ",
+          iconUrl:
+            "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Tristana.png",
+        },
+      },
+      queues: { "420": "ランクソロ/デュオ" },
+      maps: { "11": "サモナーズリフト" },
+      gameModes: { CLASSIC: "クラシック" },
+    },
+  };
+}
+
 function clientWithSend(
   send: (options: unknown) => Promise<unknown> = () =>
     Promise.resolve({ id: "message-new" }),
@@ -233,53 +255,32 @@ async function resultEmbedFields(resultMatch: RiotMatch) {
 }
 
 describe("match_tracking.ts", () => {
-  const staticDataStubs: Partial<
-    Record<keyof typeof riotStaticData, { restore(): void }>
-  > = {};
+  let staticDataStub: { restore(): void } | undefined;
 
-  function restoreStaticDataStub(method: keyof typeof riotStaticData) {
-    staticDataStubs[method]?.restore();
-    delete staticDataStubs[method];
+  function restoreStaticDataStub() {
+    staticDataStub?.restore();
+    staticDataStub = undefined;
   }
 
   beforeEach(() => {
-    staticDataStubs.getChampionNameById = stub(
-      riotStaticData,
-      "getChampionNameById",
-      () => Promise.resolve("ティーモ"),
-    );
-    staticDataStubs.getQueueNameById = stub(
-      riotStaticData,
-      "getQueueNameById",
-      () => Promise.resolve("ランクソロ/デュオ"),
-    );
-    staticDataStubs.getMapNameById = stub(
-      riotStaticData,
-      "getMapNameById",
-      () => Promise.resolve("サモナーズリフト"),
-    );
-    staticDataStubs.getGameModeName = stub(
-      riotStaticData,
-      "getGameModeName",
-      () => Promise.resolve("クラシック"),
-    );
-    staticDataStubs.getChampionIconUrlById = stub(
-      riotStaticData,
-      "getChampionIconUrlById",
-      () =>
-        Promise.resolve(
-          "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
-        ),
+    staticDataStub = stub(
+      apiClient,
+      "resolveRiotStaticData",
+      () => Promise.resolve(resolvedRiotStaticData()),
     );
   });
 
   afterEach(() => {
-    for (const method of Object.keys(staticDataStubs)) {
-      restoreStaticDataStub(method as keyof typeof riotStaticData);
-    }
+    restoreStaticDataStub();
   });
 
   test("idleの監視対象が試合中になったとき、開始通知を送りIN_GAMEへ更新する", async () => {
+    restoreStaticDataStub();
+    using resolveStaticDataStub = stub(
+      apiClient,
+      "resolveRiotStaticData",
+      () => Promise.resolve(resolvedRiotStaticData()),
+    );
     const { client, sendSpy } = clientWithSend();
     using getWatchersStub = stub(
       apiClient,
@@ -307,6 +308,16 @@ describe("match_tracking.ts", () => {
     assertSpyCalls(getWatchersStub, 1);
     assertSpyCalls(getAccountStub, 1);
     assertSpyCalls(activeGameStub, 1);
+    assertSpyCalls(resolveStaticDataStub, 1);
+    assertSpyCall(resolveStaticDataStub, 0, {
+      args: [{
+        locale: "ja_JP",
+        championIds: [17],
+        queueIds: [420],
+        mapIds: [11],
+        gameModes: ["CLASSIC"],
+      }],
+    });
     assertSpyCalls(sendSpy, 1);
     assertEquals(updateStub.calls[0].args[0], "guild-1");
     assertEquals(updateStub.calls[0].args[1], "target-1");
@@ -466,12 +477,11 @@ describe("match_tracking.ts", () => {
   });
 
   test("共有試合中通知に複数監視対象を表示するとき、対象ごとのチャンピオンを表示し単一Riot IDをfooterに出さない", async () => {
-    restoreStaticDataStub("getChampionNameById");
-    using _championNameByIdStub = stub(
-      riotStaticData,
-      "getChampionNameById",
-      (championId) =>
-        Promise.resolve(championId === 17 ? "ティーモ" : "トリスターナ"),
+    restoreStaticDataStub();
+    using resolveStaticDataStub = stub(
+      apiClient,
+      "resolveRiotStaticData",
+      () => Promise.resolve(resolvedRiotStaticData()),
     );
     const { client, editSpy } = clientWithSend();
     using _getWatchersStub = stub(
@@ -512,6 +522,21 @@ describe("match_tracking.ts", () => {
 
     await matchTracker.processMatchWatchers(client);
 
+    assertSpyCalls(resolveStaticDataStub, 2);
+    assertEquals(resolveStaticDataStub.calls[0].args[0].championIds, [17]);
+    const secondInput = resolveStaticDataStub.calls[1].args[0];
+    const secondChampionIds = secondInput.championIds ?? [];
+    assertEquals(
+      secondChampionIds.toSorted(),
+      [17, 18],
+    );
+    assertEquals(secondInput, {
+      locale: "ja_JP",
+      championIds: secondChampionIds,
+      queueIds: [420],
+      mapIds: [11],
+      gameModes: ["CLASSIC"],
+    });
     const editedEmbed = editedEmbedJson(editSpy, 0);
     const activeChampions = editedEmbed.fields?.find((field) =>
       field.name === messageHandler.formatMessage(
@@ -1949,11 +1974,20 @@ describe("match_tracking.ts", () => {
   });
 
   test("チャンピオン画像URLの解決に失敗したとき、thumbnailなしでチャンピオン名を含む試合結果を送信する", async () => {
-    restoreStaticDataStub("getChampionIconUrlById");
+    restoreStaticDataStub();
     using _iconFailureStub = stub(
-      riotStaticData,
-      "getChampionIconUrlById",
-      () => Promise.reject(new Error("Data Dragon failed")),
+      apiClient,
+      "resolveRiotStaticData",
+      () =>
+        Promise.resolve({
+          ...resolvedRiotStaticData(),
+          data: {
+            ...resolvedRiotStaticData().data,
+            champions: {
+              "17": { name: "ティーモ", iconUrl: null },
+            },
+          },
+        }),
     );
     const { client, editSpy } = clientWithSend();
     using _getWatchersStub = stub(
@@ -2617,12 +2651,25 @@ describe("match_tracking.ts", () => {
   });
 
   test("静的データのチャンピオン名取得に失敗したとき、Match-v5の既存名で結果通知を完了する", async () => {
-    restoreStaticDataStub("getChampionNameById");
+    restoreStaticDataStub();
     const { client, editSpy } = clientWithSend();
     using _championNameFailureStub = stub(
-      riotStaticData,
-      "getChampionNameById",
-      () => Promise.reject(new Error("Data Dragon failed")),
+      apiClient,
+      "resolveRiotStaticData",
+      () =>
+        Promise.resolve({
+          ...resolvedRiotStaticData(),
+          data: {
+            ...resolvedRiotStaticData().data,
+            champions: {
+              "17": {
+                name: null,
+                iconUrl:
+                  "https://ddragon.leagueoflegends.com/cdn/16.12.1/img/champion/Teemo.png",
+              },
+            },
+          },
+        }),
     );
     using _getWatchersStub = stub(
       apiClient,
@@ -2666,12 +2713,19 @@ describe("match_tracking.ts", () => {
   });
 
   test("静的データのモード名取得に失敗したとき、Match-v5の既存モードで結果通知を完了する", async () => {
-    restoreStaticDataStub("getGameModeName");
+    restoreStaticDataStub();
     const { client, editSpy } = clientWithSend();
     using _gameModeFailureStub = stub(
-      riotStaticData,
-      "getGameModeName",
-      () => Promise.reject(new Error("Data Dragon failed")),
+      apiClient,
+      "resolveRiotStaticData",
+      () =>
+        Promise.resolve({
+          ...resolvedRiotStaticData(),
+          data: {
+            ...resolvedRiotStaticData().data,
+            gameModes: { CLASSIC: null },
+          },
+        }),
     );
     using _getWatchersStub = stub(
       apiClient,

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -1,6 +1,5 @@
 import { type Client, EmbedBuilder } from "discord.js";
 import type { Lane, MatchWatcher, RiotAccount } from "@adteemo/api/schema";
-import { riotStaticData } from "@adteemo/api/riot-static-data";
 import {
   apiClient,
   type FinalizedRankSnapshot,
@@ -61,8 +60,15 @@ type PendingResult = {
 };
 type ActiveGameTargetDetail = {
   targetDiscordId: string;
-  champion: string;
+  championId?: number;
 };
+type RiotStaticDataResult = Awaited<
+  ReturnType<typeof apiClient.resolveRiotStaticData>
+>;
+type ResolvedRiotStaticData = Extract<
+  RiotStaticDataResult,
+  { success: true }
+>["data"];
 type RankedQueueType = RankSnapshotPayload["queueType"];
 type RankSummary = {
   queueType: RankedQueueType;
@@ -671,36 +677,30 @@ function fallbackChampionName(
   );
 }
 
-async function championNameById(
+function championNameById(
+  staticData: ResolvedRiotStaticData | null,
   championId: number | undefined,
   fallbackName?: string,
 ) {
   if (championId === undefined) {
     return fallbackChampionName(championId, fallbackName);
   }
-  try {
-    return await riotStaticData.getChampionNameById(
-      championId,
-      messageLocale(),
-    ) ?? fallbackChampionName(championId, fallbackName);
-  } catch {
-    return fallbackChampionName(championId, fallbackName);
-  }
+  return staticData?.champions[String(championId)]?.name ??
+    fallbackChampionName(championId, fallbackName);
 }
 
-async function championIconUrlById(championId: number | undefined) {
+function championIconUrlById(
+  staticData: ResolvedRiotStaticData | null,
+  championId: number | undefined,
+) {
   if (championId === undefined) return null;
-  try {
-    return await riotStaticData.getChampionIconUrlById(
-      championId,
-      messageLocale(),
-    );
-  } catch {
-    return null;
-  }
+  return staticData?.champions[String(championId)]?.iconUrl ?? null;
 }
 
-async function queueName(queueId: number | undefined) {
+function queueName(
+  staticData: ResolvedRiotStaticData | null,
+  queueId: number | undefined,
+) {
   if (queueId === undefined) {
     return messageHandler.formatMessage(
       messageKeys.matchTracking.embed.fallback.unknownQueue,
@@ -710,34 +710,38 @@ async function queueName(queueId: number | undefined) {
     messageKeys.matchTracking.embed.fallback.queueId,
     { id: queueId },
   );
-  try {
-    return await riotStaticData.getQueueNameById(queueId, messageLocale()) ??
-      fallback;
-  } catch {
-    return fallback;
-  }
+  return staticData?.queues[String(queueId)] ?? fallback;
 }
 
-async function mapName(mapId: number) {
+function mapName(
+  staticData: ResolvedRiotStaticData | null,
+  mapId: number,
+) {
   const fallback = messageHandler.formatMessage(
     messageKeys.matchTracking.embed.fallback.mapId,
     { id: mapId },
   );
-  try {
-    return await riotStaticData.getMapNameById(mapId, messageLocale()) ??
-      fallback;
-  } catch {
-    return fallback;
-  }
+  return staticData?.maps[String(mapId)] ?? fallback;
 }
 
-async function gameModeName(gameMode: string) {
-  try {
-    return await riotStaticData.getGameModeName(gameMode, messageLocale()) ??
-      gameMode;
-  } catch {
-    return gameMode;
-  }
+function gameModeName(
+  staticData: ResolvedRiotStaticData | null,
+  gameMode: string,
+) {
+  return staticData?.gameModes[gameMode] ?? gameMode;
+}
+
+async function resolveRiotStaticData(input: {
+  championIds: number[];
+  queueIds: number[];
+  mapIds: number[];
+  gameModes: string[];
+}) {
+  const result = await apiClient.resolveRiotStaticData({
+    locale: messageLocale(),
+    ...input,
+  });
+  return result.success ? result.data : null;
 }
 
 async function activeGameTargetDetails(
@@ -755,7 +759,6 @@ async function activeGameTargetDetails(
     if (!accountResult.success) {
       details.push({
         targetDiscordId,
-        champion: await championNameById(undefined),
       });
       continue;
     }
@@ -765,7 +768,7 @@ async function activeGameTargetDetails(
     );
     details.push({
       targetDiscordId,
-      champion: await championNameById(participant?.championId),
+      championId: participant?.championId,
     });
   }
   return details;
@@ -1122,10 +1125,25 @@ async function buildActiveGameEmbed(
     p.puuid === account.puuid
   );
   const minutes = elapsedMinutes(activeGame);
-  const champion = await championNameById(participant?.championId);
-  const queue = await queueName(activeGame.gameQueueConfigId);
-  const map = await mapName(activeGame.mapId);
-  const mode = await gameModeName(activeGame.gameMode);
+  const championIds = [
+    participant?.championId,
+    ...(targetDetails?.map((detail) => detail.championId) ?? []),
+  ].filter((id): id is number => id !== undefined);
+  const staticData = await resolveRiotStaticData({
+    championIds: [...new Set(championIds)],
+    queueIds: activeGame.gameQueueConfigId === undefined
+      ? []
+      : [activeGame.gameQueueConfigId],
+    mapIds: [activeGame.mapId],
+    gameModes: [activeGame.gameMode],
+  });
+  const champion = championNameById(
+    staticData,
+    participant?.championId,
+  );
+  const queue = queueName(staticData, activeGame.gameQueueConfigId);
+  const map = mapName(staticData, activeGame.mapId);
+  const mode = gameModeName(staticData, activeGame.gameMode);
   const title = kind === "started"
     ? messageHandler.formatMessage(
       messageKeys.matchTracking.embed.active.startedTitle,
@@ -1134,10 +1152,13 @@ async function buildActiveGameEmbed(
       messageKeys.matchTracking.embed.active.progressTitle,
     );
   const targets = targetDetails?.length
-    ? targetDetails
+    ? targetDetails.map(({ targetDiscordId, championId }) => ({
+      targetDiscordId,
+      champion: championNameById(staticData, championId),
+    }))
     : [{ targetDiscordId: watcher.targetDiscordId, champion }];
   const thumbnailUrl = targets.length === 1
-    ? await championIconUrlById(participant?.championId)
+    ? championIconUrlById(staticData, participant?.championId)
     : null;
   const description = messageHandler.formatMessage(
     messageKeys.matchTracking.embed.active.description,
@@ -1310,11 +1331,23 @@ async function buildMatchResultEmbed(
       .setTimestamp(new Date());
   }
 
-  const champion = await championNameById(
+  const staticData = await resolveRiotStaticData({
+    championIds: participant.championId === undefined
+      ? []
+      : [participant.championId],
+    queueIds: [match.info.queueId],
+    mapIds: [match.info.mapId],
+    gameModes: [match.info.gameMode],
+  });
+  const champion = championNameById(
+    staticData,
     participant.championId,
     participant.championName,
   );
-  const thumbnailUrl = await championIconUrlById(participant.championId);
+  const thumbnailUrl = championIconUrlById(
+    staticData,
+    participant.championId,
+  );
   const teamKills = match.info.participants
     .filter((candidate) => candidate.teamId === participant.teamId)
     .reduce((sum, candidate) => sum + candidate.kills, 0);
@@ -1323,9 +1356,9 @@ async function buildMatchResultEmbed(
     participant.assists,
     teamKills,
   );
-  const queue = await queueName(match.info.queueId);
-  const map = await mapName(match.info.mapId);
-  const mode = await gameModeName(match.info.gameMode);
+  const queue = queueName(staticData, match.info.queueId);
+  const map = mapName(staticData, match.info.mapId);
+  const mode = gameModeName(staticData, match.info.gameMode);
   const result = participant.win
     ? messageHandler.formatMessage(messageKeys.matchTracking.embed.result.win)
     : messageHandler.formatMessage(messageKeys.matchTracking.embed.result.loss);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,13 +41,10 @@ services:
     depends_on:
       api:
         condition: service_healthy
-    volumes:
-      - prod-db-data:/app/data
     env_file:
       - .env
     environment:
       API_URL: http://api:8000
-      DATABASE_URL: file:/app/data/sqlite.db
 
   # --- Development service (activate with --profile dev) ---
   dev:


### PR DESCRIPTION
## 概要

BotからRiot静的データ実装とSQLite cacheへの直接依存を除去し、Backend APIのbatch RPCへ集約します。

Closes #72

## 変更内容

- `POST /riot/static-data/resolve`を追加
- champion / queue / map / game modeを1 requestでbatch解決
- 未知IDのnull fallbackと400 / 502のHTTP契約を追加
- Botのmatch trackingを`apiClient.resolveRiotStaticData`経由へ移行
- 複数監視対象のchampion IDをEmbed単位でbatch化
- Bot serviceからDB volumeと`DATABASE_URL`を削除
- 不要な`./riot-static-data` workspace exportを削除
- Botのコンポーネント境界回帰テストを追加
- `TASKS.md`へ#69・#71のリファクタリングRoadmapを同期

## 影響

Botの外部通信先は静的データについてBackend APIへ限定されます。静的データ取得に失敗した場合も、既存のID・Match-v5名・modeによるfallbackを維持します。

## 検証

- `deno task quality`
  - 32 suites / 280 steps passed
  - Riot live tests 3件は通常どおりignored
- `git diff --check`
