### PR TITLE
[codex] logger依存をAppDependencies経由にする

### DIFF
--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -1,13 +1,14 @@
 import { testClient } from "@hono/hono/testing";
 import { Hono } from "@hono/hono";
-import { assertEquals, assertMatch } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
-import { assertSpyCalls, stub } from "@std/testing/mock";
-import { createApp, requestLoggingMiddleware } from "./app.ts";
+import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
+import { createApp, createRequestLoggingMiddleware } from "./app.ts";
 import { createTestDependencies } from "./test_utils.ts";
 
 describe("app.ts", () => {
-  const app = createApp(createTestDependencies());
+  const deps = createTestDependencies();
+  const app = createApp(deps);
   const client = testClient(app);
 
   describe("GET /health", () => {
@@ -22,33 +23,33 @@ describe("app.ts", () => {
         assertEquals(body.message, "This API is healthy!");
       });
 
-      test("リクエストを送信したとき、HTTPメソッドとパス、ステータスを含む構造化ログを出力する", async () => {
+      test("リクエストを送信したとき、HTTPメソッドとパス、ステータスを含むログを注入loggerへ出力する", async () => {
         // Arrange
-        using consoleLogStub = stub(console, "log");
+        using infoStub = stub(deps.logger, "info", () => {});
 
         // Act
         await client.health.$get();
 
         // Assert
-        assertSpyCalls(consoleLogStub, 1);
-        const [firstCall] = consoleLogStub.calls;
-        const [logPayload] = firstCall.args;
-        assertEquals(typeof logPayload, "string");
-        const parsed = JSON.parse(logPayload as string);
-        assertEquals(parsed.component, "api");
-        assertEquals(parsed.level, "INFO");
-        assertEquals(parsed.message, "request.completed");
-        assertEquals(parsed.http.method, "GET");
-        assertEquals(parsed.http.path, "/health");
-        assertEquals(parsed.http.status, 200);
-        assertMatch(parsed.timestamp, /^\d{4}-\d{2}-\d{2}T/);
+        assertSpyCall(infoStub, 0, {
+          args: ["request.completed", {
+            http: {
+              method: "GET",
+              path: "/health",
+              status: 200,
+            },
+            durationMs: infoStub.calls[0].args[1]?.durationMs,
+          }],
+        });
+        assertEquals(typeof infoStub.calls[0].args[1]?.durationMs, "number");
       });
 
-      test("ハンドラ例外で500が返るとき、失敗リクエストとしてERRORログを出力する", async () => {
+      test("ハンドラ例外で500が返るとき、失敗リクエストとして注入loggerへERRORログを出力する", async () => {
         // Arrange
-        using consoleLogStub = stub(console, "log");
+        const logger = createTestDependencies().logger;
+        using errorStub = stub(logger, "error", () => {});
         const failingApp = new Hono()
-          .use("*", requestLoggingMiddleware)
+          .use("*", createRequestLoggingMiddleware(logger))
           .get("/error", () => {
             throw new Error("Unexpected failure");
           });
@@ -58,17 +59,18 @@ describe("app.ts", () => {
 
         // Assert
         assertEquals(res.status, 500);
-        assertSpyCalls(consoleLogStub, 1);
-        const [firstCall] = consoleLogStub.calls;
-        const [logPayload] = firstCall.args;
-        assertEquals(typeof logPayload, "string");
-        const parsed = JSON.parse(logPayload as string);
-        assertEquals(parsed.component, "api");
-        assertEquals(parsed.level, "ERROR");
-        assertEquals(parsed.message, "request.failed");
-        assertEquals(parsed.http.method, "GET");
-        assertEquals(parsed.http.path, "/error");
-        assertEquals(parsed.http.status, 500);
+        assertSpyCalls(errorStub, 1);
+        assertEquals(errorStub.calls[0].args[0], "request.failed");
+        assertEquals(errorStub.calls[0].args[1], {
+          http: {
+            method: "GET",
+            path: "/error",
+            status: 500,
+          },
+          durationMs: errorStub.calls[0].args[1]?.durationMs,
+        });
+        assertEquals(typeof errorStub.calls[0].args[1]?.durationMs, "number");
+        assertEquals(errorStub.calls[0].args.length, 2);
       });
     });
   });

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -1,6 +1,6 @@
 import { testClient } from "@hono/hono/testing";
 import { Hono } from "@hono/hono";
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects, assertStrictEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCalls, stub } from "@std/testing/mock";
 import { createApp, createRequestLoggingMiddleware } from "./app.ts";
@@ -66,7 +66,40 @@ describe("app.ts", () => {
           status: 500,
         });
         assertEquals(typeof context?.durationMs, "number");
-        assertEquals(errorStub.calls[0].args.length, 2);
+      });
+
+      test("下流middlewareが例外を再throwしたとき、失敗リクエストと例外を注入loggerへERRORログ出力する", async () => {
+        // Arrange
+        const logger = createTestDependencies().logger;
+        using errorStub = stub(logger, "error", () => {});
+        const middleware = createRequestLoggingMiddleware(logger);
+        const error = new Error("Unexpected failure");
+        const context = {
+          req: {
+            method: "POST",
+            path: "/error",
+          },
+          res: new Response(null, { status: 200 }),
+        } as unknown as Parameters<typeof middleware>[0];
+
+        // Act
+        await assertRejects(
+          () => middleware(context, () => Promise.reject(error)),
+          Error,
+          error.message,
+        );
+
+        // Assert
+        assertSpyCalls(errorStub, 1);
+        const [message, logContext, loggedError] = errorStub.calls[0].args;
+        assertEquals(message, "request.failed");
+        assertEquals(logContext?.http, {
+          method: "POST",
+          path: "/error",
+          status: 500,
+        });
+        assertEquals(typeof logContext?.durationMs, "number");
+        assertStrictEquals(loggedError, error);
       });
     });
   });

