### PR TITLE
refactor(db): DB factoryとDB actions factoryを導入する

### DIFF
--- a/api/src/db/actions.test.ts
+++ b/api/src/db/actions.test.ts
@@ -1,18 +1,60 @@
 import { describe, test } from "@std/testing/bdd";
-import { assertEquals } from "@std/assert";
-import { stub } from "@std/testing/mock";
-import { dbActions } from "./actions.ts";
-import { db } from "./index.ts";
+import { assertEquals, assertRejects } from "@std/assert";
+import { createDbActions } from "./actions.ts";
+import { createDb } from "./index.ts";
 import type { MatchRankSnapshot } from "./schema.ts";
+import { MatchWatcherLimitError } from "../errors.ts";
 
-function stubTransaction(fakeTx: unknown) {
-  const transaction =
-    (async (callback: (tx: unknown) => Promise<unknown>) =>
-      await callback(fakeTx)) as typeof db.transaction;
-  return stub(db, "transaction", transaction);
+function createFakeDbWithTransaction(fakeTx: unknown) {
+  return {
+    transaction: async (callback: (tx: unknown) => Promise<unknown>) =>
+      await callback(fakeTx),
+  } as never;
+}
+
+async function createUsersTable(connection: ReturnType<typeof createDb>) {
+  await connection.client.execute(`
+    CREATE TABLE users (
+      discord_id text PRIMARY KEY NOT NULL,
+      riot_id text,
+      created_at integer NOT NULL,
+      updated_at integer
+    )
+  `);
 }
 
 describe("db/actions.ts", () => {
+  describe("createDbActions", () => {
+    test("DB接続先を指定してactionsを生成するとき、指定したDBだけを更新する", async () => {
+      // Arrange
+      const connectionA = createDb({ url: "file::memory:", logger: false });
+      const connectionB = createDb({ url: "file::memory:", logger: false });
+      try {
+        await createUsersTable(connectionA);
+        await createUsersTable(connectionB);
+        const actionsA = createDbActions(connectionA.db);
+        const actionsB = createDbActions(connectionB.db);
+
+        // Act
+        await actionsA.upsertUser("user-a");
+        await actionsB.upsertUser("user-b");
+        const resultA = await connectionA.client.execute(
+          "SELECT discord_id FROM users ORDER BY discord_id",
+        );
+        const resultB = await connectionB.client.execute(
+          "SELECT discord_id FROM users ORDER BY discord_id",
+        );
+
+        // Assert
+        assertEquals(resultA.rows.map((row) => row.discord_id), ["user-a"]);
+        assertEquals(resultB.rows.map((row) => row.discord_id), ["user-b"]);
+      } finally {
+        connectionA.close();
+        connectionB.close();
+      }
+    });
+  });
+
   describe("upsertPendingRankSnapshots", () => {
     test("beforeスナップショットを一時保存するとき、期限切れのpendingスナップショットを先に削除する", async () => {
       // Arrange
@@ -37,7 +79,7 @@ describe("db/actions.ts", () => {
           },
         }),
       };
-      using _transactionStub = stubTransaction(fakeTx);
+      const dbActions = createDbActions(createFakeDbWithTransaction(fakeTx));
 
       // Act
       await dbActions.upsertPendingRankSnapshots({
@@ -57,6 +99,50 @@ describe("db/actions.ts", () => {
 
       // Assert
       assertEquals(events, ["delete-expired", "insert-pending"]);
+    });
+
+    test("TTLを指定してbeforeスナップショットを保存するとき、指定TTLでexpiresAtを設定する", async () => {
+      // Arrange
+      let expiresAt: Date | undefined;
+      const fakeTx = {
+        delete: () => ({
+          where: () => ({
+            execute: () => Promise.resolve(),
+          }),
+        }),
+        insert: () => ({
+          values: (payload: { expiresAt: Date }) => {
+            expiresAt = payload.expiresAt;
+            return {
+              onConflictDoUpdate: () => ({
+                execute: () => Promise.resolve(),
+              }),
+            };
+          },
+        }),
+      };
+      const dbActions = createDbActions(createFakeDbWithTransaction(fakeTx), {
+        pendingRankSnapshotTtlMs: 1_000,
+      });
+
+      // Act
+      await dbActions.upsertPendingRankSnapshots({
+        platform: "jp1",
+        gameId: "12345",
+        puuid: "puuid-1",
+        snapshots: [{
+          queueType: "RANKED_SOLO_5x5",
+          tier: "EMERALD",
+          rank: "IV",
+          leaguePoints: 2,
+          wins: 10,
+          losses: 8,
+          fetchedAt: new Date("2026-01-01T00:00:00.000Z"),
+        }],
+      });
+
+      // Assert
+      assertEquals(expiresAt, new Date("2026-01-01T00:00:01.000Z"));
     });
   });
 
@@ -106,7 +192,7 @@ describe("db/actions.ts", () => {
           }),
         }),
       };
-      using _transactionStub = stubTransaction(fakeTx);
+      const dbActions = createDbActions(createFakeDbWithTransaction(fakeTx));
 
       // Act
       const result = await dbActions.finalizeMatchRankSnapshots({
@@ -129,6 +215,47 @@ describe("db/actions.ts", () => {
       assertEquals(result.before, [existingBefore]);
       assertEquals(result.after[0].phase, "after");
       assertEquals(result.after[0].leaguePoints, 19);
+    });
+  });
+
+  describe("upsertMatchWatcher", () => {
+    test("監視上限を指定して新規対象を追加するとき、指定上限を超える場合はエラーにする", async () => {
+      // Arrange
+      const fakeTx = {
+        insert: () => ({
+          values: () => ({
+            onConflictDoNothing: () => ({
+              execute: () => Promise.resolve(),
+            }),
+            onConflictDoUpdate: () => ({
+              execute: () => Promise.resolve(),
+            }),
+          }),
+        }),
+        query: {
+          riotAccounts: {
+            findFirst: () => Promise.resolve({ discordId: "target-2" }),
+          },
+          matchWatchers: {
+            findMany: () => Promise.resolve([{ targetDiscordId: "target-1" }]),
+          },
+        },
+      };
+      const dbActions = createDbActions(createFakeDbWithTransaction(fakeTx), {
+        matchWatcherMaxEnabledPerGuild: 1,
+      });
+
+      // Act & Assert
+      await assertRejects(
+        () =>
+          dbActions.upsertMatchWatcher({
+            guildId: "guild-1",
+            targetDiscordId: "target-2",
+            requesterId: "requester-1",
+            channelId: "channel-1",
+          }),
+        MatchWatcherLimitError,
+      );
     });
   });
 });

