### PR TITLE
[codex] fix(api): BotのRPC clientからDB runtime依存を除去する

### DIFF
--- a/api/src/hc.ts
+++ b/api/src/hc.ts
@@ -1,8 +1,8 @@
-import app, { type AppType } from "./app.ts";
+import type { AppType } from "./app.ts";
 import { hc } from "@hono/hono/client";
 
 // assign the client to a variable to calculate the type when compiling
-export type Client = ReturnType<typeof hc<typeof app>>;
+export type Client = ReturnType<typeof hc<AppType>>;
 
 export const hcWithType = (...args: Parameters<typeof hc>): Client =>
   hc<AppType>(...args);

--- a/bot/check-runtime-boundary.test.ts
+++ b/bot/check-runtime-boundary.test.ts
@@ -1,0 +1,61 @@
+import { assertEquals } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import * as path from "@std/path";
+import { runtimeCommandEntrypoints } from "./check-runtime-boundary.ts";
+import { isRuntimeCommandFile } from "./src/common/runtime_command_files.ts";
+
+describe("check-runtime-boundary", () => {
+  describe("正常系", () => {
+    test("commandsディレクトリに実行時commandとテストが混在するとき、実行時に動的importされるcommandだけを境界検査rootに含める", () => {
+      // Arrange
+      const commandsDirectory = new URL("file:///tmp/adteemo-commands/");
+      const commandEntries = [
+        dirEntry("create-custom-game.ts"),
+        dirEntry("health.ts"),
+        dirEntry("health.test.ts"),
+        dirEntry("link-riot-account.ts"),
+        dirEntry("README.md"),
+      ];
+
+      // Act
+      const entrypoints = runtimeCommandEntrypoints(
+        commandsDirectory,
+        commandEntries,
+      );
+
+      // Assert
+      assertEquals(entrypoints, [
+        path.join("/tmp/adteemo-commands", "create-custom-game.ts"),
+        path.join("/tmp/adteemo-commands", "health.ts"),
+      ]);
+    });
+
+    test("commandファイル名を判定するとき、command loaderと同じ除外条件になる", () => {
+      // Arrange
+      const cases: [string, boolean][] = [
+        ["health.ts", true],
+        ["health.test.ts", false],
+        ["link-riot-account.ts", false],
+        ["README.md", false],
+      ];
+
+      // Act
+      const actual = cases.map(([fileName]) => [
+        fileName,
+        isRuntimeCommandFile(fileName),
+      ]);
+
+      // Assert
+      assertEquals(actual, cases);
+    });
+  });
+});
+
+function dirEntry(name: string): Deno.DirEntry {
+  return {
+    name,
+    isFile: true,
+    isDirectory: false,
+    isSymlink: false,
+  };
+}

--- a/bot/check-runtime-boundary.ts
+++ b/bot/check-runtime-boundary.ts
@@ -1,3 +1,6 @@
+import * as path from "@std/path";
+import { isRuntimeCommandFile } from "./src/common/runtime_command_files.ts";
+
 type Dependency = {
   code?: { specifier: string };
 };
@@ -16,6 +19,7 @@ const defaultEntrypoints = [
   "bot/src/main.ts",
   "bot/src/deploy-commands.ts",
 ];
