### PR TITLE
refactor(api): createAppとroute factoryでBackend依存を注入する

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -3,9 +3,11 @@ import { Hono } from "@hono/hono";
 import { assertEquals, assertMatch } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCalls, stub } from "@std/testing/mock";
-import app, { requestLoggingMiddleware } from "./app.ts";
+import { createApp, requestLoggingMiddleware } from "./app.ts";
+import { createTestDependencies } from "./test_utils.ts";
 
 describe("app.ts", () => {
+  const app = createApp(createTestDependencies());
   const client = testClient(app);
 
   describe("GET /health", () => {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -9,7 +9,6 @@ import { riotRoutes } from "./routes/riot.ts";
 import { riotStaticDataRoutes } from "./routes/riot_static_data.ts";
 import { apiLogger } from "./logger.ts";
 import type { AppDependencies } from "./dependencies.ts";
-import { defaultDependencies } from "./default_dependencies.ts";
 
 export const requestLoggingMiddleware = createMiddleware(async (c, next) => {
   const start = performance.now();
@@ -64,7 +63,24 @@ export function createApp(deps: AppDependencies) {
     .route("/auth", authRoutes(deps));
 }
 
-const app = createApp(defaultDependencies);
+type CreatedApp = ReturnType<typeof createApp>;
 
-export default app satisfies Deno.ServeDefaultExport;
-export type AppType = typeof app;
+let defaultApp: CreatedApp | undefined;
+
+async function getDefaultApp() {
+  if (!defaultApp) {
+    const { defaultDependencies } = await import("./default_dependencies.ts");
+    defaultApp = createApp(defaultDependencies);
+  }
+  return defaultApp;
+}
+
+const app = {
+  fetch: async (...args: Parameters<CreatedApp["fetch"]>) => {
+    const defaultApp = await getDefaultApp();
+    return await defaultApp.fetch(...args);
+  },
+} satisfies Deno.ServeDefaultExport;
+
+export default app;
+export type AppType = CreatedApp;

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -8,6 +8,8 @@ import { authRoutes } from "./routes/auth.ts";
 import { riotRoutes } from "./routes/riot.ts";
 import { riotStaticDataRoutes } from "./routes/riot_static_data.ts";
 import { apiLogger } from "./logger.ts";
+import type { AppDependencies } from "./dependencies.ts";
+import { defaultDependencies } from "./default_dependencies.ts";
 
 export const requestLoggingMiddleware = createMiddleware(async (c, next) => {
   const start = performance.now();
@@ -47,18 +49,22 @@ export const requestLoggingMiddleware = createMiddleware(async (c, next) => {
   }
 });
 
-const app = new Hono()
-  .use("*", requestLoggingMiddleware)
-  .get("/health", (c) => {
-    return c.json({ message: "This API is healthy!" });
-  })
-  .route("/users", usersRoutes)
-  .route("/events", eventsRoutes)
-  .route("/matches", matchesRoutes)
-  .route("/match-watchers", matchWatchersRoutes)
-  .route("/riot/static-data", riotStaticDataRoutes)
-  .route("/riot", riotRoutes)
-  .route("/auth", authRoutes);
+export function createApp(deps: AppDependencies) {
+  return new Hono()
+    .use("*", requestLoggingMiddleware)
+    .get("/health", (c) => {
+      return c.json({ message: "This API is healthy!" });
+    })
+    .route("/users", usersRoutes(deps))
+    .route("/events", eventsRoutes(deps))
+    .route("/matches", matchesRoutes(deps))
+    .route("/match-watchers", matchWatchersRoutes(deps))
+    .route("/riot/static-data", riotStaticDataRoutes(deps))
+    .route("/riot", riotRoutes(deps))
+    .route("/auth", authRoutes(deps));
+}
+
+const app = createApp(defaultDependencies);
 
 export default app satisfies Deno.ServeDefaultExport;
 export type AppType = typeof app;

--- a/api/src/default_dependencies.ts
+++ b/api/src/default_dependencies.ts
@@ -11,4 +11,5 @@ export const defaultDependencies = {
   rso,
   riotStaticData,
   opggMatchDetailService,
+  env: Deno.env,
 } satisfies AppDependencies;

--- a/api/src/default_dependencies.ts
+++ b/api/src/default_dependencies.ts
@@ -1,0 +1,14 @@
+import { dbActions } from "./db/default_actions.ts";
+import type { AppDependencies } from "./dependencies.ts";
+import { riotApi } from "./riot_api.ts";
+import { riotStaticData } from "./riot_static_data.ts";
+import { rso } from "./rso.ts";
+import { opggMatchDetailService } from "./services/opgg_match_detail.ts";
+
+export const defaultDependencies = {
+  dbActions,
+  riotApi,
+  rso,
+  riotStaticData,
+  opggMatchDetailService,
+} satisfies AppDependencies;

--- a/api/src/dependencies.ts
+++ b/api/src/dependencies.ts
@@ -4,10 +4,15 @@ import type { rso } from "./rso.ts";
 import type { riotStaticData } from "./riot_static_data.ts";
 import type { opggMatchDetailService } from "./services/opgg_match_detail.ts";
 
+export type EnvReader = {
+  get(key: string): string | undefined;
+};
+
 export type AppDependencies = {
   dbActions: DbActions;
   riotApi: typeof riotApi;
   rso: typeof rso;
   riotStaticData: typeof riotStaticData;
   opggMatchDetailService: typeof opggMatchDetailService;
+  env: EnvReader;
 };

--- a/api/src/dependencies.ts
+++ b/api/src/dependencies.ts
@@ -1,0 +1,13 @@
+import type { DbActions } from "./db/actions.ts";
+import type { riotApi } from "./riot_api.ts";
+import type { rso } from "./rso.ts";
+import type { riotStaticData } from "./riot_static_data.ts";
+import type { opggMatchDetailService } from "./services/opgg_match_detail.ts";
+
+export type AppDependencies = {
+  dbActions: DbActions;
+  riotApi: typeof riotApi;
+  rso: typeof rso;
+  riotStaticData: typeof riotStaticData;
+  opggMatchDetailService: typeof opggMatchDetailService;
+};

--- a/api/src/routes/auth.test.ts
+++ b/api/src/routes/auth.test.ts
@@ -2,12 +2,15 @@ import { testClient } from "@hono/hono/testing";
 import { describe, test } from "@std/testing/bdd";
 import { assert, assertEquals, assertFalse } from "@std/assert";
 import { assertSpyCall, stub } from "@std/testing/mock";
-import app from "../app.ts";
-import { dbActions } from "../db/default_actions.ts";
-import { rso } from "../rso.ts";
+import { createApp } from "../app.ts";
+import { createTestDependencies } from "../test_utils.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 
 describe("routes/auth.ts", () => {
+  const deps = createTestDependencies();
+  const app = createApp(deps);
+  const { dbActions, rso } = deps;
+
   describe("GET /rso/login-url", () => {
     describe("正常系", () => {
       test("有効なdiscordIdが提供されたとき、認証用のstateを保存し、認証URLを返す", async () => {

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,9 +1,8 @@
 import { Hono } from "@hono/hono";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
-import { dbActions } from "../db/default_actions.ts";
-import { rso } from "../rso.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
+import type { AppDependencies } from "../dependencies.ts";
 
 const callbackQuerySchema = z.object({
   code: z.string().min(1),
@@ -14,68 +13,70 @@ const loginUrlQuerySchema = z.object({
   discordId: z.string().min(1),
 });
 
-export const authRoutes = new Hono()
-  .get(
-    "/rso/login-url",
-    zValidator("query", loginUrlQuerySchema),
-    async (c) => {
-      const { discordId } = c.req.valid("query");
-      const state = crypto.randomUUID();
+export function authRoutes(deps: Pick<AppDependencies, "dbActions" | "rso">) {
+  const { dbActions, rso } = deps;
+  return new Hono()
+    .get(
+      "/rso/login-url",
+      zValidator("query", loginUrlQuerySchema),
+      async (c) => {
+        const { discordId } = c.req.valid("query");
+        const state = crypto.randomUUID();
 
-      await dbActions.createAuthState(state, discordId);
+        await dbActions.createAuthState(state, discordId);
 
-      const authorizationUrl = rso.getAuthorizationUrl(state);
+        const authorizationUrl = rso.getAuthorizationUrl(state);
 
-      return c.json({ url: authorizationUrl });
-    },
-  )
-  .get(
-    "/rso/callback",
-    zValidator("query", callbackQuerySchema),
-    async (c) => {
-      const { code, state } = c.req.valid("query");
+        return c.json({ url: authorizationUrl });
+      },
+    )
+    .get(
+      "/rso/callback",
+      zValidator("query", callbackQuerySchema),
+      async (c) => {
+        const { code, state } = c.req.valid("query");
 
-      // 1. Validate state and get discordId
-      const authState = await dbActions.getAuthState(state);
-      const stateMaxAge = 5 * 60 * 1000; // 5 minutes
-      if (
-        !authState ||
-        new Date().getTime() - authState.createdAt.getTime() > stateMaxAge
-      ) {
-        if (authState) {
-          // Clean up expired state to prevent it from being used again
-          await dbActions.deleteAuthState(state);
+        // 1. Validate state and get discordId
+        const authState = await dbActions.getAuthState(state);
+        const stateMaxAge = 5 * 60 * 1000; // 5 minutes
+        if (
+          !authState ||
+          new Date().getTime() - authState.createdAt.getTime() > stateMaxAge
+        ) {
+          if (authState) {
+            // Clean up expired state to prevent it from being used again
+            await dbActions.deleteAuthState(state);
+          }
+          return c.json({
+            error: messageHandler.formatMessage(
+              messageKeys.riotAccount.link.error.invalidState,
+            ),
+          }, 400);
         }
-        return c.json({
-          error: messageHandler.formatMessage(
-            messageKeys.riotAccount.link.error.invalidState,
-          ),
-        }, 400);
-      }
-      const { discordId } = authState;
+        const { discordId } = authState;
 
-      try {
-        // 2. Exchange code for tokens
-        const { accessToken } = await rso.exchangeCodeForTokens(code);
+        try {
+          // 2. Exchange code for tokens
+          const { accessToken } = await rso.exchangeCodeForTokens(code);
 
-        // 3. Get user info (Riot ID)
-        const { sub: riotId } = await rso.getUserInfo(accessToken);
+          // 3. Get user info (Riot ID)
+          const { sub: riotId } = await rso.getUserInfo(accessToken);
 
-        // 4. Update user's Riot ID in DB
-        await dbActions.linkUserWithRiotId(discordId, riotId);
+          // 4. Update user's Riot ID in DB
+          await dbActions.linkUserWithRiotId(discordId, riotId);
 
-        // 5. Clean up auth state
-        await dbActions.deleteAuthState(state);
+          // 5. Clean up auth state
+          await dbActions.deleteAuthState(state);
 
-        // 6. Return success page
-        return c.html(`
+          // 6. Return success page
+          return c.html(`
           <html>
             <head>
               <title>${
-          messageHandler.formatMessage(
-            messageKeys.riotAccount.link.success.title,
-          )
-        }</title>
+            messageHandler.formatMessage(
+              messageKeys.riotAccount.link.success.title,
+            )
+          }</title>
               <style>
                 body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; }
                 .container { text-align: center; }
@@ -84,29 +85,30 @@ export const authRoutes = new Hono()
             <body>
               <div class="container">
                 <h1>${
-          messageHandler.formatMessage(
-            messageKeys.riotAccount.link.success.title,
-          )
-        }</h1>
+            messageHandler.formatMessage(
+              messageKeys.riotAccount.link.success.title,
+            )
+          }</h1>
                 <p>${
-          messageHandler.formatMessage(
-            messageKeys.riotAccount.link.success.body,
-          )
-        }</p>
+            messageHandler.formatMessage(
+              messageKeys.riotAccount.link.success.body,
+            )
+          }</p>
               </div>
             </body>
           </html>
         `);
-      } catch (error) {
-        console.error("Error during RSO callback:", error);
-        return c.json(
-          {
-            error: messageHandler.formatMessage(
-              messageKeys.common.error.internalServerError,
-            ),
-          },
-          500,
-        );
-      }
-    },
-  );
+        } catch (error) {
+          console.error("Error during RSO callback:", error);
+          return c.json(
+            {
+              error: messageHandler.formatMessage(
+                messageKeys.common.error.internalServerError,
+              ),
+            },
+            500,
+          );
+        }
+      },
+    );
+}

--- a/api/src/routes/events.test.ts
+++ b/api/src/routes/events.test.ts
@@ -3,10 +3,13 @@ import { assert, assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, stub } from "@std/testing/mock";
 import { z } from "zod";
-import app from "../app.ts";
-import { dbActions } from "../db/default_actions.ts";
+import { createApp } from "../app.ts";
+import { createTestDependencies } from "../test_utils.ts";
 
 describe("routes/events.ts", () => {
+  const deps = createTestDependencies();
+  const app = createApp(deps);
+  const { dbActions } = deps;
   const client = testClient(app);
   const FIXED_DATE = "2025-09-27T10:00:00.000Z";
 

--- a/api/src/routes/events.ts
+++ b/api/src/routes/events.ts
@@ -1,7 +1,7 @@
 import { Hono } from "@hono/hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { dbActions } from "../db/default_actions.ts";
+import type { AppDependencies } from "../dependencies.ts";
 
 const createEventSchema = z.object({
   name: z.string(),
@@ -12,31 +12,34 @@ const createEventSchema = z.object({
   scheduledStartAt: z.coerce.date(),
 });
 
-export const eventsRoutes = new Hono()
-  .post("/", zValidator("json", createEventSchema), async (c) => {
-    const event = c.req.valid("json");
-    await dbActions.createCustomGameEvent(event);
-    return c.body(null, 201);
-  })
-  .get("/by-creator/:creatorId", async (c) => {
-    const { creatorId } = c.req.param();
-    const events = await dbActions.getCustomGameEventsByCreatorId(creatorId);
-    return c.json({ events });
-  })
-  .get("/today/by-creator/:creatorId", async (c) => {
-    const { creatorId } = c.req.param();
-    const event = await dbActions.getEventStartingTodayByCreatorId(
-      creatorId,
-    );
-    if (!event) {
-      return c.json({ error: "Event not found" }, 404);
-    }
-    return c.json({ event }, 200);
-  })
-  .delete("/:discordEventId", async (c) => {
-    const { discordEventId } = c.req.param();
-    await dbActions.deleteCustomGameEventByDiscordEventId(discordEventId);
-    return c.body(null, 204);
-  });
+export function eventsRoutes(deps: Pick<AppDependencies, "dbActions">) {
+  const { dbActions } = deps;
+  return new Hono()
+    .post("/", zValidator("json", createEventSchema), async (c) => {
+      const event = c.req.valid("json");
+      await dbActions.createCustomGameEvent(event);
+      return c.body(null, 201);
+    })
+    .get("/by-creator/:creatorId", async (c) => {
+      const { creatorId } = c.req.param();
+      const events = await dbActions.getCustomGameEventsByCreatorId(creatorId);
+      return c.json({ events });
+    })
+    .get("/today/by-creator/:creatorId", async (c) => {
+      const { creatorId } = c.req.param();
+      const event = await dbActions.getEventStartingTodayByCreatorId(
+        creatorId,
+      );
+      if (!event) {
+        return c.json({ error: "Event not found" }, 404);
+      }
+      return c.json({ event }, 200);
+    })
+    .delete("/:discordEventId", async (c) => {
+      const { discordEventId } = c.req.param();
+      await dbActions.deleteCustomGameEventByDiscordEventId(discordEventId);
+      return c.body(null, 204);
+    });
+}
 
-export type EventsRoutes = typeof eventsRoutes;
+export type EventsRoutes = ReturnType<typeof eventsRoutes>;

--- a/api/src/routes/match_watchers.test.ts
+++ b/api/src/routes/match_watchers.test.ts
@@ -2,11 +2,14 @@ import { testClient } from "@hono/hono/testing";
 import { assert, assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, stub } from "@std/testing/mock";
-import app from "../app.ts";
-import { dbActions } from "../db/default_actions.ts";
+import { createApp } from "../app.ts";
+import { createTestDependencies } from "../test_utils.ts";
 import { MatchWatcherLimitError, RecordNotFoundError } from "../errors.ts";
 
 describe("routes/match_watchers.ts", () => {
+  const deps = createTestDependencies();
+  const app = createApp(deps);
+  const { dbActions } = deps;
   const client = testClient(app);
   const watcher = {
     guildId: "guild-1",

--- a/api/src/routes/match_watchers.ts
+++ b/api/src/routes/match_watchers.ts
@@ -1,9 +1,9 @@
 import { Hono } from "@hono/hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { dbActions } from "../db/default_actions.ts";
 import { matchWatcherStates } from "../db/schema.ts";
 import { MatchWatcherLimitError, RecordNotFoundError } from "../errors.ts";
+import type { AppDependencies } from "../dependencies.ts";
 
 const createMatchWatcherSchema = z.object({
   guildId: z.string(),
@@ -25,45 +25,54 @@ const updateMatchWatcherStateSchema = z.object({
   lastInGameNotifiedAt: z.coerce.date().nullable().optional(),
 });
 
-export const matchWatchersRoutes = new Hono()
-  .post("/", zValidator("json", createMatchWatcherSchema), async (c) => {
-    const watcher = c.req.valid("json");
-    try {
-      await dbActions.upsertMatchWatcher(watcher);
-      return c.body(null, 204);
-    } catch (e) {
-      if (e instanceof RecordNotFoundError) {
-        return c.json({ error: e.message }, 404);
+export function matchWatchersRoutes(
+  deps: Pick<AppDependencies, "dbActions">,
+) {
+  const { dbActions } = deps;
+  return new Hono()
+    .post("/", zValidator("json", createMatchWatcherSchema), async (c) => {
+      const watcher = c.req.valid("json");
+      try {
+        await dbActions.upsertMatchWatcher(watcher);
+        return c.body(null, 204);
+      } catch (e) {
+        if (e instanceof RecordNotFoundError) {
+          return c.json({ error: e.message }, 404);
+        }
+        if (e instanceof MatchWatcherLimitError) {
+          return c.json({ error: e.message }, 409);
+        }
+        throw e;
       }
-      if (e instanceof MatchWatcherLimitError) {
-        return c.json({ error: e.message }, 409);
-      }
-      throw e;
-    }
-  })
-  .get("/enabled", async (c) => {
-    const watchers = await dbActions.getEnabledMatchWatchers();
-    return c.json({ watchers }, 200);
-  })
-  .get("/enabled/:guildId", async (c) => {
-    const { guildId } = c.req.param();
-    const watchers = await dbActions.getEnabledMatchWatchersByGuild(guildId);
-    return c.json({ watchers }, 200);
-  })
-  .patch(
-    "/:guildId/:targetDiscordId/state",
-    zValidator("json", updateMatchWatcherStateSchema),
-    async (c) => {
+    })
+    .get("/enabled", async (c) => {
+      const watchers = await dbActions.getEnabledMatchWatchers();
+      return c.json({ watchers }, 200);
+    })
+    .get("/enabled/:guildId", async (c) => {
+      const { guildId } = c.req.param();
+      const watchers = await dbActions.getEnabledMatchWatchersByGuild(guildId);
+      return c.json({ watchers }, 200);
+    })
+    .patch(
+      "/:guildId/:targetDiscordId/state",
+      zValidator("json", updateMatchWatcherStateSchema),
+      async (c) => {
+        const { guildId, targetDiscordId } = c.req.param();
+        const state = c.req.valid("json");
+        await dbActions.updateMatchWatcherState(
+          guildId,
+          targetDiscordId,
+          state,
+        );
+        return c.body(null, 204);
+      },
+    )
+    .delete("/:guildId/:targetDiscordId", async (c) => {
       const { guildId, targetDiscordId } = c.req.param();
-      const state = c.req.valid("json");
-      await dbActions.updateMatchWatcherState(guildId, targetDiscordId, state);
+      await dbActions.disableMatchWatcher(guildId, targetDiscordId);
       return c.body(null, 204);
-    },
-  )
-  .delete("/:guildId/:targetDiscordId", async (c) => {
-    const { guildId, targetDiscordId } = c.req.param();
-    await dbActions.disableMatchWatcher(guildId, targetDiscordId);
-    return c.body(null, 204);
-  });
+    });
+}
 
-export type MatchWatchersRoutes = typeof matchWatchersRoutes;
+export type MatchWatchersRoutes = ReturnType<typeof matchWatchersRoutes>;

--- a/api/src/routes/matches.test.ts
+++ b/api/src/routes/matches.test.ts
@@ -2,17 +2,19 @@ import { describe, test } from "@std/testing/bdd";
 import { assert, assertEquals } from "@std/assert";
 import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
 import { testClient } from "@hono/hono/testing";
-import app from "../app.ts";
-import { dbActions } from "../db/default_actions.ts";
+import { createApp } from "../app.ts";
+import { createTestDependencies } from "../test_utils.ts";
 import type { Lane } from "../db/schema.ts";
 import {
   OpggMatchParticipantMismatchError,
   RecordNotFoundError,
 } from "../errors.ts";
-import { opggMatchDetailService } from "../services/opgg_match_detail.ts";
 import { apiLogger } from "../logger.ts";
 
 describe("routes/matches.ts", () => {
+  const deps = createTestDependencies();
+  const app = createApp(deps);
+  const { dbActions, opggMatchDetailService } = deps;
   const client = testClient(app);
 
   describe("POST /matches/rank-snapshots/pending", () => {

--- a/api/src/routes/matches.ts
+++ b/api/src/routes/matches.ts
@@ -1,6 +1,5 @@
 import { Hono } from "@hono/hono";
 import { zValidator } from "@hono/zod-validator";
-import { dbActions } from "../db/default_actions.ts";
 import {
   createParticipantSchema,
   finalizeRankSnapshotsSchema,
@@ -11,94 +10,99 @@ import {
   OpggMatchParticipantMismatchError,
   RecordNotFoundError,
 } from "../errors.ts";
-import { opggMatchDetailService } from "../services/opgg_match_detail.ts";
 import { apiLogger } from "../logger.ts";
+import type { AppDependencies } from "../dependencies.ts";
 
-export const matchesRoutes = new Hono()
-  .post(
-    "/rank-snapshots/pending",
-    zValidator("json", upsertPendingRankSnapshotsSchema),
-    async (c) => {
-      const payload = c.req.valid("json");
-      await dbActions.upsertPendingRankSnapshots(payload);
-      return c.body(null, 204);
-    },
-  )
-  .post(
-    "/:matchId/rank-snapshots/finalize",
-    zValidator("json", finalizeRankSnapshotsSchema),
-    async (c) => {
-      const { matchId } = c.req.param();
-      const payload = c.req.valid("json");
-      const snapshots = await dbActions.finalizeMatchRankSnapshots({
-        ...payload,
-        matchId,
-      });
-      return c.json({ snapshots }, 200);
-    },
-  )
-  .post(
-    "/:matchId/external-details/opgg/resolve",
-    zValidator("json", resolveOpggMatchDetailSchema, (result, c) => {
-      if (!result.success) {
-        apiLogger.warn("opgg_match_detail.invalid_request", {
-          validationIssues: result.error.issues.map((issue) => ({
-            code: issue.code,
-            path: issue.path,
-          })),
-        });
-        return c.json({ error: "Invalid request body" }, 400);
-      }
-    }),
-    async (c) => {
-      const { matchId } = c.req.param();
-      const payload = c.req.valid("json");
-
-      try {
-        const detail = await opggMatchDetailService.resolveAndSave({
-          matchId,
+export function matchesRoutes(
+  deps: Pick<AppDependencies, "dbActions" | "opggMatchDetailService">,
+) {
+  const { dbActions, opggMatchDetailService } = deps;
+  return new Hono()
+    .post(
+      "/rank-snapshots/pending",
+      zValidator("json", upsertPendingRankSnapshotsSchema),
+      async (c) => {
+        const payload = c.req.valid("json");
+        await dbActions.upsertPendingRankSnapshots(payload);
+        return c.body(null, 204);
+      },
+    )
+    .post(
+      "/:matchId/rank-snapshots/finalize",
+      zValidator("json", finalizeRankSnapshotsSchema),
+      async (c) => {
+        const { matchId } = c.req.param();
+        const payload = c.req.valid("json");
+        const snapshots = await dbActions.finalizeMatchRankSnapshots({
           ...payload,
-        });
-        return c.json({ detail }, 200);
-      } catch (error) {
-        if (error instanceof RecordNotFoundError) {
-          return c.json({ error: error.message }, 404);
-        }
-        if (error instanceof OpggMatchParticipantMismatchError) {
-          return c.json({ error: error.message }, 400);
-        }
-        apiLogger.error(
-          "opgg_match_detail.request_failed",
-          {
-            matchId,
-            targetDiscordId: payload.targetDiscordId,
-          },
-          error,
-        );
-        return c.json({ error: "Failed to resolve OP.GG match detail" }, 500);
-      }
-    },
-  )
-  .post(
-    "/:matchId/participants",
-    zValidator("json", createParticipantSchema),
-    async (c) => {
-      const { matchId } = c.req.param();
-      const participantData = c.req.valid("json");
-
-      try {
-        const result = await dbActions.createMatchParticipant({
-          ...participantData,
           matchId,
         });
-        return c.json({ id: result.id }, 201);
-      } catch (e) {
-        if (e instanceof RecordNotFoundError) {
-          return c.json({ error: e.message }, 404);
+        return c.json({ snapshots }, 200);
+      },
+    )
+    .post(
+      "/:matchId/external-details/opgg/resolve",
+      zValidator("json", resolveOpggMatchDetailSchema, (result, c) => {
+        if (!result.success) {
+          apiLogger.warn("opgg_match_detail.invalid_request", {
+            validationIssues: result.error.issues.map((issue) => ({
+              code: issue.code,
+              path: issue.path,
+            })),
+          });
+          return c.json({ error: "Invalid request body" }, 400);
         }
-        throw e;
-      }
-    },
-  );
+      }),
+      async (c) => {
+        const { matchId } = c.req.param();
+        const payload = c.req.valid("json");
 
-export type MatchesRoutes = typeof matchesRoutes;
+        try {
+          const detail = await opggMatchDetailService.resolveAndSave({
+            matchId,
+            ...payload,
+          });
+          return c.json({ detail }, 200);
+        } catch (error) {
+          if (error instanceof RecordNotFoundError) {
+            return c.json({ error: error.message }, 404);
+          }
+          if (error instanceof OpggMatchParticipantMismatchError) {
+            return c.json({ error: error.message }, 400);
+          }
+          apiLogger.error(
+            "opgg_match_detail.request_failed",
+            {
+              matchId,
+              targetDiscordId: payload.targetDiscordId,
+            },
+            error,
+          );
+          return c.json({ error: "Failed to resolve OP.GG match detail" }, 500);
+        }
+      },
+    )
+    .post(
+      "/:matchId/participants",
+      zValidator("json", createParticipantSchema),
+      async (c) => {
+        const { matchId } = c.req.param();
+        const participantData = c.req.valid("json");
+
+        try {
+          const result = await dbActions.createMatchParticipant({
+            ...participantData,
+            matchId,
+          });
+          return c.json({ id: result.id }, 201);
+        } catch (e) {
+          if (e instanceof RecordNotFoundError) {
+            return c.json({ error: e.message }, 404);
+          }
+          throw e;
+        }
+      },
+    );
+}
+
+export type MatchesRoutes = ReturnType<typeof matchesRoutes>;

--- a/api/src/routes/riot.test.ts
+++ b/api/src/routes/riot.test.ts
@@ -1,10 +1,14 @@
 import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, stub } from "@std/testing/mock";
-import app from "../app.ts";
-import { riotApi } from "../riot_api.ts";
+import { createApp } from "../app.ts";
+import { createTestDependencies } from "../test_utils.ts";
 
 describe("routes/riot.ts", () => {
+  const deps = createTestDependencies();
+  const app = createApp(deps);
+  const { riotApi } = deps;
+
   test("platformとPUUIDを指定したとき、APIサーバーから進行中の試合を返す", async () => {
     // Arrange
     const activeGame = {

--- a/api/src/routes/riot.ts
+++ b/api/src/routes/riot.ts
@@ -2,7 +2,7 @@ import { Hono } from "@hono/hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { riotPlatforms, riotRegions } from "../db/schema.ts";
-import { riotApi } from "../riot_api.ts";
+import type { AppDependencies } from "../dependencies.ts";
 
 const platformAndPuuidSchema = z.object({
   platform: z.enum(riotPlatforms),
@@ -18,45 +18,54 @@ function upstreamErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Riot API request failed";
 }
 
-export const riotRoutes = new Hono()
-  .get(
-    "/active-games/:platform/:puuid",
-    zValidator("param", platformAndPuuidSchema),
-    async (c) => {
-      const { platform, puuid } = c.req.valid("param");
-      try {
-        const activeGame = await riotApi.getActiveGameByPuuid(platform, puuid);
-        return c.json({ activeGame }, 200);
-      } catch (error) {
-        return c.json({ error: upstreamErrorMessage(error) }, 502);
-      }
-    },
-  )
-  .get(
-    "/matches/:region/:matchId",
-    zValidator("param", regionAndMatchIdSchema),
-    async (c) => {
-      const { region, matchId } = c.req.valid("param");
-      try {
-        const match = await riotApi.getMatchById(region, matchId);
-        return c.json({ match }, 200);
-      } catch (error) {
-        return c.json({ error: upstreamErrorMessage(error) }, 502);
-      }
-    },
-  )
-  .get(
-    "/league-entries/:platform/:puuid",
-    zValidator("param", platformAndPuuidSchema),
-    async (c) => {
-      const { platform, puuid } = c.req.valid("param");
-      try {
-        const entries = await riotApi.getLeagueEntriesByPuuid(platform, puuid);
-        return c.json({ entries }, 200);
-      } catch (error) {
-        return c.json({ error: upstreamErrorMessage(error) }, 502);
-      }
-    },
-  );
+export function riotRoutes(deps: Pick<AppDependencies, "riotApi">) {
+  const { riotApi } = deps;
+  return new Hono()
+    .get(
+      "/active-games/:platform/:puuid",
+      zValidator("param", platformAndPuuidSchema),
+      async (c) => {
+        const { platform, puuid } = c.req.valid("param");
+        try {
+          const activeGame = await riotApi.getActiveGameByPuuid(
+            platform,
+            puuid,
+          );
+          return c.json({ activeGame }, 200);
+        } catch (error) {
+          return c.json({ error: upstreamErrorMessage(error) }, 502);
+        }
+      },
+    )
+    .get(
+      "/matches/:region/:matchId",
+      zValidator("param", regionAndMatchIdSchema),
+      async (c) => {
+        const { region, matchId } = c.req.valid("param");
+        try {
+          const match = await riotApi.getMatchById(region, matchId);
+          return c.json({ match }, 200);
+        } catch (error) {
+          return c.json({ error: upstreamErrorMessage(error) }, 502);
+        }
+      },
+    )
+    .get(
+      "/league-entries/:platform/:puuid",
+      zValidator("param", platformAndPuuidSchema),
+      async (c) => {
+        const { platform, puuid } = c.req.valid("param");
+        try {
+          const entries = await riotApi.getLeagueEntriesByPuuid(
+            platform,
+            puuid,
+          );
+          return c.json({ entries }, 200);
+        } catch (error) {
+          return c.json({ error: upstreamErrorMessage(error) }, 502);
+        }
+      },
+    );
+}
 
-export type RiotRoutes = typeof riotRoutes;
+export type RiotRoutes = ReturnType<typeof riotRoutes>;

--- a/api/src/routes/riot_static_data.test.ts
+++ b/api/src/routes/riot_static_data.test.ts
@@ -1,10 +1,14 @@
 import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
-import app from "../app.ts";
-import { riotStaticData } from "../riot_static_data.ts";
+import { createApp } from "../app.ts";
+import { createTestDependencies } from "../test_utils.ts";
 
 describe("POST /riot/static-data/resolve", () => {
+  const deps = createTestDependencies();
+  const app = createApp(deps);
+  const { riotStaticData } = deps;
+
   test("ロケールと識別子群を指定したとき、解決した静的表示データをまとめて返す", async () => {
     // Arrange
     const resolved = {

--- a/api/src/routes/riot_static_data.ts
+++ b/api/src/routes/riot_static_data.ts
@@ -1,7 +1,7 @@
 import { Hono } from "@hono/hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
-import { riotStaticData } from "../riot_static_data.ts";
+import type { AppDependencies } from "../dependencies.ts";
 
 const riotStaticDataResolveSchema = z.object({
   locale: z.string().trim().min(1).max(32).optional(),
@@ -17,21 +17,29 @@ function errorMessage(error: unknown) {
     : "Failed to resolve Riot static data";
 }
 
-export const riotStaticDataRoutes = new Hono().post(
-  "/resolve",
-  zValidator("json", riotStaticDataResolveSchema, (result, c) => {
-    if (!result.success) {
-      return c.json({ error: "Invalid Riot static data resolve request" }, 400);
-    }
-  }),
-  async (c) => {
-    try {
-      const result = await riotStaticData.resolve(c.req.valid("json"));
-      return c.json(result, 200);
-    } catch (error) {
-      return c.json({ error: errorMessage(error) }, 502);
-    }
-  },
-);
+export function riotStaticDataRoutes(
+  deps: Pick<AppDependencies, "riotStaticData">,
+) {
+  const { riotStaticData } = deps;
+  return new Hono().post(
+    "/resolve",
+    zValidator("json", riotStaticDataResolveSchema, (result, c) => {
+      if (!result.success) {
+        return c.json(
+          { error: "Invalid Riot static data resolve request" },
+          400,
+        );
+      }
+    }),
+    async (c) => {
+      try {
+        const result = await riotStaticData.resolve(c.req.valid("json"));
+        return c.json(result, 200);
+      } catch (error) {
+        return c.json({ error: errorMessage(error) }, 502);
+      }
+    },
+  );
+}
 
-export type RiotStaticDataRoutes = typeof riotStaticDataRoutes;
+export type RiotStaticDataRoutes = ReturnType<typeof riotStaticDataRoutes>;

--- a/api/src/routes/users.test.ts
+++ b/api/src/routes/users.test.ts
@@ -2,14 +2,16 @@ import { testClient } from "@hono/hono/testing";
 import { assert, assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
-import app from "../app.ts";
-import { dbActions } from "../db/default_actions.ts";
-import { riotApi } from "../riot_api.ts";
+import { createApp } from "../app.ts";
+import { createTestDependencies } from "../test_utils.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 import { z } from "zod";
 import type { Lane } from "../db/schema.ts";
 
 describe("routes/users.ts", () => {
+  const deps = createTestDependencies();
+  const app = createApp(deps);
+  const { dbActions, riotApi } = deps;
   const client = testClient(app);
   const errorResponseSchema = z.object({ error: z.string() });
   const discordId = "test-discord-id";

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -9,7 +9,7 @@ import {
   riotRegions,
 } from "../db/schema.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
-import type { AppDependencies } from "../dependencies.ts";
+import type { AppDependencies, EnvReader } from "../dependencies.ts";
 
 const roleSchema = z.object({
   guildId: z.string(),
@@ -24,24 +24,24 @@ const linkByRiotIdSchema = z.object({
   region: z.enum(riotRegions).optional(),
 });
 
-function defaultPlatform(): RiotPlatform {
-  const platform = Deno.env.get("RIOT_DEFAULT_PLATFORM") ?? "jp1";
+function defaultPlatform(env: EnvReader): RiotPlatform {
+  const platform = env.get("RIOT_DEFAULT_PLATFORM") ?? "jp1";
   return riotPlatforms.includes(platform as RiotPlatform)
     ? platform as RiotPlatform
     : "jp1";
 }
 
-function defaultRegion(): RiotRegion {
-  const region = Deno.env.get("RIOT_DEFAULT_REGION") ?? "asia";
+function defaultRegion(env: EnvReader): RiotRegion {
+  const region = env.get("RIOT_DEFAULT_REGION") ?? "asia";
   return riotRegions.includes(region as RiotRegion)
     ? region as RiotRegion
     : "asia";
 }
 
 export function usersRoutes(
-  deps: Pick<AppDependencies, "dbActions" | "riotApi">,
+  deps: Pick<AppDependencies, "dbActions" | "riotApi" | "env">,
 ) {
-  const { dbActions, riotApi } = deps;
+  const { dbActions, riotApi, env } = deps;
   return new Hono()
     .patch(
       "/link-by-riot-id",
@@ -50,8 +50,8 @@ export function usersRoutes(
         const { discordId, gameName, tagLine, platform, region } = c.req.valid(
           "json",
         );
-        const resolvedPlatform = platform ?? defaultPlatform();
-        const resolvedRegion = region ?? defaultRegion();
+        const resolvedPlatform = platform ?? defaultPlatform(env);
+        const resolvedRegion = region ?? defaultRegion(env);
 
         const account = await riotApi.getAccountByRiotId(
           resolvedRegion,

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -8,9 +8,8 @@ import {
   type RiotRegion,
   riotRegions,
 } from "../db/schema.ts";
-import { dbActions } from "../db/default_actions.ts";
-import { riotApi } from "../riot_api.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
+import type { AppDependencies } from "../dependencies.ts";
 
 const roleSchema = z.object({
   guildId: z.string(),
@@ -39,60 +38,65 @@ function defaultRegion(): RiotRegion {
     : "asia";
 }
 
-export const usersRoutes = new Hono()
-  .patch(
-    "/link-by-riot-id",
-    zValidator("json", linkByRiotIdSchema),
-    async (c) => {
-      const { discordId, gameName, tagLine, platform, region } = c.req.valid(
-        "json",
-      );
-      const resolvedPlatform = platform ?? defaultPlatform();
-      const resolvedRegion = region ?? defaultRegion();
+export function usersRoutes(
+  deps: Pick<AppDependencies, "dbActions" | "riotApi">,
+) {
+  const { dbActions, riotApi } = deps;
+  return new Hono()
+    .patch(
+      "/link-by-riot-id",
+      zValidator("json", linkByRiotIdSchema),
+      async (c) => {
+        const { discordId, gameName, tagLine, platform, region } = c.req.valid(
+          "json",
+        );
+        const resolvedPlatform = platform ?? defaultPlatform();
+        const resolvedRegion = region ?? defaultRegion();
 
-      const account = await riotApi.getAccountByRiotId(
-        resolvedRegion,
-        gameName,
-        tagLine,
-      );
+        const account = await riotApi.getAccountByRiotId(
+          resolvedRegion,
+          gameName,
+          tagLine,
+        );
 
-      if (!account) {
-        return c.json({
-          error: messageHandler.formatMessage(
-            messageKeys.riotAccount.set.error.summonerNotFound,
-          ),
-        }, 404);
-      }
+        if (!account) {
+          return c.json({
+            error: messageHandler.formatMessage(
+              messageKeys.riotAccount.set.error.summonerNotFound,
+            ),
+          }, 404);
+        }
 
-      await dbActions.upsertRiotAccount({
-        discordId,
-        puuid: account.puuid,
-        gameName: account.gameName,
-        tagLine: account.tagLine,
-        platform: resolvedPlatform,
-        region: resolvedRegion,
-      });
+        await dbActions.upsertRiotAccount({
+          discordId,
+          puuid: account.puuid,
+          gameName: account.gameName,
+          tagLine: account.tagLine,
+          platform: resolvedPlatform,
+          region: resolvedRegion,
+        });
 
-      return c.body(null, 204);
-    },
-  )
-  .get("/:userId/riot-account", async (c) => {
-    const { userId } = c.req.param();
-    const account = await dbActions.getRiotAccountByDiscordId(userId);
-    if (!account) {
-      return c.json({ error: "Riot account not found" }, 404);
-    }
-    return c.json({ account }, 200);
-  })
-  .put(
-    "/:userId/main-role",
-    zValidator("json", roleSchema),
-    async (c) => {
+        return c.body(null, 204);
+      },
+    )
+    .get("/:userId/riot-account", async (c) => {
       const { userId } = c.req.param();
-      const { guildId, role } = c.req.valid("json");
-      await dbActions.setMainRole(userId, guildId, role);
-      return c.body(null, 204);
-    },
-  );
+      const account = await dbActions.getRiotAccountByDiscordId(userId);
+      if (!account) {
+        return c.json({ error: "Riot account not found" }, 404);
+      }
+      return c.json({ account }, 200);
+    })
+    .put(
+      "/:userId/main-role",
+      zValidator("json", roleSchema),
+      async (c) => {
+        const { userId } = c.req.param();
+        const { guildId, role } = c.req.valid("json");
+        await dbActions.setMainRole(userId, guildId, role);
+        return c.body(null, 204);
+      },
+    );
+}
 
-export type UsersRoutes = typeof usersRoutes;
+export type UsersRoutes = ReturnType<typeof usersRoutes>;

--- a/api/src/test_utils.test.ts
+++ b/api/src/test_utils.test.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import { createTestDependencies } from "./test_utils.ts";
+
+describe("test_utils.ts", () => {
+  test("Riot API testing helperを部分overrideするとき、未指定のtesting helperを保持する", () => {
+    // Arrange
+    let resetCalled = false;
+
+    // Act
+    const deps = createTestDependencies({
+      riotApi: {
+        __testing: {
+          resetRateLimiter: () => {
+            resetCalled = true;
+          },
+        },
+      },
+    });
+    deps.riotApi.__testing.resetRateLimiter();
+
+    // Assert
+    assertEquals(resetCalled, true);
+    assertEquals(typeof deps.riotApi.__testing.rateLimiterSnapshot, "function");
+  });
+});

--- a/api/src/test_utils.ts
+++ b/api/src/test_utils.ts
@@ -1,0 +1,107 @@
+import type { AppDependencies } from "./dependencies.ts";
+
+function unexpectedDependencyCall(name: string): never {
+  throw new Error(`Unexpected dependency call: ${name}`);
+}
+
+export function createTestDependencies(
+  overrides: {
+    dbActions?: Partial<AppDependencies["dbActions"]>;
+    riotApi?: Partial<AppDependencies["riotApi"]>;
+    rso?: Partial<AppDependencies["rso"]>;
+    riotStaticData?: Partial<AppDependencies["riotStaticData"]>;
+    opggMatchDetailService?: Partial<
+      AppDependencies["opggMatchDetailService"]
+    >;
+  } = {},
+): AppDependencies {
+  const deps = {
+    dbActions: {
+      upsertUser: () => unexpectedDependencyCall("dbActions.upsertUser"),
+      ensureGuild: () => unexpectedDependencyCall("dbActions.ensureGuild"),
+      deleteUser: () => unexpectedDependencyCall("dbActions.deleteUser"),
+      setMainRole: () => unexpectedDependencyCall("dbActions.setMainRole"),
+      createCustomGameEvent: () =>
+        unexpectedDependencyCall("dbActions.createCustomGameEvent"),
+      getCustomGameEventsByCreatorId: () =>
+        unexpectedDependencyCall("dbActions.getCustomGameEventsByCreatorId"),
+      deleteCustomGameEventByDiscordEventId: () =>
+        unexpectedDependencyCall(
+          "dbActions.deleteCustomGameEventByDiscordEventId",
+        ),
+      getEventStartingTodayByCreatorId: () =>
+        unexpectedDependencyCall("dbActions.getEventStartingTodayByCreatorId"),
+      createMatchParticipant: () =>
+        unexpectedDependencyCall("dbActions.createMatchParticipant"),
+      upsertPendingRankSnapshots: () =>
+        unexpectedDependencyCall("dbActions.upsertPendingRankSnapshots"),
+      finalizeMatchRankSnapshots: () =>
+        unexpectedDependencyCall("dbActions.finalizeMatchRankSnapshots"),
+      upsertExternalMatchDetail: () =>
+        unexpectedDependencyCall("dbActions.upsertExternalMatchDetail"),
+      getAuthState: () => unexpectedDependencyCall("dbActions.getAuthState"),
+      deleteAuthState: () =>
+        unexpectedDependencyCall("dbActions.deleteAuthState"),
+      updateUserRiotId: () =>
+        unexpectedDependencyCall("dbActions.updateUserRiotId"),
+      linkUserWithRiotId: () =>
+        unexpectedDependencyCall("dbActions.linkUserWithRiotId"),
+      upsertRiotAccount: () =>
+        unexpectedDependencyCall("dbActions.upsertRiotAccount"),
+      getRiotAccountByDiscordId: () =>
+        unexpectedDependencyCall("dbActions.getRiotAccountByDiscordId"),
+      getRiotStaticDataCache: () =>
+        unexpectedDependencyCall("dbActions.getRiotStaticDataCache"),
+      upsertRiotStaticDataCache: () =>
+        unexpectedDependencyCall("dbActions.upsertRiotStaticDataCache"),
+      upsertMatchWatcher: () =>
+        unexpectedDependencyCall("dbActions.upsertMatchWatcher"),
+      getEnabledMatchWatchers: () =>
+        unexpectedDependencyCall("dbActions.getEnabledMatchWatchers"),
+      getEnabledMatchWatchersByGuild: () =>
+        unexpectedDependencyCall("dbActions.getEnabledMatchWatchersByGuild"),
+      updateMatchWatcherState: () =>
+        unexpectedDependencyCall("dbActions.updateMatchWatcherState"),
+      disableMatchWatcher: () =>
+        unexpectedDependencyCall("dbActions.disableMatchWatcher"),
+      createAuthState: () =>
+        unexpectedDependencyCall("dbActions.createAuthState"),
+      ...overrides.dbActions,
+    },
+    riotApi: {
+      getAccountByRiotId: () =>
+        unexpectedDependencyCall("riotApi.getAccountByRiotId"),
+      getActiveGameByPuuid: () =>
+        unexpectedDependencyCall("riotApi.getActiveGameByPuuid"),
+      getMatchById: () => unexpectedDependencyCall("riotApi.getMatchById"),
+      getLeagueEntriesByPuuid: () =>
+        unexpectedDependencyCall("riotApi.getLeagueEntriesByPuuid"),
+      __testing: {
+        resetRateLimiter: () =>
+          unexpectedDependencyCall("riotApi.__testing.resetRateLimiter"),
+        rateLimiterSnapshot: () =>
+          unexpectedDependencyCall("riotApi.__testing.rateLimiterSnapshot"),
+      },
+      ...overrides.riotApi,
+    },
+    rso: {
+      exchangeCodeForTokens: () =>
+        unexpectedDependencyCall("rso.exchangeCodeForTokens"),
+      getUserInfo: () => unexpectedDependencyCall("rso.getUserInfo"),
+      getAuthorizationUrl: () =>
+        unexpectedDependencyCall("rso.getAuthorizationUrl"),
+      ...overrides.rso,
+    },
+    riotStaticData: {
+      resolve: () => unexpectedDependencyCall("riotStaticData.resolve"),
+      ...overrides.riotStaticData,
+    },
+    opggMatchDetailService: {
+      resolveAndSave: () =>
+        unexpectedDependencyCall("opggMatchDetailService.resolveAndSave"),
+      ...overrides.opggMatchDetailService,
+    },
+  };
+
+  return deps as AppDependencies;
+}

--- a/api/src/test_utils.ts
+++ b/api/src/test_utils.ts
@@ -1,19 +1,22 @@
 import type { AppDependencies } from "./dependencies.ts";
 
+type TestDependencyOverrides = {
+  dbActions?: Partial<AppDependencies["dbActions"]>;
+  riotApi?: Omit<Partial<AppDependencies["riotApi"]>, "__testing"> & {
+    __testing?: Partial<AppDependencies["riotApi"]["__testing"]>;
+  };
+  rso?: Partial<AppDependencies["rso"]>;
+  riotStaticData?: Partial<AppDependencies["riotStaticData"]>;
+  opggMatchDetailService?: Partial<AppDependencies["opggMatchDetailService"]>;
+  env?: Partial<AppDependencies["env"]>;
+};
+
 function unexpectedDependencyCall(name: string): never {
   throw new Error(`Unexpected dependency call: ${name}`);
 }
 
 export function createTestDependencies(
-  overrides: {
-    dbActions?: Partial<AppDependencies["dbActions"]>;
-    riotApi?: Partial<AppDependencies["riotApi"]>;
-    rso?: Partial<AppDependencies["rso"]>;
-    riotStaticData?: Partial<AppDependencies["riotStaticData"]>;
-    opggMatchDetailService?: Partial<
-      AppDependencies["opggMatchDetailService"]
-    >;
-  } = {},
+  overrides: TestDependencyOverrides = {},
 ): AppDependencies {
   const deps = {
     dbActions: {
@@ -76,13 +79,14 @@ export function createTestDependencies(
       getMatchById: () => unexpectedDependencyCall("riotApi.getMatchById"),
       getLeagueEntriesByPuuid: () =>
         unexpectedDependencyCall("riotApi.getLeagueEntriesByPuuid"),
+      ...overrides.riotApi,
       __testing: {
         resetRateLimiter: () =>
           unexpectedDependencyCall("riotApi.__testing.resetRateLimiter"),
         rateLimiterSnapshot: () =>
           unexpectedDependencyCall("riotApi.__testing.rateLimiterSnapshot"),
+        ...overrides.riotApi?.__testing,
       },
-      ...overrides.riotApi,
     },
     rso: {
       exchangeCodeForTokens: () =>
@@ -100,6 +104,10 @@ export function createTestDependencies(
       resolveAndSave: () =>
         unexpectedDependencyCall("opggMatchDetailService.resolveAndSave"),
       ...overrides.opggMatchDetailService,
+    },
+    env: {
+      get: () => undefined,
+      ...overrides.env,
     },
   };
 


### PR DESCRIPTION
## 概要

Closes #78

Backend APIのapp / route生成をfactory化し、routeからmodule-level singleton依存を外しました。

## 変更内容

- `createApp(deps)` を導入し、default exportはproduction用依存を組み立てて生成する形にした
- `AppDependencies` と `defaultDependencies` を追加した
- users / events / matches / match-watchers / riot / riot static data / auth routeをfactory化した
- routeから `dbActions` / `riotApi` / `rso` / `riotStaticData` / `opggMatchDetailService` の直接importを除去した
- route testを公開singleton stubから `createTestDependencies()` によるdeps注入へ移行した
- `AppType` とHono RPC型推論を維持し、URL・HTTP status・response bodyは変更していない

## 検証

- `deno test --allow-env --allow-read --allow-sys --allow-ffi api/src/routes`
- `deno check api/src/app.ts`
- `deno task quality`