--- a/api/src/db/actions.test.ts
+++ b/api/src/db/actions.test.ts
@@ -28,29 +28,32 @@ describe("db/actions.ts", () => {
     test("DB接続先を指定してactionsを生成するとき、指定したDBだけを更新する", async () => {
       // Arrange
       const connectionA = createDb({ url: "file::memory:", logger: false });
-      const connectionB = createDb({ url: "file::memory:", logger: false });
       try {
-        await createUsersTable(connectionA);
-        await createUsersTable(connectionB);
-        const actionsA = createDbActions(connectionA.db);
-        const actionsB = createDbActions(connectionB.db);
+        const connectionB = createDb({ url: "file::memory:", logger: false });
+        try {
+          await createUsersTable(connectionA);
+          await createUsersTable(connectionB);
+          const actionsA = createDbActions(connectionA.db);
+          const actionsB = createDbActions(connectionB.db);
 
-        // Act
-        await actionsA.upsertUser("user-a");
-        await actionsB.upsertUser("user-b");
-        const resultA = await connectionA.client.execute(
-          "SELECT discord_id FROM users ORDER BY discord_id",
-        );
-        const resultB = await connectionB.client.execute(
-          "SELECT discord_id FROM users ORDER BY discord_id",
-        );
+          // Act
+          await actionsA.upsertUser("user-a");
+          await actionsB.upsertUser("user-b");
+          const resultA = await connectionA.client.execute(
+            "SELECT discord_id FROM users ORDER BY discord_id",
+          );
+          const resultB = await connectionB.client.execute(
+            "SELECT discord_id FROM users ORDER BY discord_id",
+          );
 
-        // Assert
-        assertEquals(resultA.rows.map((row) => row.discord_id), ["user-a"]);
-        assertEquals(resultB.rows.map((row) => row.discord_id), ["user-b"]);
+          // Assert
+          assertEquals(resultA.rows.map((row) => row.discord_id), ["user-a"]);
+          assertEquals(resultB.rows.map((row) => row.discord_id), ["user-b"]);
+        } finally {
+          connectionB.close();
+        }
       } finally {
         connectionA.close();
-        connectionB.close();
       }
     });
   });

--- a/api/src/db/actions.ts
+++ b/api/src/db/actions.ts
@@ -1,7 +1,7 @@
 import { and, eq, gte, lte } from "drizzle-orm";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