--- a/api/src/app.test.ts
+++ b/api/src/app.test.ts
@@ -2,7 +2,7 @@ import { testClient } from "@hono/hono/testing";
 import { Hono } from "@hono/hono";
 import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
-import { assertSpyCall, assertSpyCalls, stub } from "@std/testing/mock";
+import { assertSpyCalls, stub } from "@std/testing/mock";
 import { createApp, createRequestLoggingMiddleware } from "./app.ts";
 import { createTestDependencies } from "./test_utils.ts";
 
@@ -31,17 +31,15 @@ describe("app.ts", () => {
         await client.health.$get();
 
         // Assert
-        assertSpyCall(infoStub, 0, {
-          args: ["request.completed", {
-            http: {
-              method: "GET",
-              path: "/health",
-              status: 200,
-            },
-            durationMs: infoStub.calls[0].args[1]?.durationMs,
-          }],
+        assertSpyCalls(infoStub, 1);
+        const [message, context] = infoStub.calls[0].args;
+        assertEquals(message, "request.completed");
+        assertEquals(context?.http, {
+          method: "GET",
+          path: "/health",
+          status: 200,
         });
-        assertEquals(typeof infoStub.calls[0].args[1]?.durationMs, "number");
+        assertEquals(typeof context?.durationMs, "number");
       });
 
       test("ハンドラ例外で500が返るとき、失敗リクエストとして注入loggerへERRORログを出力する", async () => {
@@ -60,16 +58,14 @@ describe("app.ts", () => {
         // Assert
         assertEquals(res.status, 500);
         assertSpyCalls(errorStub, 1);
-        assertEquals(errorStub.calls[0].args[0], "request.failed");
-        assertEquals(errorStub.calls[0].args[1], {
-          http: {
-            method: "GET",
-            path: "/error",
-            status: 500,
-          },
-          durationMs: errorStub.calls[0].args[1]?.durationMs,
+        const [message, context] = errorStub.calls[0].args;
+        assertEquals(message, "request.failed");
+        assertEquals(context?.http, {
+          method: "GET",
+          path: "/error",
+          status: 500,
         });
-        assertEquals(typeof errorStub.calls[0].args[1]?.durationMs, "number");
+        assertEquals(typeof context?.durationMs, "number");
         assertEquals(errorStub.calls[0].args.length, 2);
       });
     });

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -7,50 +7,53 @@ import { matchWatchersRoutes } from "./routes/match_watchers.ts";
 import { authRoutes } from "./routes/auth.ts";
 import { riotRoutes } from "./routes/riot.ts";
 import { riotStaticDataRoutes } from "./routes/riot_static_data.ts";
-import { apiLogger } from "./logger.ts";
 import type { AppDependencies } from "./dependencies.ts";
 
-export const requestLoggingMiddleware = createMiddleware(async (c, next) => {
-  const start = performance.now();
-  try {
-    await next();
-    const durationMs = Math.round(performance.now() - start);
-    const context = {
-      http: {
-        method: c.req.method,
-        path: c.req.path,
-        status: c.res.status,
-      },
-      durationMs,
-    };
-
-    if (c.res.status >= 500) {
-      apiLogger.error("request.failed", context);
-      return;
-    }
-
-    apiLogger.info("request.completed", context);
-  } catch (error) {
-    const durationMs = Math.round(performance.now() - start);
-    apiLogger.error(
-      "request.failed",
-      {
+export function createRequestLoggingMiddleware(
+  logger: AppDependencies["logger"],
+) {
+  return createMiddleware(async (c, next) => {
+    const start = performance.now();
+    try {
+      await next();
+      const durationMs = Math.round(performance.now() - start);
+      const context = {
         http: {
           method: c.req.method,
           path: c.req.path,
-          status: c.res.status >= 500 ? c.res.status : 500,
+          status: c.res.status,
         },
         durationMs,
-      },
-      error,
-    );
-    throw error;
-  }
-});
+      };
+
+      if (c.res.status >= 500) {
+        logger.error("request.failed", context);
+        return;
+      }
+
+      logger.info("request.completed", context);
+    } catch (error) {
+      const durationMs = Math.round(performance.now() - start);
+      logger.error(
+        "request.failed",
+        {
+          http: {
+            method: c.req.method,
+            path: c.req.path,
+            status: c.res.status >= 500 ? c.res.status : 500,
+          },
+          durationMs,
+        },
+        error,
+      );
+      throw error;
+    }
+  });
+}
 
 export function createApp(deps: AppDependencies) {
   return new Hono()
-    .use("*", requestLoggingMiddleware)
+    .use("*", createRequestLoggingMiddleware(deps.logger))
     .get("/health", (c) => {
       return c.json({ message: "This API is healthy!" });
     })

--- a/api/src/default_dependencies.ts
+++ b/api/src/default_dependencies.ts
@@ -31,4 +31,5 @@ export const defaultDependencies = {
   riotStaticData,
   opggMatchDetailService,
   env: Deno.env,
+  logger: apiLogger,
 } satisfies AppDependencies;

--- a/api/src/dependencies.ts
+++ b/api/src/dependencies.ts
@@ -3,6 +3,7 @@ import type { riotApi } from "./riot_api.ts";
 import type { rso } from "./rso.ts";
 import type { RiotStaticDataService } from "./riot_static_data.ts";
 import type { OpggMatchDetailService } from "./services/opgg_match_detail.ts";
+import type { StructuredLogger } from "../../lib/logger/mod.ts";
 
 export type EnvReader = {
   get(key: string): string | undefined;
@@ -15,4 +16,5 @@ export type AppDependencies = {
   riotStaticData: RiotStaticDataService;
   opggMatchDetailService: OpggMatchDetailService;
   env: EnvReader;
+  logger: StructuredLogger;
 };

--- a/api/src/routes/matches.test.ts
+++ b/api/src/routes/matches.test.ts
@@ -9,12 +9,11 @@ import {
   OpggMatchParticipantMismatchError,
   RecordNotFoundError,
 } from "../errors.ts";
-import { apiLogger } from "../logger.ts";
 
 describe("routes/matches.ts", () => {
   const deps = createTestDependencies();
   const app = createApp(deps);
-  const { dbActions, opggMatchDetailService } = deps;
+  const { dbActions, opggMatchDetailService, logger } = deps;
   const client = testClient(app);
 
   describe("POST /matches/rank-snapshots/pending", () => {
@@ -235,7 +234,7 @@ describe("routes/matches.ts", () => {
         "resolveAndSave",
         () => Promise.resolve(null),
       );
-      using warnStub = stub(apiLogger, "warn", () => {});
+      using warnStub = stub(logger, "warn", () => {});
 
       // Act
       const res = await app.request(
@@ -330,7 +329,7 @@ describe("routes/matches.ts", () => {
         "resolveAndSave",
         () => Promise.reject(error),
       );
-      using errorStub = stub(apiLogger, "error", () => {});
+      using errorStub = stub(logger, "error", () => {});
 
       // Act
       const res = await app.request(

--- a/api/src/routes/matches.ts
+++ b/api/src/routes/matches.ts
@@ -10,7 +10,6 @@ import {
   OpggMatchParticipantMismatchError,
   RecordNotFoundError,
 } from "../errors.ts";
-import { apiLogger } from "../logger.ts";
 import type { AppDependencies } from "../dependencies.ts";
 
 type MatchesDbActions = Pick<
@@ -24,9 +23,10 @@ export function matchesRoutes(
   deps: {
     dbActions: MatchesDbActions;
     opggMatchDetailService: AppDependencies["opggMatchDetailService"];
+    logger: AppDependencies["logger"];
   },
 ) {
-  const { dbActions, opggMatchDetailService } = deps;
+  const { dbActions, opggMatchDetailService, logger } = deps;
   return new Hono()
     .post(
       "/rank-snapshots/pending",
@@ -54,7 +54,7 @@ export function matchesRoutes(
       "/:matchId/external-details/opgg/resolve",
       zValidator("json", resolveOpggMatchDetailSchema, (result, c) => {
         if (!result.success) {
-          apiLogger.warn("opgg_match_detail.invalid_request", {
+          logger.warn("opgg_match_detail.invalid_request", {
             validationIssues: result.error.issues.map((issue) => ({
               code: issue.code,
               path: issue.path,
@@ -80,7 +80,7 @@ export function matchesRoutes(
           if (error instanceof OpggMatchParticipantMismatchError) {
             return c.json({ error: error.message }, 400);
           }
-          apiLogger.error(
+          logger.error(
             "opgg_match_detail.request_failed",
             {
               matchId,

--- a/api/src/test_utils.ts
+++ b/api/src/test_utils.ts
@@ -9,6 +9,7 @@ type TestDependencyOverrides = {
   riotStaticData?: Partial<AppDependencies["riotStaticData"]>;
   opggMatchDetailService?: Partial<AppDependencies["opggMatchDetailService"]>;
   env?: Partial<AppDependencies["env"]>;
+  logger?: Partial<AppDependencies["logger"]>;
 };
 
 function unexpectedDependencyCall(name: string): never {
@@ -108,6 +109,12 @@ export function createTestDependencies(
     env: {
       get: () => undefined,
       ...overrides.env,
+    },
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      ...overrides.logger,
     },
   };
 


### PR DESCRIPTION
## 概要

- `AppDependencies` に `logger` を追加し、API app composition root から注入するようにしました。
- `matchesRoutes` の `apiLogger` singleton 直接 import を廃止しました。
- request logging middleware を `createRequestLoggingMiddleware(logger)` にし、`createApp(deps)` から注入 logger を渡す構成にしました。
- route / app test は公開 singleton や `console.log` ではなく、`createTestDependencies()` の fake logger を stub する形へ更新しました。

## 背景

#71 の最新コメントで、Backend基盤整理後も `matchesRoutes` と route test が `apiLogger` singleton に直接依存している点が指摘されていました。#71 の方針である module-level singleton の composition root への集約に合わせ、logger も依存注入対象に寄せています。

あわせて #71 本文の checklist は、完了済みの `#69` / `#76` / `#78` / `#79` を `[x]` に同期済みです。

## 影響

HTTP API契約やレスポンスの成否判定は変更していません。production では従来通り `apiLogger` を `defaultDependencies` から注入します。テストでは公開 singleton を stub せず、テスト用依存の logger fake を使います。

## 検証

- `deno task quality`