+const defaultCommandsDirectory = new URL("./src/commands/", import.meta.url);
 
 const forbiddenModulePatterns = [
   /\/api\/src\/app\.ts$/,
@@ -26,6 +30,40 @@ const forbiddenModulePatterns = [
   /@libsql\/client/,
   /drizzle-orm.*\/libsql/,
 ];
+
+export function runtimeCommandEntrypoints(
+  commandsDirectory: URL,
+  dirEntries: Iterable<Deno.DirEntry>,
+): string[] {
+  const entrypoints: string[] = [];
+
+  for (const dirEntry of dirEntries) {
+    if (!dirEntry.isFile || !isRuntimeCommandFile(dirEntry.name)) continue;
+
+    const commandUrl = new URL(dirEntry.name, commandsDirectory);
+    entrypoints.push(path.fromFileUrl(commandUrl));
+  }
+
+  return entrypoints.sort();
+}
+
+export async function collectRuntimeCommandEntrypoints(
+  commandsDirectory = defaultCommandsDirectory,
+): Promise<string[]> {
+  const dirEntries: Deno.DirEntry[] = [];
+  for await (const dirEntry of Deno.readDir(commandsDirectory)) {
+    dirEntries.push(dirEntry);
+  }
+
+  return runtimeCommandEntrypoints(commandsDirectory, dirEntries);
+}
+
+export async function collectDefaultEntrypoints(): Promise<string[]> {
+  return [
+    ...defaultEntrypoints,
+    ...await collectRuntimeCommandEntrypoints(),
+  ];
+}
 
 async function loadModuleGraph(entrypoint: string): Promise<ModuleGraph> {
   const command = new Deno.Command(Deno.execPath(), {
@@ -64,27 +102,39 @@ function runtimeModules(graph: ModuleGraph): Set<string> {
   return visited;
 }
 
-const entrypoints = Deno.args.length > 0 ? Deno.args : defaultEntrypoints;
-const violations: string[] = [];
+export async function checkRuntimeBoundary(
+  entrypoints: string[],
+): Promise<string[]> {
+  const violations: string[] = [];
 
-for (const entrypoint of entrypoints) {
-  const graph = await loadModuleGraph(entrypoint);
-  for (const specifier of runtimeModules(graph)) {
-    if (forbiddenModulePatterns.some((pattern) => pattern.test(specifier))) {
-      violations.push(`${entrypoint}: ${specifier}`);
+  for (const entrypoint of entrypoints) {
+    const graph = await loadModuleGraph(entrypoint);
+    for (const specifier of runtimeModules(graph)) {
+      if (forbiddenModulePatterns.some((pattern) => pattern.test(specifier))) {
+        violations.push(`${entrypoint}: ${specifier}`);
+      }
     }
   }
+
+  return violations;
 }
 
-if (violations.length > 0) {
-  console.error(
-    `Bot runtime boundary violations:\n${
-      violations.map((value) => `- ${value}`).join("\n")
-    }`,
+if (import.meta.main) {
+  const entrypoints = Deno.args.length > 0
+    ? Deno.args
+    : await collectDefaultEntrypoints();
+  const violations = await checkRuntimeBoundary(entrypoints);
+
+  if (violations.length > 0) {
+    console.error(
+      `Bot runtime boundary violations:\n${
+        violations.map((value) => `- ${value}`).join("\n")
+      }`,
+    );
+    Deno.exit(1);
+  }
+
+  console.log(
+    `Bot runtime boundary is valid: ${entrypoints.join(", ")}`,
   );
-  Deno.exit(1);
 }
-
-console.log(
-  `Bot runtime boundary is valid: ${entrypoints.join(", ")}`,
-);

--- a/bot/check-runtime-boundary.ts
+++ b/bot/check-runtime-boundary.ts
@@ -1,0 +1,90 @@
+type Dependency = {
+  code?: { specifier: string };
+};
+
+type Module = {
+  specifier: string;
+  dependencies?: Dependency[];
+};
+
+type ModuleGraph = {
+  roots: string[];
+  modules: Module[];
+};
+
+const defaultEntrypoints = [
+  "bot/src/main.ts",
+  "bot/src/deploy-commands.ts",
+];
+
+const forbiddenModulePatterns = [
+  /\/api\/src\/app\.ts$/,
+  /\/api\/src\/routes\//,
+  /\/api\/src\/db\/(actions|index)\.ts$/,
+  /\/api\/src\/(integrations|services)\//,
+  /\/api\/src\/(riot_api|riot_static_data|rso)\.ts$/,
+  /@libsql\/client/,
+  /drizzle-orm.*\/libsql/,
+];
+
+async function loadModuleGraph(entrypoint: string): Promise<ModuleGraph> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["info", "--json", entrypoint],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const output = await command.output();
+  if (!output.success) {
+    throw new Error(
+      new TextDecoder().decode(output.stderr) ||
+        `Failed to inspect module graph: ${entrypoint}`,
+    );
+  }
+  return JSON.parse(new TextDecoder().decode(output.stdout));
+}
+
+function runtimeModules(graph: ModuleGraph): Set<string> {
+  const modules = new Map(
+    graph.modules.map((module) => [module.specifier, module]),
+  );
+  const queue = [...graph.roots];
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const specifier = queue.shift();
+    if (!specifier || visited.has(specifier)) continue;
+    visited.add(specifier);
+
+    const module = modules.get(specifier);
+    for (const dependency of module?.dependencies ?? []) {
+      if (dependency.code?.specifier) queue.push(dependency.code.specifier);
+    }
+  }
+
+  return visited;
+}
+
+const entrypoints = Deno.args.length > 0 ? Deno.args : defaultEntrypoints;
+const violations: string[] = [];
+
+for (const entrypoint of entrypoints) {
+  const graph = await loadModuleGraph(entrypoint);
+  for (const specifier of runtimeModules(graph)) {
+    if (forbiddenModulePatterns.some((pattern) => pattern.test(specifier))) {
+      violations.push(`${entrypoint}: ${specifier}`);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    `Bot runtime boundary violations:\n${
+      violations.map((value) => `- ${value}`).join("\n")
+    }`,
+  );
+  Deno.exit(1);
+}
+
+console.log(
+  `Bot runtime boundary is valid: ${entrypoints.join(", ")}`,
+);

--- a/bot/src/common/command_loader.ts
+++ b/bot/src/common/command_loader.ts
@@ -1,5 +1,6 @@
 import * as path from "@std/path";
 import { Command } from "../types.ts";
+import { isRuntimeCommandFile } from "./runtime_command_files.ts";
 
 export async function loadCommands(): Promise<Command[]> {
   const commands: Command[] = [];
@@ -8,9 +9,7 @@ export async function loadCommands(): Promise<Command[]> {
 
   for await (const dirEntry of Deno.readDir(commandsPath)) {
     if (
-      dirEntry.isFile && dirEntry.name.endsWith(".ts") &&
-      !dirEntry.name.endsWith(".test.ts") &&
-      !dirEntry.name.startsWith("link-riot-account")
+      dirEntry.isFile && isRuntimeCommandFile(dirEntry.name)
     ) {
       const filePath = path.join(commandsPath, dirEntry.name);
       try {

--- a/bot/src/common/runtime_command_files.ts
+++ b/bot/src/common/runtime_command_files.ts
@@ -1,0 +1,5 @@
+export function isRuntimeCommandFile(name: string): boolean {
+  return name.endsWith(".ts") &&
+    !name.endsWith(".test.ts") &&
+    !name.startsWith("link-riot-account");
+}

--- a/bot/src/component_boundary.test.ts
+++ b/bot/src/component_boundary.test.ts
@@ -19,107 +19,6 @@ async function runtimeTypeScriptFiles(directory: URL): Promise<URL[]> {
   return files;
 }
 
-function runtimeImportSpecifiers(source: string): string[] {
-  const specifiers: string[] = [];
-  const importFromPattern =
-    /^\s*import\s+([\s\S]*?)\s+from\s+["']([^"']+)["'];?/gm;
-
-  for (const match of source.matchAll(importFromPattern)) {
-    const clause = match[1].trim();
-    if (clause.startsWith("type ")) continue;
-
-    if (clause.startsWith("{") && clause.endsWith("}")) {
-      const imports = clause.slice(1, -1).split(",").map((value) =>
-        value.trim()
-      ).filter(Boolean);
-      if (
-        imports.length > 0 &&
-        imports.every((value) => value.startsWith("type "))
-      ) {
-        continue;
-      }
-    }
-
-    specifiers.push(match[2]);
-  }
-
-  const sideEffectImportPattern = /^\s*import\s+["']([^"']+)["'];?/gm;
-  for (const match of source.matchAll(sideEffectImportPattern)) {
-    specifiers.push(match[1]);
-  }
-
-  return specifiers;
-}
-
-async function botRuntimeBoundaryViolations(): Promise<string[]> {
-  const apiDirectory = new URL("../../api/", import.meta.url);
-  const apiConfig = JSON.parse(
-    await Deno.readTextFile(new URL("deno.json", apiDirectory)),
-  );
-  const apiExports = apiConfig.exports as Record<string, string>;
-  const forbiddenPaths = [
-    "/api/src/db/actions.ts",
-    "/api/src/db/index.ts",
-    "/api/src/integrations/",
-    "/api/src/riot_static_data.ts",
-    "/api/src/services/",
-  ];
-  const forbiddenPackages = new Set([
-    "@libsql/client",
-    "drizzle-orm/libsql",
-  ]);
-  const queue = [
-    {
-      module: new URL("./main.ts", import.meta.url),
-      chain: ["bot/src/main.ts"],
-    },
-    {
-      module: new URL("./deploy-commands.ts", import.meta.url),
-      chain: ["bot/src/deploy-commands.ts"],
-    },
-  ];
-  const visited = new Set<string>();
-  const violations: string[] = [];
-
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (!current || visited.has(current.module.href)) continue;
-    visited.add(current.module.href);
-
-    const source = await Deno.readTextFile(current.module);
-    for (const specifier of runtimeImportSpecifiers(source)) {
-      if (forbiddenPackages.has(specifier)) {
-        violations.push([...current.chain, specifier].join(" -> "));
-        continue;
-      }
-
-      let dependency: URL | undefined;
-      if (specifier.startsWith("./") || specifier.startsWith("../")) {
-        dependency = new URL(specifier, current.module);
-      } else if (
-        specifier === "@adteemo/api" || specifier.startsWith("@adteemo/api/")
-      ) {
-        const exportName = specifier === "@adteemo/api"
-          ? "."
-          : `.${specifier.slice("@adteemo/api".length)}`;
-        const exportedPath = apiExports[exportName];
-        if (exportedPath) dependency = new URL(exportedPath, apiDirectory);
-      }
-
-      if (!dependency || !dependency.pathname.endsWith(".ts")) continue;
-
-      const nextChain = [...current.chain, dependency.pathname];
-      if (forbiddenPaths.some((path) => dependency.pathname.includes(path))) {
-        violations.push(nextChain.join(" -> "));
-        continue;
-      }
-      queue.push({ module: dependency, chain: nextChain });
-    }
-  }
-
-  return violations;
-}
-
 test("Bot実行環境がBackend内部実装とDB設定に依存しない", async () => {
   // Arrange
   const violations: string[] = [];
@@ -172,13 +71,5 @@ test("Bot実行環境がBackend内部実装とDB設定に依存しない", async
   }
 
   // Act / Assert
-  assertEquals(violations, []);
-});
-
-test("Bot entrypointの実行時依存を推移的にたどるとき、Backendの外部サービス実装とDB clientへ到達しない", async () => {
-  // Arrange / Act
-  const violations = await botRuntimeBoundaryViolations();
-
-  // Assert
   assertEquals(violations, []);
 });

--- a/bot/src/component_boundary.test.ts
+++ b/bot/src/component_boundary.test.ts
@@ -19,6 +19,107 @@ async function runtimeTypeScriptFiles(directory: URL): Promise<URL[]> {
   return files;
 }
 
+function runtimeImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  const importFromPattern =
+    /^\s*import\s+([\s\S]*?)\s+from\s+["']([^"']+)["'];?/gm;
+
+  for (const match of source.matchAll(importFromPattern)) {
+    const clause = match[1].trim();
+    if (clause.startsWith("type ")) continue;
+
+    if (clause.startsWith("{") && clause.endsWith("}")) {
+      const imports = clause.slice(1, -1).split(",").map((value) =>
+        value.trim()
+      ).filter(Boolean);
+      if (
+        imports.length > 0 &&
+        imports.every((value) => value.startsWith("type "))
+      ) {
+        continue;
+      }
+    }
+
+    specifiers.push(match[2]);
+  }
+
+  const sideEffectImportPattern = /^\s*import\s+["']([^"']+)["'];?/gm;
+  for (const match of source.matchAll(sideEffectImportPattern)) {
+    specifiers.push(match[1]);
+  }
+
+  return specifiers;
+}
+
+async function botRuntimeBoundaryViolations(): Promise<string[]> {
+  const apiDirectory = new URL("../../api/", import.meta.url);
+  const apiConfig = JSON.parse(
+    await Deno.readTextFile(new URL("deno.json", apiDirectory)),
+  );
+  const apiExports = apiConfig.exports as Record<string, string>;
+  const forbiddenPaths = [
+    "/api/src/db/actions.ts",
+    "/api/src/db/index.ts",
+    "/api/src/integrations/",
+    "/api/src/riot_static_data.ts",
+    "/api/src/services/",
+  ];
+  const forbiddenPackages = new Set([
+    "@libsql/client",
+    "drizzle-orm/libsql",
+  ]);
+  const queue = [
+    {
+      module: new URL("./main.ts", import.meta.url),
+      chain: ["bot/src/main.ts"],
+    },
+    {
+      module: new URL("./deploy-commands.ts", import.meta.url),
+      chain: ["bot/src/deploy-commands.ts"],
+    },
+  ];
+  const visited = new Set<string>();
+  const violations: string[] = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || visited.has(current.module.href)) continue;
+    visited.add(current.module.href);
+
+    const source = await Deno.readTextFile(current.module);
+    for (const specifier of runtimeImportSpecifiers(source)) {
+      if (forbiddenPackages.has(specifier)) {
+        violations.push([...current.chain, specifier].join(" -> "));
+        continue;
+      }
+
+      let dependency: URL | undefined;
+      if (specifier.startsWith("./") || specifier.startsWith("../")) {
+        dependency = new URL(specifier, current.module);
+      } else if (
+        specifier === "@adteemo/api" || specifier.startsWith("@adteemo/api/")
+      ) {
+        const exportName = specifier === "@adteemo/api"
+          ? "."
+          : `.${specifier.slice("@adteemo/api".length)}`;
+        const exportedPath = apiExports[exportName];
+        if (exportedPath) dependency = new URL(exportedPath, apiDirectory);
+      }
+
+      if (!dependency || !dependency.pathname.endsWith(".ts")) continue;
+
+      const nextChain = [...current.chain, dependency.pathname];
+      if (forbiddenPaths.some((path) => dependency.pathname.includes(path))) {
+        violations.push(nextChain.join(" -> "));
+        continue;
+      }
+      queue.push({ module: dependency, chain: nextChain });
+    }
+  }
+
+  return violations;
+}
+
 test("Bot実行環境がBackend内部実装とDB設定に依存しない", async () => {
   // Arrange
   const violations: string[] = [];
@@ -71,5 +172,13 @@ test("Bot実行環境がBackend内部実装とDB設定に依存しない", async
   }
 
   // Act / Assert
+  assertEquals(violations, []);
+});
+
+test("Bot entrypointの実行時依存を推移的にたどるとき、Backendの外部サービス実装とDB clientへ到達しない", async () => {
+  // Arrange / Act
+  const violations = await botRuntimeBoundaryViolations();
+
+  // Assert
   assertEquals(violations, []);
 });

--- a/deno.json
+++ b/deno.json
@@ -16,10 +16,12 @@
         "fmt:check",
         "lint",
         "check",
+        "check:bot-boundary",
         "check:messages",
         "test:all"
       ]
     },
+    "check:bot-boundary": "deno run --allow-run=deno bot/check-runtime-boundary.ts",
     "check:messages": "deno run --allow-read messages/src/check-messages.ts",
     "deploy-commands": "deno run --allow-net --allow-read --allow-env --allow-sys --allow-ffi --env=.env bot/src/deploy-commands.ts",
     "db:push": "deno run --allow-env --allow-read --allow-sys --allow-run --allow-ffi --node-modules-dir npm:drizzle-kit push",

--- a/deno.json
+++ b/deno.json
@@ -21,7 +21,7 @@
         "test:all"
       ]
     },
-    "check:bot-boundary": "deno run --allow-run=deno bot/check-runtime-boundary.ts",
+    "check:bot-boundary": "deno run --allow-run=deno --allow-read=bot/src/commands bot/check-runtime-boundary.ts",
     "check:messages": "deno run --allow-read messages/src/check-messages.ts",
     "deploy-commands": "deno run --allow-net --allow-read --allow-env --allow-sys --allow-ffi --env=.env bot/src/deploy-commands.ts",
     "db:push": "deno run --allow-env --allow-read --allow-sys --allow-run --allow-ffi --node-modules-dir npm:drizzle-kit push",


### PR DESCRIPTION
## 概要

BotのHono RPC clientからBackend appへのruntime importを除去し、Bot entrypointからDB actions・libsqlへ推移的に到達しない構成へ修正します。

Closes #72

## 原因

`api/src/hc.ts` がRPC型の計算にBackend `app`を値importしていました。

```text
bot/src/api_client.ts
  -> @adteemo/api/hc
  -> api/src/app.ts
  -> routes
  -> api/src/db/actions.ts
  -> api/src/db/index.ts
  -> @libsql/client
```

既存の境界確認はBotソース内の直接import文字列だけを検査していたため、この推移的runtime依存を検出できませんでした。

## 変更内容

- `api/src/hc.ts` の `AppType` をtype-only importへ変更
- Deno自身の `deno info --json` が生成するcode dependency graphを検査する `check:bot-boundary` を追加
- `check:bot-boundary` を `deno task quality` へ組み込み
- import構文を正規表現で解析する単体テスト案はレビューを受けて削除

## 検証

- architecture checkへBackend appを入力するとDB actions・libsqlを検出し終了コード1
- Botのmain / deploy entrypointではBackend app・routes・services・DB actions/index・libsqlへの到達0件
- `deno task quality`
  - 33 suites / 295 steps passed
  - 3 Riot live tests ignored