-import { db } from "./index.ts";
+import type { Database } from "./index.ts";
 import {
   authStates,
   customGameEvents,
@@ -47,632 +47,688 @@ const matchRankSnapshotInsertSchema = createInsertSchema(matchRankSnapshots);
 const DEFAULT_MATCH_WATCH_MAX_ENABLED_PER_GUILD = 20;
 const DEFAULT_PENDING_RANK_SNAPSHOT_TTL_MS = 6 * 60 * 60 * 1000;
 
-function numberEnv(name: string, fallback: number) {
-  const value = Number(Deno.env.get(name));
+export type DbActionsConfig = {
+  matchWatcherMaxEnabledPerGuild: number;
+  pendingRankSnapshotTtlMs: number;
+};
+
+type EnvReader = {
+  get(name: string): string | undefined;
+};
+
+function numberEnv(env: EnvReader, name: string, fallback: number) {
+  const value = Number(env.get(name));
   return Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
-async function upsertUser(userId: string) {
-  const user = { discordId: userId };
-  const parsed = userInsertSchema.parse(user);
-  await db.insert(users).values(parsed).onConflictDoNothing().execute();
-  const result = await db.query.users.findFirst({
-    where: eq(users.discordId, userId),
-  });
-  if (!result) {
-    throw new Error("Failed to upsert user");
-  }
-  return result;
-}
-
-async function ensureGuild(guildId: string) {
-  const payload = guildInsertSchema.parse({ id: guildId });
-  await db.insert(guilds).values(payload).onConflictDoNothing().execute();
-}
-
-async function deleteUser(userId: string) {
-  await db.delete(users).where(eq(users.discordId, userId)).execute();
-}
-
-async function setMainRole(userId: string, guildId: string, role: Lane) {
-  await db.transaction(async (tx) => {
-    // ユーザーが存在しない場合は作成する
-    const userPayload = userInsertSchema.parse({ discordId: userId });
-    await tx.insert(users).values(userPayload).onConflictDoNothing().execute();
-
-    // ギルドが存在しない場合は作成する
-    const guildPayload = guildInsertSchema.parse({ id: guildId });
-    await tx.insert(guilds).values(guildPayload).onConflictDoNothing()
-      .execute();
-
-    // ユーザーのギルドプロファイル（メインロール）を更新または作成する
-    const profilePayload = userGuildProfileInsertSchema.parse({
-      userId,
-      guildId,
-      mainRole: role,
-    });
-
-    await tx.insert(userGuildProfiles).values(profilePayload)
-      .onConflictDoUpdate(
-        {
-          target: [userGuildProfiles.userId, userGuildProfiles.guildId],
-          set: {
-            mainRole: role,
-            updatedAt: new Date(),
-          },
-        },
-      ).execute();
-  });
-}
-
-async function createCustomGameEvent(event: {
-  name: string;
-  guildId: string;
-  creatorId: string;
-  discordScheduledEventId: string;
-  recruitmentMessageId: string;
-  scheduledStartAt: Date;
-}) {
-  await db.transaction(async (tx) => {
-    // ユーザーが存在しない場合は作成する
-    const userPayload = userInsertSchema.parse({ discordId: event.creatorId });
-    await tx.insert(users).values(userPayload).onConflictDoNothing().execute();
-
-    // ギルドが存在しない場合は作成する
-    const guildPayload = guildInsertSchema.parse({ id: event.guildId });
-    await tx.insert(guilds).values(guildPayload).onConflictDoNothing()
-      .execute();
-
-    // カスタムゲームイベントを作成する
-    const parsedEvent = customGameEventInsertSchema.parse(event);
-    await tx.insert(customGameEvents).values(parsedEvent).execute();
-  });
-}
-
-async function getCustomGameEventsByCreatorId(creatorId: string) {
-  return await db.query.customGameEvents.findMany({
-    where: eq(customGameEvents.creatorId, creatorId),
-  });
-}
-
-async function deleteCustomGameEventByDiscordEventId(discordEventId: string) {
-  await db.delete(customGameEvents).where(
-    eq(customGameEvents.discordScheduledEventId, discordEventId),
-  ).execute();
-}
-
-async function getEventStartingTodayByCreatorId(creatorId: string) {
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-
-  const todayEnd = new Date();
-  todayEnd.setHours(23, 59, 59, 999);
-
-  return await db.query.customGameEvents.findFirst({
-    where: and(
-      eq(customGameEvents.creatorId, creatorId),
-      gte(customGameEvents.scheduledStartAt, todayStart),
-      lte(customGameEvents.scheduledStartAt, todayEnd),
+export function createDbActionsConfigFromEnv(
+  env: EnvReader = Deno.env,
+): DbActionsConfig {
+  return {
+    matchWatcherMaxEnabledPerGuild: numberEnv(
+      env,
+      "MATCH_WATCH_MAX_ENABLED_PER_GUILD",
+      DEFAULT_MATCH_WATCH_MAX_ENABLED_PER_GUILD,
     ),
-  });
+    pendingRankSnapshotTtlMs: numberEnv(
+      env,
+      "PENDING_RANK_SNAPSHOT_TTL_MS",
+      DEFAULT_PENDING_RANK_SNAPSHOT_TTL_MS,
+    ),
+  };
 }
 
-async function createMatchParticipant(
-  participantData: z.infer<typeof matchParticipantInsertSchema>,
-) {
-  // 存在チェック
-  const userExists = await db.query.users.findFirst({
-    where: eq(users.discordId, participantData.userId),
-  });
-  if (!userExists) {
-    throw new RecordNotFoundError(
-      `User with id ${participantData.userId} not found`,
-    );
-  }
-
-  const matchExists = await db.query.matches.findFirst({
-    where: eq(matches.id, participantData.matchId),
-  });
-  if (!matchExists) {
-    throw new RecordNotFoundError(
-      `Match with id ${participantData.matchId} not found`,
-    );
-  }
-
-  const parsed = matchParticipantInsertSchema.parse(participantData);
-  const result = await db.insert(matchParticipants).values(parsed).returning({
-    id: matchParticipants.id,
-  });
-  return result[0];
-}
-
-type RankSnapshotPayload = {
-  queueType: RankedQueueType;
-  tier: string | null;
-  rank: string | null;
-  leaguePoints: number | null;
-  wins: number | null;
-  losses: number | null;
-  fetchedAt?: Date;
+const DEFAULT_DB_ACTIONS_CONFIG: DbActionsConfig = {
+  matchWatcherMaxEnabledPerGuild: DEFAULT_MATCH_WATCH_MAX_ENABLED_PER_GUILD,
+  pendingRankSnapshotTtlMs: DEFAULT_PENDING_RANK_SNAPSHOT_TTL_MS,
 };
 
-function pendingRankSnapshotExpiresAt(fetchedAt: Date) {
-  return new Date(fetchedAt.getTime() + DEFAULT_PENDING_RANK_SNAPSHOT_TTL_MS);
-}
+export function createDbActions(
+  database: Database,
+  config: Partial<DbActionsConfig> = {},
+) {
+  const resolvedConfig = { ...DEFAULT_DB_ACTIONS_CONFIG, ...config };
 
-async function upsertPendingRankSnapshots(input: {
-  platform: RiotPlatform;
-  gameId: string;
-  puuid: string;
-  snapshots: RankSnapshotPayload[];
-}) {
-  const now = new Date();
-  await db.transaction(async (tx) => {
-    await tx.delete(pendingMatchRankSnapshots).where(
-      lte(pendingMatchRankSnapshots.expiresAt, now),
-    ).execute();
-
-    for (const snapshot of input.snapshots) {
-      const fetchedAt = snapshot.fetchedAt ?? now;
-      const payload = pendingMatchRankSnapshotInsertSchema.parse({
-        platform: input.platform,
-        gameId: input.gameId,
-        puuid: input.puuid,
-        queueType: snapshot.queueType,
-        tier: snapshot.tier,
-        rank: snapshot.rank,
-        leaguePoints: snapshot.leaguePoints,
-        wins: snapshot.wins,
-        losses: snapshot.losses,
-        fetchedAt,
-        expiresAt: pendingRankSnapshotExpiresAt(fetchedAt),
-      });
-      await tx.insert(pendingMatchRankSnapshots).values(payload)
-        .onConflictDoUpdate({
-          target: [
-            pendingMatchRankSnapshots.platform,
-            pendingMatchRankSnapshots.gameId,
-            pendingMatchRankSnapshots.puuid,
-            pendingMatchRankSnapshots.queueType,
-          ],
-          set: {
-            tier: payload.tier,
-            rank: payload.rank,
-            leaguePoints: payload.leaguePoints,
-            wins: payload.wins,
-            losses: payload.losses,
-            fetchedAt: payload.fetchedAt,
-            expiresAt: payload.expiresAt,
-          },
-        }).execute();
+  async function upsertUser(userId: string) {
+    const user = { discordId: userId };
+    const parsed = userInsertSchema.parse(user);
+    await database.insert(users).values(parsed).onConflictDoNothing().execute();
+    const result = await database.query.users.findFirst({
+      where: eq(users.discordId, userId),
+    });
+    if (!result) {
+      throw new Error("Failed to upsert user");
     }
-  });
-}
+    return result;
+  }
 
-async function finalizeMatchRankSnapshots(input: {
-  matchId: string;
-  platform: RiotPlatform;
-  gameId: string;
-  puuid: string;
-  snapshots: RankSnapshotPayload[];
-}) {
-  return await db.transaction(async (tx) => {
-    await tx.insert(matches).values({ id: input.matchId })
-      .onConflictDoNothing()
+  async function ensureGuild(guildId: string) {
+    const payload = guildInsertSchema.parse({ id: guildId });
+    await database.insert(guilds).values(payload).onConflictDoNothing()
       .execute();
+  }
 
-    const beforeSnapshots = await tx.query.pendingMatchRankSnapshots.findMany({
+  async function deleteUser(userId: string) {
+    await database.delete(users).where(eq(users.discordId, userId)).execute();
+  }
+
+  async function setMainRole(userId: string, guildId: string, role: Lane) {
+    await database.transaction(async (tx) => {
+      // ユーザーが存在しない場合は作成する
+      const userPayload = userInsertSchema.parse({ discordId: userId });
+      await tx.insert(users).values(userPayload).onConflictDoNothing()
+        .execute();
+
+      // ギルドが存在しない場合は作成する
+      const guildPayload = guildInsertSchema.parse({ id: guildId });
+      await tx.insert(guilds).values(guildPayload).onConflictDoNothing()
+        .execute();
+
+      // ユーザーのギルドプロファイル（メインロール）を更新または作成する
+      const profilePayload = userGuildProfileInsertSchema.parse({
+        userId,
+        guildId,
+        mainRole: role,
+      });
+
+      await tx.insert(userGuildProfiles).values(profilePayload)
+        .onConflictDoUpdate(
+          {
+            target: [userGuildProfiles.userId, userGuildProfiles.guildId],
+            set: {
+              mainRole: role,
+              updatedAt: new Date(),
+            },
+          },
+        ).execute();
+    });
+  }
+
+  async function createCustomGameEvent(event: {
+    name: string;
+    guildId: string;
+    creatorId: string;
+    discordScheduledEventId: string;
+    recruitmentMessageId: string;
+    scheduledStartAt: Date;
+  }) {
+    await database.transaction(async (tx) => {
+      // ユーザーが存在しない場合は作成する
+      const userPayload = userInsertSchema.parse({
+        discordId: event.creatorId,
+      });
+      await tx.insert(users).values(userPayload).onConflictDoNothing()
+        .execute();
+
+      // ギルドが存在しない場合は作成する
+      const guildPayload = guildInsertSchema.parse({ id: event.guildId });
+      await tx.insert(guilds).values(guildPayload).onConflictDoNothing()
+        .execute();
+
+      // カスタムゲームイベントを作成する
+      const parsedEvent = customGameEventInsertSchema.parse(event);
+      await tx.insert(customGameEvents).values(parsedEvent).execute();
+    });
+  }
+
+  async function getCustomGameEventsByCreatorId(creatorId: string) {
+    return await database.query.customGameEvents.findMany({
+      where: eq(customGameEvents.creatorId, creatorId),
+    });
+  }
+
+  async function deleteCustomGameEventByDiscordEventId(discordEventId: string) {
+    await database.delete(customGameEvents).where(
+      eq(customGameEvents.discordScheduledEventId, discordEventId),
+    ).execute();
+  }
+
+  async function getEventStartingTodayByCreatorId(creatorId: string) {
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+
+    const todayEnd = new Date();
+    todayEnd.setHours(23, 59, 59, 999);
+
+    return await database.query.customGameEvents.findFirst({
       where: and(
-        eq(pendingMatchRankSnapshots.platform, input.platform),
-        eq(pendingMatchRankSnapshots.gameId, input.gameId),
-        eq(pendingMatchRankSnapshots.puuid, input.puuid),
+        eq(customGameEvents.creatorId, creatorId),
+        gte(customGameEvents.scheduledStartAt, todayStart),
+        lte(customGameEvents.scheduledStartAt, todayEnd),
       ),
     });
+  }
 
-    const savedBefore = [];
-    for (const snapshot of beforeSnapshots) {
-      const payload = matchRankSnapshotInsertSchema.parse({
-        matchId: input.matchId,
-        platform: snapshot.platform,
-        puuid: snapshot.puuid,
-        queueType: snapshot.queueType,
-        phase: "before",
-        tier: snapshot.tier,
-        rank: snapshot.rank,
-        leaguePoints: snapshot.leaguePoints,
-        wins: snapshot.wins,
-        losses: snapshot.losses,
-        fetchedAt: snapshot.fetchedAt,
-      });
-      const [saved] = await tx.insert(matchRankSnapshots).values(payload)
-        .onConflictDoUpdate({
-          target: [
-            matchRankSnapshots.matchId,
-            matchRankSnapshots.puuid,
-            matchRankSnapshots.queueType,
-            matchRankSnapshots.phase,
-          ],
-          set: {
-            tier: payload.tier,
-            rank: payload.rank,
-            leaguePoints: payload.leaguePoints,
-            wins: payload.wins,
-            losses: payload.losses,
-            fetchedAt: payload.fetchedAt,
-          },
-        })
-        .returning();
-      savedBefore.push(saved);
-    }
-
-    const reusableBefore = savedBefore.length > 0 ? savedBefore : await tx.query
-      .matchRankSnapshots.findMany({
-        where: and(
-          eq(matchRankSnapshots.matchId, input.matchId),
-          eq(matchRankSnapshots.puuid, input.puuid),
-          eq(matchRankSnapshots.phase, "before"),
-        ),
-      });
-
-    const savedAfter = [];
-    const now = new Date();
-    for (const snapshot of input.snapshots) {
-      const payload = matchRankSnapshotInsertSchema.parse({
-        matchId: input.matchId,
-        platform: input.platform,
-        puuid: input.puuid,
-        queueType: snapshot.queueType,
-        phase: "after",
-        tier: snapshot.tier,
-        rank: snapshot.rank,
-        leaguePoints: snapshot.leaguePoints,
-        wins: snapshot.wins,
-        losses: snapshot.losses,
-        fetchedAt: snapshot.fetchedAt ?? now,
-      });
-      const [saved] = await tx.insert(matchRankSnapshots).values(payload)
-        .onConflictDoUpdate({
-          target: [
-            matchRankSnapshots.matchId,
-            matchRankSnapshots.puuid,
-            matchRankSnapshots.queueType,
-            matchRankSnapshots.phase,
-          ],
-          set: {
-            tier: payload.tier,
-            rank: payload.rank,
-            leaguePoints: payload.leaguePoints,
-            wins: payload.wins,
-            losses: payload.losses,
-            fetchedAt: payload.fetchedAt,
-          },
-        })
-        .returning();
-      savedAfter.push(saved);
-    }
-
-    await tx.delete(pendingMatchRankSnapshots).where(
-      and(
-        eq(pendingMatchRankSnapshots.platform, input.platform),
-        eq(pendingMatchRankSnapshots.gameId, input.gameId),
-        eq(pendingMatchRankSnapshots.puuid, input.puuid),
-      ),
-    ).execute();
-
-    return { before: reusableBefore, after: savedAfter };
-  });
-}
-
-async function upsertExternalMatchDetail(input: {
-  matchId: string;
-  provider: "opgg";
-  providerRegion: string;
-  providerMatchId: string;
-  detailUrl: string;
-  providerCreatedAt: Date;
-  averageTier: string | null;
-  participant?: {
-    puuid: string;
-    participantId: number | null;
-    laneScore: number | null;
-  };
-}) {
-  await db.transaction(async (tx) => {
-    await tx.insert(matches).values({ id: input.matchId })
-      .onConflictDoNothing()
-      .execute();
-
-    const now = new Date();
-    const detailPayload = externalMatchDetailInsertSchema.parse({
-      matchId: input.matchId,
-      provider: input.provider,
-      providerRegion: input.providerRegion,
-      providerMatchId: input.providerMatchId,
-      detailUrl: input.detailUrl,
-      providerCreatedAt: input.providerCreatedAt,
-      averageTier: input.averageTier,
-      fetchedAt: now,
+  async function createMatchParticipant(
+    participantData: z.infer<typeof matchParticipantInsertSchema>,
+  ) {
+    // 存在チェック
+    const userExists = await database.query.users.findFirst({
+      where: eq(users.discordId, participantData.userId),
     });
-    await tx.insert(externalMatchDetails).values(detailPayload)
-      .onConflictDoUpdate({
-        target: [externalMatchDetails.matchId, externalMatchDetails.provider],
-        set: {
-          providerRegion: detailPayload.providerRegion,
-          providerMatchId: detailPayload.providerMatchId,
-          detailUrl: detailPayload.detailUrl,
-          providerCreatedAt: detailPayload.providerCreatedAt,
-          averageTier: detailPayload.averageTier,
-          fetchedAt: detailPayload.fetchedAt,
-        },
-      })
-      .execute();
-
-    if (!input.participant) return;
-
-    const participantPayload = externalMatchParticipantDetailInsertSchema.parse(
-      {
-        matchId: input.matchId,
-        provider: input.provider,
-        puuid: input.participant.puuid,
-        participantId: input.participant.participantId,
-        laneScore: input.participant.laneScore,
-        fetchedAt: now,
-      },
-    );
-    await tx.insert(externalMatchParticipantDetails).values(participantPayload)
-      .onConflictDoUpdate({
-        target: [
-          externalMatchParticipantDetails.matchId,
-          externalMatchParticipantDetails.provider,
-          externalMatchParticipantDetails.puuid,
-        ],
-        set: {
-          participantId: participantPayload.participantId,
-          laneScore: participantPayload.laneScore,
-          fetchedAt: participantPayload.fetchedAt,
-        },
-      })
-      .execute();
-  });
-}
-
-async function getAuthState(state: string) {
-  return await db.query.authStates.findFirst({
-    where: eq(authStates.state, state),
-  });
-}
-
-async function deleteAuthState(state: string) {
-  await db.delete(authStates).where(eq(authStates.state, state)).execute();
-}
-
-async function updateUserRiotId(discordId: string, riotId: string) {
-  await db.update(users).set({ riotId }).where(eq(users.discordId, discordId))
-    .execute();
-}
-
-async function linkUserWithRiotId(discordId: string, riotId: string) {
-  const payload = userInsertSchema.parse({ discordId, riotId });
-
-  await db.insert(users).values(payload).onConflictDoUpdate({
-    target: users.discordId,
-    set: { riotId },
-  }).execute();
-}
-
-async function upsertRiotAccount(account: {
-  discordId: string;
-  puuid: string;
-  gameName: string;
-  tagLine: string;
-  platform: RiotPlatform;
-  region: RiotRegion;
-}) {
-  await db.transaction(async (tx) => {
-    const userPayload = userInsertSchema.parse({
-      discordId: account.discordId,
-      riotId: account.puuid,
-    });
-    await tx.insert(users).values(userPayload).onConflictDoUpdate({
-      target: users.discordId,
-      set: { riotId: account.puuid },
-    }).execute();
-
-    const payload = riotAccountInsertSchema.parse(account);
-    await tx.insert(riotAccounts).values(payload).onConflictDoUpdate({
-      target: riotAccounts.discordId,
-      set: {
-        puuid: account.puuid,
-        gameName: account.gameName,
-        tagLine: account.tagLine,
-        platform: account.platform,
-        region: account.region,
-        updatedAt: new Date(),
-      },
-    }).execute();
-  });
-}
-
-async function getRiotAccountByDiscordId(discordId: string) {
-  return await db.query.riotAccounts.findFirst({
-    where: eq(riotAccounts.discordId, discordId),
-  });
-}
-
-async function getRiotStaticDataCache(key: string) {
-  return await db.query.riotStaticDataCache.findFirst({
-    where: eq(riotStaticDataCache.key, key),
-  });
-}
-
-async function upsertRiotStaticDataCache(cache: {
-  key: string;
-  version: string;
-  value: string;
-}) {
-  const payload = riotStaticDataCacheInsertSchema.parse(cache);
-  await db.insert(riotStaticDataCache).values(payload).onConflictDoUpdate({
-    target: riotStaticDataCache.key,
-    set: {
-      version: cache.version,
-      value: cache.value,
-      updatedAt: new Date(),
-    },
-  }).execute();
-}
-
-async function upsertMatchWatcher(watcher: {
-  guildId: string;
-  targetDiscordId: string;
-  requesterId: string;
-  channelId: string;
-}) {
-  const maxEnabledPerGuild = numberEnv(
-    "MATCH_WATCH_MAX_ENABLED_PER_GUILD",
-    DEFAULT_MATCH_WATCH_MAX_ENABLED_PER_GUILD,
-  );
-
-  await db.transaction(async (tx) => {
-    await tx.insert(guilds).values({ id: watcher.guildId })
-      .onConflictDoNothing()
-      .execute();
-    await tx.insert(users).values({ discordId: watcher.requesterId })
-      .onConflictDoNothing().execute();
-
-    const targetAccount = await tx.query.riotAccounts.findFirst({
-      where: eq(riotAccounts.discordId, watcher.targetDiscordId),
-    });
-    if (!targetAccount) {
+    if (!userExists) {
       throw new RecordNotFoundError(
-        `Riot account for ${watcher.targetDiscordId} not found`,
+        `User with id ${participantData.userId} not found`,
       );
     }
 
-    const enabledWatchers = await tx.query.matchWatchers.findMany({
+    const matchExists = await database.query.matches.findFirst({
+      where: eq(matches.id, participantData.matchId),
+    });
+    if (!matchExists) {
+      throw new RecordNotFoundError(
+        `Match with id ${participantData.matchId} not found`,
+      );
+    }
+
+    const parsed = matchParticipantInsertSchema.parse(participantData);
+    const result = await database.insert(matchParticipants).values(parsed)
+      .returning({
+        id: matchParticipants.id,
+      });
+    return result[0];
+  }
+
+  type RankSnapshotPayload = {
+    queueType: RankedQueueType;
+    tier: string | null;
+    rank: string | null;
+    leaguePoints: number | null;
+    wins: number | null;
+    losses: number | null;
+    fetchedAt?: Date;
+  };
+
+  function pendingRankSnapshotExpiresAt(fetchedAt: Date) {
+    return new Date(
+      fetchedAt.getTime() + resolvedConfig.pendingRankSnapshotTtlMs,
+    );
+  }
+
+  async function upsertPendingRankSnapshots(input: {
+    platform: RiotPlatform;
+    gameId: string;
+    puuid: string;
+    snapshots: RankSnapshotPayload[];
+  }) {
+    const now = new Date();
+    await database.transaction(async (tx) => {
+      await tx.delete(pendingMatchRankSnapshots).where(
+        lte(pendingMatchRankSnapshots.expiresAt, now),
+      ).execute();
+
+      for (const snapshot of input.snapshots) {
+        const fetchedAt = snapshot.fetchedAt ?? now;
+        const payload = pendingMatchRankSnapshotInsertSchema.parse({
+          platform: input.platform,
+          gameId: input.gameId,
+          puuid: input.puuid,
+          queueType: snapshot.queueType,
+          tier: snapshot.tier,
+          rank: snapshot.rank,
+          leaguePoints: snapshot.leaguePoints,
+          wins: snapshot.wins,
+          losses: snapshot.losses,
+          fetchedAt,
+          expiresAt: pendingRankSnapshotExpiresAt(fetchedAt),
+        });
+        await tx.insert(pendingMatchRankSnapshots).values(payload)
+          .onConflictDoUpdate({
+            target: [
+              pendingMatchRankSnapshots.platform,
+              pendingMatchRankSnapshots.gameId,
+              pendingMatchRankSnapshots.puuid,
+              pendingMatchRankSnapshots.queueType,
+            ],
+            set: {
+              tier: payload.tier,
+              rank: payload.rank,
+              leaguePoints: payload.leaguePoints,
+              wins: payload.wins,
+              losses: payload.losses,
+              fetchedAt: payload.fetchedAt,
+              expiresAt: payload.expiresAt,
+            },
+          }).execute();
+      }
+    });
+  }
+
+  async function finalizeMatchRankSnapshots(input: {
+    matchId: string;
+    platform: RiotPlatform;
+    gameId: string;
+    puuid: string;
+    snapshots: RankSnapshotPayload[];
+  }) {
+    return await database.transaction(async (tx) => {
+      await tx.insert(matches).values({ id: input.matchId })
+        .onConflictDoNothing()
+        .execute();
+
+      const beforeSnapshots = await tx.query.pendingMatchRankSnapshots.findMany(
+        {
+          where: and(
+            eq(pendingMatchRankSnapshots.platform, input.platform),
+            eq(pendingMatchRankSnapshots.gameId, input.gameId),
+            eq(pendingMatchRankSnapshots.puuid, input.puuid),
+          ),
+        },
+      );
+
+      const savedBefore = [];
+      for (const snapshot of beforeSnapshots) {
+        const payload = matchRankSnapshotInsertSchema.parse({
+          matchId: input.matchId,
+          platform: snapshot.platform,
+          puuid: snapshot.puuid,
+          queueType: snapshot.queueType,
+          phase: "before",
+          tier: snapshot.tier,
+          rank: snapshot.rank,
+          leaguePoints: snapshot.leaguePoints,
+          wins: snapshot.wins,
+          losses: snapshot.losses,
+          fetchedAt: snapshot.fetchedAt,
+        });
+        const [saved] = await tx.insert(matchRankSnapshots).values(payload)
+          .onConflictDoUpdate({
+            target: [
+              matchRankSnapshots.matchId,
+              matchRankSnapshots.puuid,
+              matchRankSnapshots.queueType,
+              matchRankSnapshots.phase,
+            ],
+            set: {
+              tier: payload.tier,
+              rank: payload.rank,
+              leaguePoints: payload.leaguePoints,
+              wins: payload.wins,
+              losses: payload.losses,
+              fetchedAt: payload.fetchedAt,
+            },
+          })
+          .returning();
+        savedBefore.push(saved);
+      }
+
+      const reusableBefore = savedBefore.length > 0
+        ? savedBefore
+        : await tx.query
+          .matchRankSnapshots.findMany({
+            where: and(
+              eq(matchRankSnapshots.matchId, input.matchId),
+              eq(matchRankSnapshots.puuid, input.puuid),
+              eq(matchRankSnapshots.phase, "before"),
+            ),
+          });
+
+      const savedAfter = [];
+      const now = new Date();
+      for (const snapshot of input.snapshots) {
+        const payload = matchRankSnapshotInsertSchema.parse({
+          matchId: input.matchId,
+          platform: input.platform,
+          puuid: input.puuid,
+          queueType: snapshot.queueType,
+          phase: "after",
+          tier: snapshot.tier,
+          rank: snapshot.rank,
+          leaguePoints: snapshot.leaguePoints,
+          wins: snapshot.wins,
+          losses: snapshot.losses,
+          fetchedAt: snapshot.fetchedAt ?? now,
+        });
+        const [saved] = await tx.insert(matchRankSnapshots).values(payload)
+          .onConflictDoUpdate({
+            target: [
+              matchRankSnapshots.matchId,
+              matchRankSnapshots.puuid,
+              matchRankSnapshots.queueType,
+              matchRankSnapshots.phase,
+            ],
+            set: {
+              tier: payload.tier,
+              rank: payload.rank,
+              leaguePoints: payload.leaguePoints,
+              wins: payload.wins,
+              losses: payload.losses,
+              fetchedAt: payload.fetchedAt,
+            },
+          })
+          .returning();
+        savedAfter.push(saved);
+      }
+
+      await tx.delete(pendingMatchRankSnapshots).where(
+        and(
+          eq(pendingMatchRankSnapshots.platform, input.platform),
+          eq(pendingMatchRankSnapshots.gameId, input.gameId),
+          eq(pendingMatchRankSnapshots.puuid, input.puuid),
+        ),
+      ).execute();
+
+      return { before: reusableBefore, after: savedAfter };
+    });
+  }
+
+  async function upsertExternalMatchDetail(input: {
+    matchId: string;
+    provider: "opgg";
+    providerRegion: string;
+    providerMatchId: string;
+    detailUrl: string;
+    providerCreatedAt: Date;
+    averageTier: string | null;
+    participant?: {
+      puuid: string;
+      participantId: number | null;
+      laneScore: number | null;
+    };
+  }) {
+    await database.transaction(async (tx) => {
+      await tx.insert(matches).values({ id: input.matchId })
+        .onConflictDoNothing()
+        .execute();
+
+      const now = new Date();
+      const detailPayload = externalMatchDetailInsertSchema.parse({
+        matchId: input.matchId,
+        provider: input.provider,
+        providerRegion: input.providerRegion,
+        providerMatchId: input.providerMatchId,
+        detailUrl: input.detailUrl,
+        providerCreatedAt: input.providerCreatedAt,
+        averageTier: input.averageTier,
+        fetchedAt: now,
+      });
+      await tx.insert(externalMatchDetails).values(detailPayload)
+        .onConflictDoUpdate({
+          target: [externalMatchDetails.matchId, externalMatchDetails.provider],
+          set: {
+            providerRegion: detailPayload.providerRegion,
+            providerMatchId: detailPayload.providerMatchId,
+            detailUrl: detailPayload.detailUrl,
+            providerCreatedAt: detailPayload.providerCreatedAt,
+            averageTier: detailPayload.averageTier,
+            fetchedAt: detailPayload.fetchedAt,
+          },
+        })
+        .execute();
+
+      if (!input.participant) return;
+
+      const participantPayload = externalMatchParticipantDetailInsertSchema
+        .parse(
+          {
+            matchId: input.matchId,
+            provider: input.provider,
+            puuid: input.participant.puuid,
+            participantId: input.participant.participantId,
+            laneScore: input.participant.laneScore,
+            fetchedAt: now,
+          },
+        );
+      await tx.insert(externalMatchParticipantDetails).values(
+        participantPayload,
+      )
+        .onConflictDoUpdate({
+          target: [
+            externalMatchParticipantDetails.matchId,
+            externalMatchParticipantDetails.provider,
+            externalMatchParticipantDetails.puuid,
+          ],
+          set: {
+            participantId: participantPayload.participantId,
+            laneScore: participantPayload.laneScore,
+            fetchedAt: participantPayload.fetchedAt,
+          },
+        })
+        .execute();
+    });
+  }
+
+  async function getAuthState(state: string) {
+    return await database.query.authStates.findFirst({
+      where: eq(authStates.state, state),
+    });
+  }
+
+  async function deleteAuthState(state: string) {
+    await database.delete(authStates).where(eq(authStates.state, state))
+      .execute();
+  }
+
+  async function updateUserRiotId(discordId: string, riotId: string) {
+    await database.update(users).set({ riotId }).where(
+      eq(users.discordId, discordId),
+    )
+      .execute();
+  }
+
+  async function linkUserWithRiotId(discordId: string, riotId: string) {
+    const payload = userInsertSchema.parse({ discordId, riotId });
+
+    await database.insert(users).values(payload).onConflictDoUpdate({
+      target: users.discordId,
+      set: { riotId },
+    }).execute();
+  }
+
+  async function upsertRiotAccount(account: {
+    discordId: string;
+    puuid: string;
+    gameName: string;
+    tagLine: string;
+    platform: RiotPlatform;
+    region: RiotRegion;
+  }) {
+    await database.transaction(async (tx) => {
+      const userPayload = userInsertSchema.parse({
+        discordId: account.discordId,
+        riotId: account.puuid,
+      });
+      await tx.insert(users).values(userPayload).onConflictDoUpdate({
+        target: users.discordId,
+        set: { riotId: account.puuid },
+      }).execute();
+
+      const payload = riotAccountInsertSchema.parse(account);
+      await tx.insert(riotAccounts).values(payload).onConflictDoUpdate({
+        target: riotAccounts.discordId,
+        set: {
+          puuid: account.puuid,
+          gameName: account.gameName,
+          tagLine: account.tagLine,
+          platform: account.platform,
+          region: account.region,
+          updatedAt: new Date(),
+        },
+      }).execute();
+    });
+  }
+
+  async function getRiotAccountByDiscordId(discordId: string) {
+    return await database.query.riotAccounts.findFirst({
+      where: eq(riotAccounts.discordId, discordId),
+    });
+  }
+
+  async function getRiotStaticDataCache(key: string) {
+    return await database.query.riotStaticDataCache.findFirst({
+      where: eq(riotStaticDataCache.key, key),
+    });
+  }
+
+  async function upsertRiotStaticDataCache(cache: {
+    key: string;
+    version: string;
+    value: string;
+  }) {
+    const payload = riotStaticDataCacheInsertSchema.parse(cache);
+    await database.insert(riotStaticDataCache).values(payload)
+      .onConflictDoUpdate({
+        target: riotStaticDataCache.key,
+        set: {
+          version: cache.version,
+          value: cache.value,
+          updatedAt: new Date(),
+        },
+      }).execute();
+  }
+
+  async function upsertMatchWatcher(watcher: {
+    guildId: string;
+    targetDiscordId: string;
+    requesterId: string;
+    channelId: string;
+  }) {
+    const maxEnabledPerGuild = resolvedConfig.matchWatcherMaxEnabledPerGuild;
+
+    await database.transaction(async (tx) => {
+      await tx.insert(guilds).values({ id: watcher.guildId })
+        .onConflictDoNothing()
+        .execute();
+      await tx.insert(users).values({ discordId: watcher.requesterId })
+        .onConflictDoNothing().execute();
+
+      const targetAccount = await tx.query.riotAccounts.findFirst({
+        where: eq(riotAccounts.discordId, watcher.targetDiscordId),
+      });
+      if (!targetAccount) {
+        throw new RecordNotFoundError(
+          `Riot account for ${watcher.targetDiscordId} not found`,
+        );
+      }
+
+      const enabledWatchers = await tx.query.matchWatchers.findMany({
+        where: and(
+          eq(matchWatchers.guildId, watcher.guildId),
+          eq(matchWatchers.enabled, true),
+        ),
+      });
+      const isAlreadyEnabledTarget = enabledWatchers.some((enabledWatcher) =>
+        enabledWatcher.targetDiscordId === watcher.targetDiscordId
+      );
+      if (
+        !isAlreadyEnabledTarget && enabledWatchers.length >= maxEnabledPerGuild
+      ) {
+        throw new MatchWatcherLimitError(
+          `Enabled match watchers limit exceeded for guild ${watcher.guildId}`,
+        );
+      }
+
+      const payload = matchWatcherInsertSchema.parse({
+        ...watcher,
+        enabled: true,
+        lastState: "IDLE",
+        currentGameId: null,
+        currentMatchId: null,
+        currentNotificationMessageId: null,
+        pendingResultMatchId: null,
+        pendingResultNotificationMessageId: null,
+        pendingResultStartedAt: null,
+        gameStartedAt: null,
+        lastInGameNotifiedAt: null,
+      });
+      await tx.insert(matchWatchers).values(payload).onConflictDoUpdate({
+        target: [matchWatchers.guildId, matchWatchers.targetDiscordId],
+        set: {
+          requesterId: watcher.requesterId,
+          channelId: watcher.channelId,
+          enabled: true,
+          updatedAt: new Date(),
+        },
+      }).execute();
+    });
+  }
+
+  async function getEnabledMatchWatchers() {
+    return await database.query.matchWatchers.findMany({
+      where: eq(matchWatchers.enabled, true),
+    });
+  }
+
+  async function getEnabledMatchWatchersByGuild(guildId: string) {
+    return await database.query.matchWatchers.findMany({
       where: and(
-        eq(matchWatchers.guildId, watcher.guildId),
+        eq(matchWatchers.guildId, guildId),
         eq(matchWatchers.enabled, true),
       ),
     });
-    const isAlreadyEnabledTarget = enabledWatchers.some((enabledWatcher) =>
-      enabledWatcher.targetDiscordId === watcher.targetDiscordId
-    );
-    if (
-      !isAlreadyEnabledTarget && enabledWatchers.length >= maxEnabledPerGuild
-    ) {
-      throw new MatchWatcherLimitError(
-        `Enabled match watchers limit exceeded for guild ${watcher.guildId}`,
-      );
-    }
+  }
 
-    const payload = matchWatcherInsertSchema.parse({
-      ...watcher,
-      enabled: true,
-      lastState: "IDLE",
-      currentGameId: null,
-      currentMatchId: null,
-      currentNotificationMessageId: null,
-      pendingResultMatchId: null,
-      pendingResultNotificationMessageId: null,
-      pendingResultStartedAt: null,
-      gameStartedAt: null,
-      lastInGameNotifiedAt: null,
-    });
-    await tx.insert(matchWatchers).values(payload).onConflictDoUpdate({
-      target: [matchWatchers.guildId, matchWatchers.targetDiscordId],
-      set: {
-        requesterId: watcher.requesterId,
-        channelId: watcher.channelId,
-        enabled: true,
-        updatedAt: new Date(),
-      },
-    }).execute();
-  });
+  async function updateMatchWatcherState(
+    guildId: string,
+    targetDiscordId: string,
+    state: {
+      lastState: MatchWatcherState;
+      currentGameId?: string | null;
+      currentMatchId?: string | null;
+      currentNotificationMessageId?: string | null;
+      pendingResultMatchId?: string | null;
+      pendingResultNotificationMessageId?: string | null;
+      pendingResultStartedAt?: Date | null;
+      gameStartedAt?: Date | null;
+      lastCheckedAt?: Date | null;
+      lastInGameNotifiedAt?: Date | null;
+    },
+  ) {
+    await database.update(matchWatchers).set({
+      ...state,
+      updatedAt: new Date(),
+    }).where(
+      and(
+        eq(matchWatchers.guildId, guildId),
+        eq(matchWatchers.targetDiscordId, targetDiscordId),
+      ),
+    ).execute();
+  }
+
+  async function disableMatchWatcher(guildId: string, targetDiscordId: string) {
+    await database.update(matchWatchers).set({
+      enabled: false,
+      updatedAt: new Date(),
+    }).where(
+      and(
+        eq(matchWatchers.guildId, guildId),
+        eq(matchWatchers.targetDiscordId, targetDiscordId),
+      ),
+    ).execute();
+  }
+
+  async function createAuthState(state: string, discordId: string) {
+    await database.insert(authStates).values({ state, discordId }).execute();
+  }
+
+  return {
+    upsertUser,
+    ensureGuild,
+    deleteUser,
+    setMainRole,
+    createCustomGameEvent,
+    getCustomGameEventsByCreatorId,
+    deleteCustomGameEventByDiscordEventId,
+    getEventStartingTodayByCreatorId,
+    createMatchParticipant,
+    upsertPendingRankSnapshots,
+    finalizeMatchRankSnapshots,
+    upsertExternalMatchDetail,
+    getAuthState,
+    deleteAuthState,
+    updateUserRiotId,
+    linkUserWithRiotId,
+    upsertRiotAccount,
+    getRiotAccountByDiscordId,
+    getRiotStaticDataCache,
+    upsertRiotStaticDataCache,
+    upsertMatchWatcher,
+    getEnabledMatchWatchers,
+    getEnabledMatchWatchersByGuild,
+    updateMatchWatcherState,
+    disableMatchWatcher,
+    createAuthState,
+  };
 }
 
-async function getEnabledMatchWatchers() {
-  return await db.query.matchWatchers.findMany({
-    where: eq(matchWatchers.enabled, true),
-  });
-}
-
-async function getEnabledMatchWatchersByGuild(guildId: string) {
-  return await db.query.matchWatchers.findMany({
-    where: and(
-      eq(matchWatchers.guildId, guildId),
-      eq(matchWatchers.enabled, true),
-    ),
-  });
-}
-
-async function updateMatchWatcherState(
-  guildId: string,
-  targetDiscordId: string,
-  state: {
-    lastState: MatchWatcherState;
-    currentGameId?: string | null;
-    currentMatchId?: string | null;
-    currentNotificationMessageId?: string | null;
-    pendingResultMatchId?: string | null;
-    pendingResultNotificationMessageId?: string | null;
-    pendingResultStartedAt?: Date | null;
-    gameStartedAt?: Date | null;
-    lastCheckedAt?: Date | null;
-    lastInGameNotifiedAt?: Date | null;
-  },
-) {
-  await db.update(matchWatchers).set({
-    ...state,
-    updatedAt: new Date(),
-  }).where(
-    and(
-      eq(matchWatchers.guildId, guildId),
-      eq(matchWatchers.targetDiscordId, targetDiscordId),
-    ),
-  ).execute();
-}
-
-async function disableMatchWatcher(guildId: string, targetDiscordId: string) {
-  await db.update(matchWatchers).set({
-    enabled: false,
-    updatedAt: new Date(),
-  }).where(
-    and(
-      eq(matchWatchers.guildId, guildId),
-      eq(matchWatchers.targetDiscordId, targetDiscordId),
-    ),
-  ).execute();
-}
-
-async function createAuthState(state: string, discordId: string) {
-  await db.insert(authStates).values({ state, discordId }).execute();
-}
-
-export const dbActions = {
-  upsertUser,
-  ensureGuild,
-  deleteUser,
-  setMainRole,
-  createCustomGameEvent,
-  getCustomGameEventsByCreatorId,
-  deleteCustomGameEventByDiscordEventId,
-  getEventStartingTodayByCreatorId,
-  createMatchParticipant,
-  upsertPendingRankSnapshots,
-  finalizeMatchRankSnapshots,
-  upsertExternalMatchDetail,
-  getAuthState,
-  deleteAuthState,
-  updateUserRiotId,
-  linkUserWithRiotId,
-  upsertRiotAccount,
-  getRiotAccountByDiscordId,
-  getRiotStaticDataCache,
-  upsertRiotStaticDataCache,
-  upsertMatchWatcher,
-  getEnabledMatchWatchers,
-  getEnabledMatchWatchersByGuild,
-  updateMatchWatcherState,
-  disableMatchWatcher,
-  createAuthState,
-};
+export type DbActions = ReturnType<typeof createDbActions>;

--- a/api/src/db/default_actions.ts
+++ b/api/src/db/default_actions.ts
@@ -1,0 +1,4 @@
+import { createDbActions, createDbActionsConfigFromEnv } from "./actions.ts";
+import { db } from "./default_connection.ts";
+
+export const dbActions = createDbActions(db, createDbActionsConfigFromEnv());

--- a/api/src/db/default_connection.ts
+++ b/api/src/db/default_connection.ts
@@ -1,0 +1,15 @@
+import { createDb } from "./index.ts";
+
+function defaultDatabaseUrl() {
+  const url = Deno.env.get("DATABASE_URL");
+  if (!url) {
+    // Fallback for local development if DATABASE_URL is not set
+    console.log(
+      "DATABASE_URL not set, falling back to local file './data/sqlite.db'",
+    );
+  }
+  return url || "file:./data/sqlite.db";
+}
+
+export const dbConnection = createDb({ url: defaultDatabaseUrl() });
+export const db = dbConnection.db;

--- a/api/src/db/default_connection.ts
+++ b/api/src/db/default_connection.ts
@@ -2,12 +2,6 @@ import { createDb } from "./index.ts";
 
 function defaultDatabaseUrl() {
   const url = Deno.env.get("DATABASE_URL");
-  if (!url) {
-    // Fallback for local development if DATABASE_URL is not set
-    console.log(
-      "DATABASE_URL not set, falling back to local file './data/sqlite.db'",
-    );
-  }
   return url || "file:./data/sqlite.db";
 }
 

--- a/api/src/db/index.ts
+++ b/api/src/db/index.ts
@@ -2,16 +2,21 @@ import { drizzle } from "drizzle-orm/libsql";
 import { createClient } from "@libsql/client";
 import * as schema from "./schema.ts";
 
-const url = Deno.env.get("DATABASE_URL");
-if (!url) {
-  // Fallback for local development if DATABASE_URL is not set
-  console.log(
-    "DATABASE_URL not set, falling back to local file './data/sqlite.db'",
-  );
+export type CreateDbOptions = {
+  url: string;
+  logger?: boolean;
+};
+
+export function createDb({ url, logger = true }: CreateDbOptions) {
+  const client = createClient({ url });
+  const db = drizzle(client, { schema, logger });
+
+  return {
+    client,
+    db,
+    close: () => client.close(),
+  };
 }
 
-const client = createClient({
-  url: url || "file:./data/sqlite.db",
-});
-
-export const db = drizzle(client, { schema, logger: true });
+export type DatabaseConnection = ReturnType<typeof createDb>;
+export type Database = DatabaseConnection["db"];

--- a/api/src/riot_static_data.test.ts
+++ b/api/src/riot_static_data.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
-import { dbActions } from "./db/actions.ts";
+import { dbActions } from "./db/default_actions.ts";
 import { apiLogger } from "./logger.ts";
 import { riotStaticData } from "./riot_static_data.ts";
 

--- a/api/src/riot_static_data.ts
+++ b/api/src/riot_static_data.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { dbActions } from "./db/actions.ts";
+import { dbActions } from "./db/default_actions.ts";
 import { apiLogger } from "./logger.ts";
 
 const DEFAULT_STATIC_DATA_CACHE_TTL_MS = 24 * 60 * 60 * 1000;

--- a/api/src/routes/auth.test.ts
+++ b/api/src/routes/auth.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from "@std/testing/bdd";
 import { assert, assertEquals, assertFalse } from "@std/assert";
 import { assertSpyCall, stub } from "@std/testing/mock";
 import app from "../app.ts";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 import { rso } from "../rso.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,7 +1,7 @@
 import { Hono } from "@hono/hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 import { rso } from "../rso.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 

--- a/api/src/routes/events.test.ts
+++ b/api/src/routes/events.test.ts
@@ -4,7 +4,7 @@ import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, stub } from "@std/testing/mock";
 import { z } from "zod";
 import app from "../app.ts";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 
 describe("routes/events.ts", () => {
   const client = testClient(app);

--- a/api/src/routes/events.ts
+++ b/api/src/routes/events.ts
@@ -1,7 +1,7 @@
 import { Hono } from "@hono/hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 
 const createEventSchema = z.object({
   name: z.string(),

--- a/api/src/routes/match_watchers.test.ts
+++ b/api/src/routes/match_watchers.test.ts
@@ -3,7 +3,7 @@ import { assert, assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, stub } from "@std/testing/mock";
 import app from "../app.ts";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 import { MatchWatcherLimitError, RecordNotFoundError } from "../errors.ts";
 
 describe("routes/match_watchers.ts", () => {

--- a/api/src/routes/match_watchers.ts
+++ b/api/src/routes/match_watchers.ts
@@ -1,7 +1,7 @@
 import { Hono } from "@hono/hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 import { matchWatcherStates } from "../db/schema.ts";
 import { MatchWatcherLimitError, RecordNotFoundError } from "../errors.ts";
 

--- a/api/src/routes/matches.test.ts
+++ b/api/src/routes/matches.test.ts
@@ -3,7 +3,7 @@ import { assert, assertEquals } from "@std/assert";
 import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
 import { testClient } from "@hono/hono/testing";
 import app from "../app.ts";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 import type { Lane } from "../db/schema.ts";
 import {
   OpggMatchParticipantMismatchError,

--- a/api/src/routes/matches.ts
+++ b/api/src/routes/matches.ts
@@ -1,6 +1,6 @@
 import { Hono } from "@hono/hono";
 import { zValidator } from "@hono/zod-validator";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 import {
   createParticipantSchema,
   finalizeRankSnapshotsSchema,

--- a/api/src/routes/users.test.ts
+++ b/api/src/routes/users.test.ts
@@ -3,7 +3,7 @@ import { assert, assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
 import app from "../app.ts";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 import { riotApi } from "../riot_api.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 import { z } from "zod";

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -8,7 +8,7 @@ import {
   type RiotRegion,
   riotRegions,
 } from "../db/schema.ts";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 import { riotApi } from "../riot_api.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 

--- a/api/src/services/opgg_match_detail.test.ts
+++ b/api/src/services/opgg_match_detail.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 import type { RiotAccount } from "../db/schema.ts";
 import {
   OpggMatchParticipantMismatchError,

--- a/api/src/services/opgg_match_detail.ts
+++ b/api/src/services/opgg_match_detail.ts
@@ -1,4 +1,4 @@
-import { dbActions } from "../db/actions.ts";
+import { dbActions } from "../db/default_actions.ts";
 import {
   OpggMatchParticipantMismatchError,
   RecordNotFoundError,


### PR DESCRIPTION
## 概要

Closes #76

DB接続とDB actionsの生成をfactory化し、module-level singleton依存をdefault composition用ファイルへ分離しました。

## 変更内容

- `createDb({ url, logger })` を追加し、DB接続先指定と `close()` を扱えるようにした
- default DB接続を `db/default_connection.ts` へ分離した
- `createDbActions(database, config)` を追加し、`db/actions.ts` がmodule-level DBを直接参照しない構成にした
- default `dbActions` を `db/default_actions.ts` へ分離し、既存route/serviceの公開挙動を維持した
- match watcher上限とpending rank snapshot TTLを `DbActionsConfig` から注入可能にした
- DB actions testをfactory経由へ移行し、in-memory SQLiteによる接続分離、TTL、監視上限configのテストを追加した

## 検証

- `deno task quality`