### PR TITLE
refactor(api): Backend service依存をfactoryへ寄せる

### DIFF
--- a/api/src/default_dependencies.ts
+++ b/api/src/default_dependencies.ts
@@ -1,9 +1,28 @@
 import { dbActions } from "./db/default_actions.ts";
 import type { AppDependencies } from "./dependencies.ts";
+import { opggClient } from "./integrations/opgg.ts";
+import { apiLogger } from "./logger.ts";
 import { riotApi } from "./riot_api.ts";
-import { riotStaticData } from "./riot_static_data.ts";
+import {
+  createRiotStaticData,
+  fetchRiotStaticDataJson,
+} from "./riot_static_data.ts";
 import { rso } from "./rso.ts";
-import { opggMatchDetailService } from "./services/opgg_match_detail.ts";
+import { createOpggMatchDetailService } from "./services/opgg_match_detail.ts";
+
+const riotStaticData = createRiotStaticData({
+  dbActions,
+  env: Deno.env,
+  fetchJson: fetchRiotStaticDataJson,
+  logger: apiLogger,
+});
+
+const opggMatchDetailService = createOpggMatchDetailService({
+  dbActions,
+  env: Deno.env,
+  logger: apiLogger,
+  opggClient,
+});
 
 export const defaultDependencies = {
   dbActions,

--- a/api/src/dependencies.ts
+++ b/api/src/dependencies.ts
@@ -1,8 +1,8 @@
 import type { DbActions } from "./db/actions.ts";
 import type { riotApi } from "./riot_api.ts";
 import type { rso } from "./rso.ts";
-import type { riotStaticData } from "./riot_static_data.ts";
-import type { opggMatchDetailService } from "./services/opgg_match_detail.ts";
+import type { RiotStaticDataService } from "./riot_static_data.ts";
+import type { OpggMatchDetailService } from "./services/opgg_match_detail.ts";
 
 export type EnvReader = {
   get(key: string): string | undefined;
@@ -12,7 +12,7 @@ export type AppDependencies = {
   dbActions: DbActions;
   riotApi: typeof riotApi;
   rso: typeof rso;
-  riotStaticData: typeof riotStaticData;
-  opggMatchDetailService: typeof opggMatchDetailService;
+  riotStaticData: RiotStaticDataService;
+  opggMatchDetailService: OpggMatchDetailService;
   env: EnvReader;
 };

--- a/api/src/riot_static_data.test.ts
+++ b/api/src/riot_static_data.test.ts
@@ -1,14 +1,44 @@
 import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
-import { dbActions } from "./db/default_actions.ts";
-import { apiLogger } from "./logger.ts";
-import { riotStaticData } from "./riot_static_data.ts";
+import { createRiotStaticData } from "./riot_static_data.ts";
+
+type StaticDataCache = {
+  key: string;
+  version: string;
+  value: string;
+  updatedAt: Date;
+};
+
+function dependencies() {
+  return {
+    dbActions: {
+      getRiotStaticDataCache: (
+        _key: string,
+      ): Promise<StaticDataCache | undefined> => Promise.resolve(undefined),
+      upsertRiotStaticDataCache: (_cache: {
+        key: string;
+        version: string;
+        value: string;
+      }) => Promise.resolve(),
+    },
+    env: {
+      get: (_key: string) => undefined,
+    },
+    fetchJson: (_url: string): Promise<unknown> =>
+      Promise.reject(new Error("fetch should not be called")),
+    logger: {
+      warn: (_message: string, _metadata?: Record<string, unknown>) => {},
+    },
+  };
+}
 
 describe("riot_static_data.ts", () => {
   test("チャンピオン名がキャッシュ済みかつTTL内の場合、外部取得せずDBの値を返す", async () => {
+    const deps = dependencies();
+    const riotStaticData = createRiotStaticData(deps);
     using getCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotStaticDataCache",
       () =>
         Promise.resolve({
@@ -21,13 +51,13 @@ describe("riot_static_data.ts", () => {
         }),
     );
     using upsertCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "upsertRiotStaticDataCache",
       () => Promise.resolve(),
     );
     using fetchStub = stub(
-      globalThis,
-      "fetch",
+      deps,
+      "fetchJson",
       () => Promise.reject(new Error("fetch should not be called")),
     );
 
@@ -40,16 +70,16 @@ describe("riot_static_data.ts", () => {
   });
 
   test("チャンピオン名と画像URLを続けて解決するとき、単一の取得結果とキャッシュを共有する", async () => {
-    let cached: Awaited<
-      ReturnType<typeof dbActions.getRiotStaticDataCache>
-    >;
+    const deps = dependencies();
+    const riotStaticData = createRiotStaticData(deps);
+    let cached: StaticDataCache | undefined;
     using getCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotStaticDataCache",
       () => Promise.resolve(cached),
     );
     using upsertCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "upsertRiotStaticDataCache",
       (value) => {
         cached = { ...value, updatedAt: new Date() };
@@ -57,28 +87,23 @@ describe("riot_static_data.ts", () => {
       },
     );
     using fetchStub = stub(
-      globalThis,
-      "fetch",
+      deps,
+      "fetchJson",
       (input) => {
         const url = String(input);
         if (url.endsWith("/api/versions.json")) {
-          return Promise.resolve(
-            new Response(JSON.stringify(["16.12.1"]), { status: 200 }),
-          );
+          return Promise.resolve(["16.12.1"]);
         }
         return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              data: {
-                Teemo: {
-                  key: "17",
-                  name: "ティーモ",
-                  image: { full: "Teemo.png" },
-                },
+          {
+            data: {
+              Teemo: {
+                key: "17",
+                name: "ティーモ",
+                image: { full: "Teemo.png" },
               },
-            }),
-            { status: 200 },
-          ),
+            },
+          },
         );
       },
     );
@@ -98,20 +123,22 @@ describe("riot_static_data.ts", () => {
   });
 
   test("チャンピオン画像のstatic data取得に失敗しキャッシュもない場合、エラーを返す", async () => {
+    const deps = dependencies();
+    const riotStaticData = createRiotStaticData(deps);
     using _getCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotStaticDataCache",
       () => Promise.resolve(undefined),
     );
     using _upsertCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "upsertRiotStaticDataCache",
       () => Promise.resolve(),
     );
     using _fetchStub = stub(
-      globalThis,
-      "fetch",
-      () => Promise.resolve(new Response(null, { status: 503 })),
+      deps,
+      "fetchJson",
+      () => Promise.reject(new Error("Failed to fetch Riot static data: 503")),
     );
 
     let error: unknown;
@@ -125,28 +152,27 @@ describe("riot_static_data.ts", () => {
   });
 
   test("キュー名が未キャッシュの場合、公式static JSONを取得してDBへ保存する", async () => {
+    const deps = dependencies();
+    const riotStaticData = createRiotStaticData(deps);
     using getCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotStaticDataCache",
       () => Promise.resolve(undefined),
     );
     using upsertCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "upsertRiotStaticDataCache",
       () => Promise.resolve(),
     );
     using fetchStub = stub(
-      globalThis,
-      "fetch",
+      deps,
+      "fetchJson",
       () =>
         Promise.resolve(
-          new Response(
-            JSON.stringify([{
-              queueId: 420,
-              description: "5v5 Ranked Solo games",
-            }]),
-            { status: 200 },
-          ),
+          [{
+            queueId: 420,
+            description: "5v5 Ranked Solo games",
+          }],
         ),
     );
 
@@ -159,14 +185,16 @@ describe("riot_static_data.ts", () => {
   });
 
   test("ja_JPの代表キューは日本語ユーザー向けの表示名を返す", async () => {
+    const deps = dependencies();
+    const riotStaticData = createRiotStaticData(deps);
     using getCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotStaticDataCache",
       () => Promise.reject(new Error("cache should not be called")),
     );
     using fetchStub = stub(
-      globalThis,
-      "fetch",
+      deps,
+      "fetchJson",
       () => Promise.reject(new Error("fetch should not be called")),
     );
 
@@ -178,14 +206,16 @@ describe("riot_static_data.ts", () => {
   });
 
   test("ja_JPの代表マップとゲームモードは日本語ユーザー向けの表示名を返す", async () => {
+    const deps = dependencies();
+    const riotStaticData = createRiotStaticData(deps);
     using getCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotStaticDataCache",
       () => Promise.reject(new Error("cache should not be called")),
     );
     using fetchStub = stub(
-      globalThis,
-      "fetch",
+      deps,
+      "fetchJson",
       () => Promise.reject(new Error("fetch should not be called")),
     );
 
@@ -199,8 +229,10 @@ describe("riot_static_data.ts", () => {
   });
 
   test("キャッシュ更新に失敗した場合、古いDB値をfallbackとして返す", async () => {
+    const deps = dependencies();
+    const riotStaticData = createRiotStaticData(deps);
     using _getCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotStaticDataCache",
       () =>
         Promise.resolve({
@@ -211,14 +243,14 @@ describe("riot_static_data.ts", () => {
         }),
     );
     using _upsertCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "upsertRiotStaticDataCache",
       () => Promise.resolve(),
     );
     using fetchStub = stub(
-      globalThis,
-      "fetch",
-      () => Promise.resolve(new Response(null, { status: 500 })),
+      deps,
+      "fetchJson",
+      () => Promise.reject(new Error("Failed to fetch Riot static data: 500")),
     );
 
     const name = await riotStaticData.getMapNameById(11, "en_US");
@@ -229,8 +261,10 @@ describe("riot_static_data.ts", () => {
 
   test("複数の静的データ識別子を解決するとき、種別ごとに単一のキャッシュ読み込みから表示データを返す", async () => {
     // Arrange
+    const deps = dependencies();
+    const riotStaticData = createRiotStaticData(deps);
     using getCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotStaticDataCache",
       (key) => {
         const values: Record<string, string> = {
@@ -253,8 +287,8 @@ describe("riot_static_data.ts", () => {
       },
     );
     using fetchStub = stub(
-      globalThis,
-      "fetch",
+      deps,
+      "fetchJson",
       () => Promise.reject(new Error("fetch should not be called")),
     );
 
@@ -287,8 +321,10 @@ describe("riot_static_data.ts", () => {
 
   test("一部の静的データ取得に失敗したとき、失敗した種別だけnullにして取得済みデータを返す", async () => {
     // Arrange
+    const deps = dependencies();
+    const riotStaticData = createRiotStaticData(deps);
     using _getCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotStaticDataCache",
       (key) =>
         Promise.resolve(
@@ -305,11 +341,11 @@ describe("riot_static_data.ts", () => {
         ),
     );
     using _fetchStub = stub(
-      globalThis,
-      "fetch",
-      () => Promise.resolve(new Response(null, { status: 503 })),
+      deps,
+      "fetchJson",
+      () => Promise.reject(new Error("Failed to fetch Riot static data: 503")),
     );
-    using warnStub = stub(apiLogger, "warn", () => {});
+    using warnStub = stub(deps.logger, "warn", () => {});
 
     // Act
     const result = await riotStaticData.resolve({
@@ -340,8 +376,10 @@ describe("riot_static_data.ts", () => {
 
   test("未知の識別子を含む静的データを解決するとき、対応する値をnullで返す", async () => {
     // Arrange
+    const deps = dependencies();
+    const riotStaticData = createRiotStaticData(deps);
     using _getCacheStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotStaticDataCache",
       (key) =>
         Promise.resolve({

--- a/api/src/riot_static_data.ts
+++ b/api/src/riot_static_data.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-import { dbActions } from "./db/default_actions.ts";
-import { apiLogger } from "./logger.ts";
+import type { DbActions } from "./db/actions.ts";
 
 const DEFAULT_STATIC_DATA_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const DATA_DRAGON_VERSIONS_URL =
@@ -76,50 +75,92 @@ export type RiotStaticDataResolveResult = {
   gameModes: Record<string, string | null>;
 };
 
-function numberEnv(name: string, fallback: number) {
-  const value = Number(Deno.env.get(name));
+type EnvReader = {
+  get(key: string): string | undefined;
+};
+
+type Logger = {
+  warn(message: string, metadata?: Record<string, unknown>): void;
+};
+
+type RiotStaticDataDbActions = Pick<
+  DbActions,
+  "getRiotStaticDataCache" | "upsertRiotStaticDataCache"
+>;
+
+export type RiotStaticDataServiceDependencies = {
+  dbActions: RiotStaticDataDbActions;
+  env: EnvReader;
+  fetchJson: (url: string) => Promise<unknown>;
+  logger: Logger;
+};
+
+export type RiotStaticDataService = {
+  getChampionNameById(
+    championId: number,
+    locale?: string,
+  ): Promise<string | null>;
+  getChampionIconUrlById(
+    championId: number,
+    locale?: string,
+  ): Promise<string | null>;
+  getQueueNameById(queueId: number, locale?: string): Promise<string | null>;
+  getMapNameById(mapId: number, locale?: string): Promise<string | null>;
+  getGameModeName(gameMode: string, locale?: string): Promise<string | null>;
+  resolve(
+    input: RiotStaticDataResolveInput,
+  ): Promise<RiotStaticDataResolveResult>;
+};
+
+function numberEnv(env: EnvReader, name: string, fallback: number) {
+  const value = Number(env.get(name));
   return Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
-function cacheTtlMs() {
+function cacheTtlMs(env: EnvReader) {
   return numberEnv(
+    env,
     "RIOT_STATIC_DATA_CACHE_TTL_MS",
     DEFAULT_STATIC_DATA_CACHE_TTL_MS,
   );
 }
 
-function normalizeLocale(locale?: string) {
-  const raw = locale ?? Deno.env.get("BOT_MESSAGE_LANG") ??
-    Deno.env.get("API_MESSAGE_LANG") ?? "ja_JP";
+function normalizeLocale(env: EnvReader, locale?: string) {
+  const raw = locale ?? env.get("BOT_MESSAGE_LANG") ??
+    env.get("API_MESSAGE_LANG") ?? "ja_JP";
   return raw.replace("-", "_").split(".")[0];
 }
 
-function localizedQueueName(queueId: number, locale?: string) {
-  if (normalizeLocale(locale) === "ja_JP") {
+function localizedQueueName(env: EnvReader, queueId: number, locale?: string) {
+  if (normalizeLocale(env, locale) === "ja_JP") {
     return jaQueueNames[queueId] ?? null;
   }
   return null;
 }
 
-function localizedMapName(mapId: number, locale?: string) {
-  if (normalizeLocale(locale) === "ja_JP") {
+function localizedMapName(env: EnvReader, mapId: number, locale?: string) {
+  if (normalizeLocale(env, locale) === "ja_JP") {
     return jaMapNames[mapId] ?? null;
   }
   return null;
 }
 
-function localizedGameModeName(gameMode: string, locale?: string) {
-  if (normalizeLocale(locale) === "ja_JP") {
+function localizedGameModeName(
+  env: EnvReader,
+  gameMode: string,
+  locale?: string,
+) {
+  if (normalizeLocale(env, locale) === "ja_JP") {
     return jaGameModeNames[gameMode] ?? null;
   }
   return null;
 }
 
-function isFresh(updatedAt: Date, now = Date.now()) {
-  return now - updatedAt.getTime() < cacheTtlMs();
+function isFresh(env: EnvReader, updatedAt: Date, now = Date.now()) {
+  return now - updatedAt.getTime() < cacheTtlMs(env);
 }
 
-async function fetchJson(url: string) {
+export async function fetchRiotStaticDataJson(url: string) {
   const res = await fetch(url);
   if (!res.ok) {
     await res.body?.cancel();
@@ -145,12 +186,13 @@ const championCacheSchema = z.record(
 );
 
 async function cachedVersionedJson<T>(
+  deps: RiotStaticDataServiceDependencies,
   key: string,
   schema: z.ZodType<T>,
   fetcher: () => Promise<{ version: string; value: T }>,
 ) {
-  const cached = await dbActions.getRiotStaticDataCache(key);
-  if (cached && isFresh(cached.updatedAt)) {
+  const cached = await deps.dbActions.getRiotStaticDataCache(key);
+  if (cached && isFresh(deps.env, cached.updatedAt)) {
     return {
       version: cached.version,
       value: parseCachedValue(cached.value, schema),
@@ -159,7 +201,7 @@ async function cachedVersionedJson<T>(
 
   try {
     const fetched = await fetcher();
-    await dbActions.upsertRiotStaticDataCache({
+    await deps.dbActions.upsertRiotStaticDataCache({
       key,
       version: fetched.version,
       value: JSON.stringify(fetched.value),
@@ -167,7 +209,7 @@ async function cachedVersionedJson<T>(
     return fetched;
   } catch (error) {
     if (cached) {
-      apiLogger.warn("riot_static_data.cache_refresh_failed", {
+      deps.logger.warn("riot_static_data.cache_refresh_failed", {
         key,
         version: cached.version,
         error: error instanceof Error ? error.message : String(error),
@@ -182,29 +224,36 @@ async function cachedVersionedJson<T>(
 }
 
 async function cachedJson<T>(
+  deps: RiotStaticDataServiceDependencies,
   key: string,
   schema: z.ZodType<T>,
   fetcher: () => Promise<{ version: string; value: T }>,
 ) {
-  return (await cachedVersionedJson(key, schema, fetcher)).value;
+  return (await cachedVersionedJson(deps, key, schema, fetcher)).value;
 }
 
-async function getLatestDataDragonVersion() {
+async function getLatestDataDragonVersion(
+  deps: RiotStaticDataServiceDependencies,
+) {
   const versions = versionsSchema.parse(
-    await fetchJson(DATA_DRAGON_VERSIONS_URL),
+    await deps.fetchJson(DATA_DRAGON_VERSIONS_URL),
   );
   return versions[0];
 }
 
-async function getChampions(locale?: string) {
-  const normalizedLocale = normalizeLocale(locale);
+async function getChampions(
+  deps: RiotStaticDataServiceDependencies,
+  locale?: string,
+) {
+  const normalizedLocale = normalizeLocale(deps.env, locale);
   return await cachedVersionedJson(
+    deps,
     `champions-data:${normalizedLocale}`,
     championCacheSchema,
     async () => {
-      const version = await getLatestDataDragonVersion();
+      const version = await getLatestDataDragonVersion(deps);
       const data = championDataSchema.parse(
-        await fetchJson(
+        await deps.fetchJson(
           `${DATA_DRAGON_CDN_BASE}/${version}/data/${normalizedLocale}/champion.json`,
         ),
       );
@@ -223,10 +272,10 @@ async function getChampions(locale?: string) {
   );
 }
 
-async function getQueues() {
-  return await cachedJson("queues", stringRecordSchema, async () => {
+async function getQueues(deps: RiotStaticDataServiceDependencies) {
+  return await cachedJson(deps, "queues", stringRecordSchema, async () => {
     const queues = queuesSchema.parse(
-      await fetchJson(`${RIOT_STATIC_DOCS_BASE}/queues.json`),
+      await deps.fetchJson(`${RIOT_STATIC_DOCS_BASE}/queues.json`),
     );
     const names: Record<string, string> = {};
     for (const queue of queues) {
@@ -238,10 +287,10 @@ async function getQueues() {
   });
 }
 
-async function getMaps() {
-  return await cachedJson("maps", stringRecordSchema, async () => {
+async function getMaps(deps: RiotStaticDataServiceDependencies) {
+  return await cachedJson(deps, "maps", stringRecordSchema, async () => {
     const maps = mapsSchema.parse(
-      await fetchJson(`${RIOT_STATIC_DOCS_BASE}/maps.json`),
+      await deps.fetchJson(`${RIOT_STATIC_DOCS_BASE}/maps.json`),
     );
     const names: Record<string, string> = {};
     for (const map of maps) {
@@ -253,10 +302,10 @@ async function getMaps() {
   });
 }
 
-async function getGameModes() {
-  return await cachedJson("gameModes", stringRecordSchema, async () => {
+async function getGameModes(deps: RiotStaticDataServiceDependencies) {
+  return await cachedJson(deps, "gameModes", stringRecordSchema, async () => {
     const gameModes = gameModesSchema.parse(
-      await fetchJson(`${RIOT_STATIC_DOCS_BASE}/gameModes.json`),
+      await deps.fetchJson(`${RIOT_STATIC_DOCS_BASE}/gameModes.json`),
     );
     const names: Record<string, string> = {};
     for (const mode of gameModes) {
@@ -268,40 +317,60 @@ async function getGameModes() {
   });
 }
 
-async function getChampionNameById(championId: number, locale?: string) {
-  const { value: champions } = await getChampions(locale);
+async function getChampionNameById(
+  deps: RiotStaticDataServiceDependencies,
+  championId: number,
+  locale?: string,
+) {
+  const { value: champions } = await getChampions(deps, locale);
   return champions[String(championId)]?.name ?? null;
 }
 
-async function getChampionIconUrlById(championId: number, locale?: string) {
-  const { version, value: champions } = await getChampions(locale);
+async function getChampionIconUrlById(
+  deps: RiotStaticDataServiceDependencies,
+  championId: number,
+  locale?: string,
+) {
+  const { version, value: champions } = await getChampions(deps, locale);
   const file = champions[String(championId)]?.imageFull;
   return file
     ? `${DATA_DRAGON_CDN_BASE}/${version}/img/champion/${file}`
     : null;
 }
 
-async function getQueueNameById(queueId: number, locale?: string) {
-  const localizedName = localizedQueueName(queueId, locale);
+async function getQueueNameById(
+  deps: RiotStaticDataServiceDependencies,
+  queueId: number,
+  locale?: string,
+) {
+  const localizedName = localizedQueueName(deps.env, queueId, locale);
   if (localizedName) return localizedName;
 
-  const names = await getQueues();
+  const names = await getQueues(deps);
   return names[String(queueId)] ?? null;
 }
 
-async function getMapNameById(mapId: number, locale?: string) {
-  const localizedName = localizedMapName(mapId, locale);
+async function getMapNameById(
+  deps: RiotStaticDataServiceDependencies,
+  mapId: number,
+  locale?: string,
+) {
+  const localizedName = localizedMapName(deps.env, mapId, locale);
   if (localizedName) return localizedName;
 
-  const names = await getMaps();
+  const names = await getMaps(deps);
   return names[String(mapId)] ?? null;
 }
 
-async function getGameModeName(gameMode: string, locale?: string) {
-  const localizedName = localizedGameModeName(gameMode, locale);
+async function getGameModeName(
+  deps: RiotStaticDataServiceDependencies,
+  gameMode: string,
+  locale?: string,
+) {
+  const localizedName = localizedGameModeName(deps.env, gameMode, locale);
   if (localizedName) return localizedName;
 
-  const names = await getGameModes();
+  const names = await getGameModes(deps);
   return names[gameMode] ?? null;
 }
 
@@ -310,13 +379,14 @@ function unique<T>(values: T[] | undefined) {
 }
 
 async function resolveResource<T>(
+  deps: RiotStaticDataServiceDependencies,
   resource: string,
   load: () => Promise<T>,
 ): Promise<T | null> {
   try {
     return await load();
   } catch (error) {
-    apiLogger.warn(`riot_static_data.resolve_${resource}_failed`, {
+    deps.logger.warn(`riot_static_data.resolve_${resource}_failed`, {
       error: error instanceof Error ? error.message : String(error),
     });
     return null;
@@ -324,6 +394,7 @@ async function resolveResource<T>(
 }
 
 async function resolve(
+  deps: RiotStaticDataServiceDependencies,
   input: RiotStaticDataResolveInput,
 ): Promise<RiotStaticDataResolveResult> {
   const championIds = unique(input.championIds);
@@ -332,26 +403,32 @@ async function resolve(
   const gameModes = unique(input.gameModes);
 
   const needsQueues = queueIds.some((queueId) =>
-    localizedQueueName(queueId, input.locale) === null
+    localizedQueueName(deps.env, queueId, input.locale) === null
   );
   const needsMaps = mapIds.some((mapId) =>
-    localizedMapName(mapId, input.locale) === null
+    localizedMapName(deps.env, mapId, input.locale) === null
   );
   const needsGameModes = gameModes.some((gameMode) =>
-    localizedGameModeName(gameMode, input.locale) === null
+    localizedGameModeName(deps.env, gameMode, input.locale) === null
   );
 
   const [championData, queueNames, mapNames, gameModeNames] = await Promise.all(
     [
       championIds.length > 0
-        ? resolveResource("champions", () => getChampions(input.locale))
+        ? resolveResource(
+          deps,
+          "champions",
+          () => getChampions(deps, input.locale),
+        )
         : Promise.resolve(null),
       needsQueues
-        ? resolveResource("queues", getQueues)
+        ? resolveResource(deps, "queues", () => getQueues(deps))
         : Promise.resolve(null),
-      needsMaps ? resolveResource("maps", getMaps) : Promise.resolve(null),
+      needsMaps
+        ? resolveResource(deps, "maps", () => getMaps(deps))
+        : Promise.resolve(null),
       needsGameModes
-        ? resolveResource("game_modes", getGameModes)
+        ? resolveResource(deps, "game_modes", () => getGameModes(deps))
         : Promise.resolve(null),
     ],
   );
@@ -369,19 +446,24 @@ async function resolve(
 
   const queues: RiotStaticDataResolveResult["queues"] = {};
   for (const queueId of queueIds) {
-    queues[String(queueId)] = localizedQueueName(queueId, input.locale) ??
+    queues[String(queueId)] = localizedQueueName(
+      deps.env,
+      queueId,
+      input.locale,
+    ) ??
       queueNames?.[String(queueId)] ?? null;
   }
 
   const maps: RiotStaticDataResolveResult["maps"] = {};
   for (const mapId of mapIds) {
-    maps[String(mapId)] = localizedMapName(mapId, input.locale) ??
+    maps[String(mapId)] = localizedMapName(deps.env, mapId, input.locale) ??
       mapNames?.[String(mapId)] ?? null;
   }
 
   const resolvedGameModes: RiotStaticDataResolveResult["gameModes"] = {};
   for (const gameMode of gameModes) {
     resolvedGameModes[gameMode] = localizedGameModeName(
+      deps.env,
       gameMode,
       input.locale,
     ) ?? gameModeNames?.[gameMode] ?? null;
@@ -395,11 +477,19 @@ async function resolve(
   };
 }
 
-export const riotStaticData = {
-  getChampionNameById,
-  getChampionIconUrlById,
-  getQueueNameById,
-  getMapNameById,
-  getGameModeName,
-  resolve,
-};
+export function createRiotStaticData(
+  deps: RiotStaticDataServiceDependencies,
+): RiotStaticDataService {
+  return {
+    getChampionNameById: (championId, locale) =>
+      getChampionNameById(deps, championId, locale),
+    getChampionIconUrlById: (championId, locale) =>
+      getChampionIconUrlById(deps, championId, locale),
+    getQueueNameById: (queueId, locale) =>
+      getQueueNameById(deps, queueId, locale),
+    getMapNameById: (mapId, locale) => getMapNameById(deps, mapId, locale),
+    getGameModeName: (gameMode, locale) =>
+      getGameModeName(deps, gameMode, locale),
+    resolve: (input) => resolve(deps, input),
+  };
+}

--- a/api/src/services/opgg_match_detail.test.ts
+++ b/api/src/services/opgg_match_detail.test.ts
@@ -1,15 +1,13 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
-import { dbActions } from "../db/default_actions.ts";
 import type { RiotAccount } from "../db/schema.ts";
 import {
   OpggMatchParticipantMismatchError,
   RecordNotFoundError,
 } from "../errors.ts";
-import { opggClient, type OpggMatchDetail } from "../integrations/opgg.ts";
-import { apiLogger } from "../logger.ts";
-import { resolveAndSaveOpggMatchDetail } from "./opgg_match_detail.ts";
+import type { OpggMatchDetail } from "../integrations/opgg.ts";
+import { createOpggMatchDetailService } from "./opgg_match_detail.ts";
 
 function account(overrides: Partial<RiotAccount> = {}): RiotAccount {
   const now = new Date("2026-01-01T00:00:00.000Z");
@@ -63,47 +61,52 @@ function detail(): OpggMatchDetail {
   };
 }
 
-async function withOpggEnabled<T>(
-  enabled: boolean,
-  action: () => Promise<T>,
-) {
-  const original = Deno.env.get("OPGG_ENABLED");
-  enabled
-    ? Deno.env.set("OPGG_ENABLED", "true")
-    : Deno.env.delete("OPGG_ENABLED");
-  try {
-    return await action();
-  } finally {
-    original === undefined
-      ? Deno.env.delete("OPGG_ENABLED")
-      : Deno.env.set("OPGG_ENABLED", original);
-  }
+function dependencies(enabled = true) {
+  const deps = {
+    dbActions: {
+      getRiotAccountByDiscordId: (
+        _discordId: string,
+      ): Promise<RiotAccount | undefined> => Promise.resolve(account()),
+      upsertExternalMatchDetail: () => Promise.resolve(),
+    },
+    env: {
+      get: (key: string) =>
+        key === "OPGG_ENABLED" && enabled ? "true" : undefined,
+    },
+    logger: {
+      warn: (_message: string, _metadata?: Record<string, unknown>) => {},
+    },
+    opggClient: {
+      resolveMatchDetail: (): Promise<OpggMatchDetail | null> =>
+        Promise.resolve(detail()),
+    },
+  };
+  return deps;
 }
 
 describe("OP.GG試合詳細service", () => {
   test("OP.GG連携が無効なとき、アカウント取得と外部解決と保存を行わずnullを返す", async () => {
     // Arrange
+    const deps = dependencies(false);
+    const service = createOpggMatchDetailService(deps);
     using accountStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotAccountByDiscordId",
       () => Promise.resolve(account()),
     );
     using resolveStub = stub(
-      opggClient,
+      deps.opggClient,
       "resolveMatchDetail",
       () => Promise.resolve(detail()),
     );
     using saveStub = stub(
-      dbActions,
+      deps.dbActions,
       "upsertExternalMatchDetail",
       () => Promise.resolve(),
     );
 
     // Act
-    const result = await withOpggEnabled(
-      false,
-      () => resolveAndSaveOpggMatchDetail(input()),
-    );
+    const result = await service.resolveAndSave(input());
 
     // Assert
     assertEquals(result, null);
@@ -114,63 +117,64 @@ describe("OP.GG試合詳細service", () => {
 
   test("対象DiscordユーザーのRiotアカウントがないとき、RecordNotFoundErrorを返す", async () => {
     // Arrange
+    const deps = dependencies();
+    const service = createOpggMatchDetailService(deps);
     using _accountStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotAccountByDiscordId",
       () => Promise.resolve(undefined),
     );
 
     // Act / Assert
-    await withOpggEnabled(true, () =>
-      assertRejects(
-        () => resolveAndSaveOpggMatchDetail(input()),
-        RecordNotFoundError,
-        "Riot account not found",
-      ));
+    await assertRejects(
+      () => service.resolveAndSave(input()),
+      RecordNotFoundError,
+      "Riot account not found",
+    );
   });
 
   test("保存対象参加者とRiotアカウントのPUUIDが異なるとき、専用errorを返す", async () => {
     // Arrange
+    const deps = dependencies();
+    const service = createOpggMatchDetailService(deps);
     using _accountStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotAccountByDiscordId",
       () => Promise.resolve(account()),
     );
 
     // Act / Assert
-    await withOpggEnabled(true, () =>
-      assertRejects(
-        () =>
-          resolveAndSaveOpggMatchDetail(
-            input({ participantPuuid: "different-puuid" }),
-          ),
-        OpggMatchParticipantMismatchError,
-      ));
+    await assertRejects(
+      () =>
+        service.resolveAndSave(
+          input({ participantPuuid: "different-puuid" }),
+        ),
+      OpggMatchParticipantMismatchError,
+    );
   });
 
   test("OP.GGに該当試合がないとき、保存を行わずnullを返す", async () => {
     // Arrange
+    const deps = dependencies();
+    const service = createOpggMatchDetailService(deps);
     using _accountStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotAccountByDiscordId",
       () => Promise.resolve(account()),
     );
     using _resolveStub = stub(
-      opggClient,
+      deps.opggClient,
       "resolveMatchDetail",
       () => Promise.resolve(null),
     );
     using saveStub = stub(
-      dbActions,
+      deps.dbActions,
       "upsertExternalMatchDetail",
       () => Promise.resolve(),
     );
 
     // Act
-    const result = await withOpggEnabled(
-      true,
-      () => resolveAndSaveOpggMatchDetail(input()),
-    );
+    const result = await service.resolveAndSave(input());
 
     // Assert
     assertEquals(result, null);
@@ -179,29 +183,28 @@ describe("OP.GG試合詳細service", () => {
 
   test("OP.GGの外部解決が失敗したとき、警告を記録して保存せずnullを返す", async () => {
     // Arrange
+    const deps = dependencies();
+    const service = createOpggMatchDetailService(deps);
     const error = new Error("OP.GG unavailable");
     using _accountStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotAccountByDiscordId",
       () => Promise.resolve(account()),
     );
     using _resolveStub = stub(
-      opggClient,
+      deps.opggClient,
       "resolveMatchDetail",
       () => Promise.reject(error),
     );
     using saveStub = stub(
-      dbActions,
+      deps.dbActions,
       "upsertExternalMatchDetail",
       () => Promise.resolve(),
     );
-    using warnStub = stub(apiLogger, "warn");
+    using warnStub = stub(deps.logger, "warn");
 
     // Act
-    const result = await withOpggEnabled(
-      true,
-      () => resolveAndSaveOpggMatchDetail(input()),
-    );
+    const result = await service.resolveAndSave(input());
 
     // Assert
     assertEquals(result, null);
@@ -217,28 +220,27 @@ describe("OP.GG試合詳細service", () => {
 
   test("OP.GG詳細を解決できたとき、外部試合詳細を保存して同じ詳細を返す", async () => {
     // Arrange
+    const deps = dependencies();
+    const service = createOpggMatchDetailService(deps);
     const resolved = detail();
     using _accountStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotAccountByDiscordId",
       () => Promise.resolve(account()),
     );
     using resolveStub = stub(
-      opggClient,
+      deps.opggClient,
       "resolveMatchDetail",
       () => Promise.resolve(resolved),
     );
     using saveStub = stub(
-      dbActions,
+      deps.dbActions,
       "upsertExternalMatchDetail",
       () => Promise.resolve(),
     );
 
     // Act
-    const result = await withOpggEnabled(
-      true,
-      () => resolveAndSaveOpggMatchDetail(input()),
-    );
+    const result = await service.resolveAndSave(input());
 
     // Assert
     assertEquals(result, resolved);
@@ -260,29 +262,30 @@ describe("OP.GG試合詳細service", () => {
 
   test("OP.GG詳細の保存が失敗したとき、保存errorを呼び出し元へ伝播する", async () => {
     // Arrange
+    const deps = dependencies();
+    const service = createOpggMatchDetailService(deps);
     const saveError = new Error("database unavailable");
     using _accountStub = stub(
-      dbActions,
+      deps.dbActions,
       "getRiotAccountByDiscordId",
       () => Promise.resolve(account()),
     );
     using _resolveStub = stub(
-      opggClient,
+      deps.opggClient,
       "resolveMatchDetail",
       () => Promise.resolve(detail()),
     );
     using _saveStub = stub(
-      dbActions,
+      deps.dbActions,
       "upsertExternalMatchDetail",
       () => Promise.reject(saveError),
     );
 
     // Act / Assert
-    await withOpggEnabled(true, () =>
-      assertRejects(
-        () => resolveAndSaveOpggMatchDetail(input()),
-        Error,
-        "database unavailable",
-      ));
+    await assertRejects(
+      () => service.resolveAndSave(input()),
+      Error,
+      "database unavailable",
+    );
   });
 });

--- a/api/src/services/opgg_match_detail.ts
+++ b/api/src/services/opgg_match_detail.ts
@@ -1,10 +1,9 @@
-import { dbActions } from "../db/default_actions.ts";
+import type { DbActions } from "../db/actions.ts";
 import {
   OpggMatchParticipantMismatchError,
   RecordNotFoundError,
 } from "../errors.ts";
-import { opggClient } from "../integrations/opgg.ts";
-import { apiLogger } from "../logger.ts";
+import type { opggClient, OpggMatchDetail } from "../integrations/opgg.ts";
 
 export type ResolveAndSaveOpggMatchDetailInput = {
   matchId: string;
@@ -21,60 +20,86 @@ export type ResolveAndSaveOpggMatchDetailInput = {
   };
 };
 
-function booleanEnv(name: string) {
-  const value = Deno.env.get(name)?.toLowerCase();
+type EnvReader = {
+  get(key: string): string | undefined;
+};
+
+type OpggMatchDetailDbActions = Pick<
+  DbActions,
+  "getRiotAccountByDiscordId" | "upsertExternalMatchDetail"
+>;
+
+type Logger = {
+  warn(message: string, metadata?: Record<string, unknown>): void;
+};
+
+export type OpggMatchDetailServiceDependencies = {
+  dbActions: OpggMatchDetailDbActions;
+  env: EnvReader;
+  logger: Logger;
+  opggClient: Pick<typeof opggClient, "resolveMatchDetail">;
+};
+
+export type OpggMatchDetailService = {
+  resolveAndSave(
+    input: ResolveAndSaveOpggMatchDetailInput,
+  ): Promise<OpggMatchDetail | null>;
+};
+
+function booleanEnv(env: EnvReader, name: string) {
+  const value = env.get(name)?.toLowerCase();
   return value === "1" || value === "true" || value === "yes" ||
     value === "on";
 }
 
-export async function resolveAndSaveOpggMatchDetail(
-  input: ResolveAndSaveOpggMatchDetailInput,
-) {
-  if (!booleanEnv("OPGG_ENABLED")) return null;
+export function createOpggMatchDetailService(
+  deps: OpggMatchDetailServiceDependencies,
+): OpggMatchDetailService {
+  async function resolveAndSave(input: ResolveAndSaveOpggMatchDetailInput) {
+    if (!booleanEnv(deps.env, "OPGG_ENABLED")) return null;
 
-  const account = await dbActions.getRiotAccountByDiscordId(
-    input.targetDiscordId,
-  );
-  if (!account) {
-    throw new RecordNotFoundError(
-      `Riot account not found for Discord user ${input.targetDiscordId}`,
+    const account = await deps.dbActions.getRiotAccountByDiscordId(
+      input.targetDiscordId,
     );
-  }
-  if (account.puuid !== input.match.participant.puuid) {
-    throw new OpggMatchParticipantMismatchError(
-      `Match participant does not belong to Discord user ${input.targetDiscordId}`,
-    );
-  }
+    if (!account) {
+      throw new RecordNotFoundError(
+        `Riot account not found for Discord user ${input.targetDiscordId}`,
+      );
+    }
+    if (account.puuid !== input.match.participant.puuid) {
+      throw new OpggMatchParticipantMismatchError(
+        `Match participant does not belong to Discord user ${input.targetDiscordId}`,
+      );
+    }
 
-  let detail;
-  try {
-    detail = await opggClient.resolveMatchDetail(account, {
-      metadata: { matchId: input.matchId },
-      info: {
-        gameCreation: input.match.gameCreation,
-        gameDuration: input.match.gameDuration,
-        queueId: input.match.queueId,
-        participants: [input.match.participant],
-      },
-    });
-  } catch (error) {
-    apiLogger.warn("opgg_match_detail.resolve_failed", {
-      targetDiscordId: input.targetDiscordId,
+    let detail;
+    try {
+      detail = await deps.opggClient.resolveMatchDetail(account, {
+        metadata: { matchId: input.matchId },
+        info: {
+          gameCreation: input.match.gameCreation,
+          gameDuration: input.match.gameDuration,
+          queueId: input.match.queueId,
+          participants: [input.match.participant],
+        },
+      });
+    } catch (error) {
+      deps.logger.warn("opgg_match_detail.resolve_failed", {
+        targetDiscordId: input.targetDiscordId,
+        matchId: input.matchId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+
+    if (!detail) return null;
+
+    await deps.dbActions.upsertExternalMatchDetail({
       matchId: input.matchId,
-      error: error instanceof Error ? error.message : String(error),
+      ...detail,
     });
-    return null;
+    return detail;
   }
 
-  if (!detail) return null;
-
-  await dbActions.upsertExternalMatchDetail({
-    matchId: input.matchId,
-    ...detail,
-  });
-  return detail;
+  return { resolveAndSave };
 }
-
-export const opggMatchDetailService = {
-  resolveAndSave: resolveAndSaveOpggMatchDetail,
-};

--- a/api/src/services/opgg_match_detail.ts
+++ b/api/src/services/opgg_match_detail.ts
@@ -52,54 +52,59 @@ function booleanEnv(env: EnvReader, name: string) {
     value === "on";
 }
 
+async function resolveAndSave(
+  deps: OpggMatchDetailServiceDependencies,
+  input: ResolveAndSaveOpggMatchDetailInput,
+) {
+  if (!booleanEnv(deps.env, "OPGG_ENABLED")) return null;
+
+  const account = await deps.dbActions.getRiotAccountByDiscordId(
+    input.targetDiscordId,
+  );
+  if (!account) {
+    throw new RecordNotFoundError(
+      `Riot account not found for Discord user ${input.targetDiscordId}`,
+    );
+  }
+  if (account.puuid !== input.match.participant.puuid) {
+    throw new OpggMatchParticipantMismatchError(
+      `Match participant does not belong to Discord user ${input.targetDiscordId}`,
+    );
+  }
+
+  let detail;
+  try {
+    detail = await deps.opggClient.resolveMatchDetail(account, {
+      metadata: { matchId: input.matchId },
+      info: {
+        gameCreation: input.match.gameCreation,
+        gameDuration: input.match.gameDuration,
+        queueId: input.match.queueId,
+        participants: [input.match.participant],
+      },
+    });
+  } catch (error) {
+    deps.logger.warn("opgg_match_detail.resolve_failed", {
+      targetDiscordId: input.targetDiscordId,
+      matchId: input.matchId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+
+  if (!detail) return null;
+
+  await deps.dbActions.upsertExternalMatchDetail({
+    matchId: input.matchId,
+    ...detail,
+  });
+  return detail;
+}
+
 export function createOpggMatchDetailService(
   deps: OpggMatchDetailServiceDependencies,
 ): OpggMatchDetailService {
-  async function resolveAndSave(input: ResolveAndSaveOpggMatchDetailInput) {
-    if (!booleanEnv(deps.env, "OPGG_ENABLED")) return null;
-
-    const account = await deps.dbActions.getRiotAccountByDiscordId(
-      input.targetDiscordId,
-    );
-    if (!account) {
-      throw new RecordNotFoundError(
-        `Riot account not found for Discord user ${input.targetDiscordId}`,
-      );
-    }
-    if (account.puuid !== input.match.participant.puuid) {
-      throw new OpggMatchParticipantMismatchError(
-        `Match participant does not belong to Discord user ${input.targetDiscordId}`,
-      );
-    }
-
-    let detail;
-    try {
-      detail = await deps.opggClient.resolveMatchDetail(account, {
-        metadata: { matchId: input.matchId },
-        info: {
-          gameCreation: input.match.gameCreation,
-          gameDuration: input.match.gameDuration,
-          queueId: input.match.queueId,
-          participants: [input.match.participant],
-        },
-      });
-    } catch (error) {
-      deps.logger.warn("opgg_match_detail.resolve_failed", {
-        targetDiscordId: input.targetDiscordId,
-        matchId: input.matchId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return null;
-    }
-
-    if (!detail) return null;
-
-    await deps.dbActions.upsertExternalMatchDetail({
-      matchId: input.matchId,
-      ...detail,
-    });
-    return detail;
-  }
-
-  return { resolveAndSave };
+  return {
+    resolveAndSave: (input) => resolveAndSave(deps, input),
+  };
 }


### PR DESCRIPTION
## 概要

- #79 の残課題として、Backend service 層の default singleton 依存を整理しました
- `createOpggMatchDetailService` と `createRiotStaticData` を導入し、DB actions / env / logger / 外部 client を `default_dependencies.ts` から注入する構成にしました
- service tests を default `dbActions` / `Deno.env` / global fetch stub から、factory に fake dependency を渡す形へ移行しました

## 背景

#79 の受け入れ条件では route/service が必要な repository interface だけへ依存することが求められています。route 側は既に注入済みでしたが、`opgg_match_detail.ts` と `riot_static_data.ts` が `db/default_actions.ts` や環境変数へ直接依存していたため、composition root 外に singleton 依存が残っていました。

## 影響

- HTTP API の URL / status / response body は変更していません
- 既存の service 挙動は維持し、依存の組み立て位置だけを `default_dependencies.ts` に寄せています
- Bot runtime boundary の検査も引き続き通っています

## 確認

- `deno task quality`

Closes #79