### PR TITLE
[codex] refactor(bot): API client factoryを導入する

### DIFF
--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -581,6 +581,15 @@ describe("apiClient", () => {
       assertEquals(result, { success: true, detail: null });
     });
 
+    test("OP.GG試合詳細レスポンスにdetailがないとき、成功結果とdetail nullを返す", async () => {
+      const rpc = createRpcClientStub([response({})]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.resolveOpggMatchDetail(matchId, payload);
+
+      assertEquals(result, { success: true, detail: null });
+    });
+
     test("Backend APIがOP.GG試合詳細を解決できないとき、失敗結果とエラーを返す", async () => {
       const error = "Failed to resolve OP.GG match detail";
       const rpc = createRpcClientStub([response({ error }, 500)]);

--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -1,78 +1,146 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
-import { assertSpyCalls, stub } from "@std/testing/mock";
-import { apiClient } from "./api_client.ts";
 import { type Client } from "@adteemo/api/contract";
-import { type InferResponseType } from "@hono/hono";
+import { createApiClient } from "./api_client.ts";
 
-type PostResponse = InferResponseType<Client["health"]["$get"]>;
+type RpcCall = {
+  method: string;
+  path: string;
+  args: unknown[];
+};
+
+type RpcResponse = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<unknown>;
+};
+
+type QueuedRpcResult = RpcResponse | Error;
+
+function response(body: unknown, status = 200): RpcResponse {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(body),
+  };
+}
+
+function createRpcClientStub(results: QueuedRpcResult[]) {
+  const calls: RpcCall[] = [];
+
+  function build(pathParts: string[]): unknown {
+    return new Proxy({}, {
+      get(_target, prop) {
+        if (typeof prop !== "string") {
+          return undefined;
+        }
+
+        if (prop.startsWith("$")) {
+          return (...args: unknown[]) => {
+            calls.push({
+              method: prop,
+              path: `/${pathParts.join("/")}`,
+              args,
+            });
+
+            const result = results.shift();
+            if (result === undefined) {
+              return Promise.reject(new Error("RPC result is not queued"));
+            }
+            if (result instanceof Error) {
+              return Promise.reject(result);
+            }
+
+            return Promise.resolve(result);
+          };
+        }
+
+        return build([...pathParts, prop]);
+      },
+    });
+  }
+
+  return {
+    calls,
+    rpcClient: build([]) as Client,
+  };
+}
 
 describe("apiClient", () => {
-  describe("checkHealth", () => {
-    test("APIが正常な場合にヘルスチェックを実行すると、成功ステータスとメッセージが返される", async () => {
+  describe("createApiClient", () => {
+    test("API_URLが未設定でもmodule importとclient生成ができ、環境変数を要求しない", async () => {
       // Arrange
-      const mockHealthGetResponse: PostResponse = { message: "Healthy" };
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify(mockHealthGetResponse), {
-              status: 200,
-            }),
-          ),
-      );
+      const originalApiUrl = Deno.env.get("API_URL");
+      Deno.env.delete("API_URL");
+      try {
+        const imported = await import(
+          `./api_client.ts?api_url_import_test=${Date.now()}`
+        );
+        const rpc = createRpcClientStub([response({ message: "Healthy" })]);
+        const client = imported.createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.checkHealth();
+        // Act
+        const result = await client.checkHealth();
 
-      // Assert
-      assertEquals(result.success, true);
-      assertEquals(result.message, "Healthy");
-      assertSpyCalls(fetchStub, 1);
-    });
-
-    test("APIが200以外のステータスを返す場合にヘルスチェックを実行すると、エラーステータスが返される", async () => {
-      // Arrange
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response("Internal Server Error", { status: 500 }),
-          ),
-      );
-
-      // Act
-      const result = await apiClient.checkHealth();
-
-      // Assert
-      assertEquals(result.success, false);
-      assertEquals(result.error, "Failed to communicate with API");
-      assertSpyCalls(fetchStub, 1);
-    });
-
-    test("fetchに失敗した場合にヘルスチェックを実行すると、通信失敗のエラーが返される", async () => {
-      // Arrange
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () => Promise.reject(new Error("Network error")),
-      );
-
-      // Act
-      const result = await apiClient.checkHealth();
-
-      // Assert
-      assertEquals(result.success, false);
-      assertEquals(result.error, "Failed to communicate with API");
-      assertSpyCalls(fetchStub, 1);
+        // Assert
+        assertEquals(result, { success: true, message: "Healthy" });
+        assertEquals(rpc.calls.length, 1);
+        assertEquals(rpc.calls[0].path, "/health");
+        assertEquals(rpc.calls[0].method, "$get");
+      } finally {
+        if (originalApiUrl === undefined) {
+          Deno.env.delete("API_URL");
+        } else {
+          Deno.env.set("API_URL", originalApiUrl);
+        }
+      }
     });
   });
 
-  describe("getCustomGameEventsByCreatorId", () => {
+  describe("checkHealth", () => {
+    test("APIが正常な場合にヘルスチェックを実行すると、成功ステータスとメッセージが返される", async () => {
+      const rpc = createRpcClientStub([response({ message: "Healthy" })]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.checkHealth();
+
+      assertEquals(result.success, true);
+      if (!result.success) return;
+      assertEquals(result.message, "Healthy");
+      assertEquals(rpc.calls.length, 1);
+    });
+
+    test("APIが200以外のステータスを返す場合にヘルスチェックを実行すると、HTTPステータスを失敗として扱う", async () => {
+      const rpc = createRpcClientStub([response("Internal Server Error", 500)]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.checkHealth();
+
+      assertEquals(result, {
+        success: false,
+        error: "Failed to communicate with API",
+      });
+      assertEquals(rpc.calls.length, 1);
+    });
+
+    test("RPC clientが失敗した場合にヘルスチェックを実行すると、通信失敗のエラーが返される", async () => {
+      const rpc = createRpcClientStub([new Error("Network error")]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.checkHealth();
+
+      assertEquals(result, {
+        success: false,
+        error: "Failed to communicate with API",
+      });
+      assertEquals(rpc.calls.length, 1);
+    });
+  });
+
+  describe("events", () => {
     test("APIがイベント一覧の日付フィールドを文字列で返すとき、イベント一覧を取得するとDateへ変換して返す", async () => {
-      // Arrange
       const event = {
         id: 1,
         name: "週末カスタム",
@@ -83,46 +151,29 @@ describe("apiClient", () => {
         scheduledStartAt: "2026-07-04T12:00:00.000Z",
         createdAt: "2026-07-01T00:00:00.000Z",
       };
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify({ events: [event] }), {
-              status: 200,
-            }),
-          ),
-      );
+      const rpc = createRpcClientStub([response({ events: [event] })]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.getCustomGameEventsByCreatorId(
-        "creator-1",
-      );
+      const result = await client.getCustomGameEventsByCreatorId("creator-1");
 
-      // Assert
       assertEquals(result.success, true);
       if (!result.success) return;
       assertEquals(
         result.events[0].scheduledStartAt,
-        new Date(
-          "2026-07-04T12:00:00.000Z",
-        ),
+        new Date("2026-07-04T12:00:00.000Z"),
       );
       assertEquals(
         result.events[0].createdAt,
         new Date("2026-07-01T00:00:00.000Z"),
       );
-      assertSpyCalls(fetchStub, 1);
-      assertEquals(
-        fetchStub.calls[0].args[0],
-        `${Deno.env.get("API_URL")}/events/by-creator/creator-1`,
-      );
+      assertEquals(rpc.calls[0], {
+        method: "$get",
+        path: "/events/by-creator/:creatorId",
+        args: [{ param: { creatorId: "creator-1" } }],
+      });
     });
-  });
 
-  describe("getEventStartingTodayByCreatorId", () => {
     test("APIが今日開始イベントの日付フィールドを文字列で返すとき、イベントを取得するとDateへ変換して返す", async () => {
-      // Arrange
       const event = {
         id: 2,
         name: "今日のカスタム",
@@ -133,153 +184,106 @@ describe("apiClient", () => {
         scheduledStartAt: "2026-07-05T11:00:00.000Z",
         createdAt: "2026-07-01T01:00:00.000Z",
       };
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify({ event }), {
-              status: 200,
-            }),
-          ),
-      );
+      const rpc = createRpcClientStub([response({ event })]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.getEventStartingTodayByCreatorId(
-        "creator-1",
-      );
+      const result = await client.getEventStartingTodayByCreatorId("creator-1");
 
-      // Assert
       assertEquals(result.success, true);
       if (!result.success) return;
       assertEquals(
         result.event.scheduledStartAt,
-        new Date(
-          "2026-07-05T11:00:00.000Z",
-        ),
+        new Date("2026-07-05T11:00:00.000Z"),
       );
       assertEquals(
         result.event.createdAt,
         new Date("2026-07-01T01:00:00.000Z"),
       );
-      assertSpyCalls(fetchStub, 1);
-      assertEquals(
-        fetchStub.calls[0].args[0],
-        `${Deno.env.get("API_URL")}/events/today/by-creator/creator-1`,
-      );
+      assertEquals(rpc.calls[0].path, "/events/today/by-creator/:creatorId");
+      assertEquals(rpc.calls[0].args, [{ param: { creatorId: "creator-1" } }]);
     });
   });
 
-  describe("getEnabledMatchWatchers", () => {
-    test("監視設定の日付フィールドをDateまたはnullへ変換する", async () => {
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(
-              JSON.stringify({
-                watchers: [{
-                  guildId: "guild-1",
-                  targetDiscordId: "target-1",
-                  requesterId: "requester-1",
-                  channelId: "channel-1",
-                  enabled: true,
-                  lastState: "IN_GAME",
-                  currentGameId: "12345",
-                  currentMatchId: null,
-                  currentNotificationMessageId: "message-1",
-                  pendingResultMatchId: "JP1_12344",
-                  pendingResultNotificationMessageId: "message-0",
-                  pendingResultStartedAt: "2026-01-01T00:00:00.000Z",
-                  gameStartedAt: "2026-01-01T00:01:00.000Z",
-                  lastCheckedAt: null,
-                  lastInGameNotifiedAt: "2026-01-01T00:02:00.000Z",
-                  createdAt: "2026-01-01T00:00:00.000Z",
-                  updatedAt: "2026-01-01T00:03:00.000Z",
-                }],
-              }),
-              { status: 200 },
-            ),
-          ),
-      );
+  describe("match watchers", () => {
+    const watcher = {
+      guildId: "guild-1",
+      targetDiscordId: "target-1",
+      requesterId: "requester-1",
+      channelId: "channel-1",
+      enabled: true,
+      lastState: "IN_GAME",
+      currentGameId: "12345",
+      currentMatchId: null,
+      currentNotificationMessageId: "message-1",
+      pendingResultMatchId: "JP1_12344",
+      pendingResultNotificationMessageId: "message-0",
+      pendingResultStartedAt: "2026-01-01T00:00:00.000Z",
+      gameStartedAt: "2026-01-01T00:01:00.000Z",
+      lastCheckedAt: null,
+      lastInGameNotifiedAt: "2026-01-01T00:02:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:03:00.000Z",
+    };
 
-      const result = await apiClient.getEnabledMatchWatchers();
+    test("監視設定の日付フィールドをDateまたはnullへ変換する", async () => {
+      const rpc = createRpcClientStub([response({ watchers: [watcher] })]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.getEnabledMatchWatchers();
 
       assertEquals(result.success, true);
       if (!result.success) return;
       assertEquals(
         result.watchers[0].pendingResultStartedAt,
-        new Date(
-          "2026-01-01T00:00:00.000Z",
-        ),
+        new Date("2026-01-01T00:00:00.000Z"),
       );
       assertEquals(
         result.watchers[0].gameStartedAt,
-        new Date(
-          "2026-01-01T00:01:00.000Z",
-        ),
+        new Date("2026-01-01T00:01:00.000Z"),
       );
       assertEquals(result.watchers[0].lastCheckedAt, null);
-      assertSpyCalls(fetchStub, 1);
+      assertEquals(rpc.calls[0].path, "/match-watchers/enabled");
     });
-  });
 
-  describe("getEnabledMatchWatchersByGuild", () => {
-    test("ギルドIDを指定して監視設定を取得すると、日付フィールドをDateまたはnullへ変換する", async () => {
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(
-              JSON.stringify({
-                watchers: [{
-                  guildId: "guild-1",
-                  targetDiscordId: "target-1",
-                  requesterId: "requester-1",
-                  channelId: "channel-1",
-                  enabled: true,
-                  lastState: "IDLE",
-                  currentGameId: null,
-                  currentMatchId: null,
-                  currentNotificationMessageId: null,
-                  pendingResultMatchId: null,
-                  pendingResultNotificationMessageId: null,
-                  pendingResultStartedAt: null,
-                  gameStartedAt: null,
-                  lastCheckedAt: "2026-01-01T00:02:00.000Z",
-                  lastInGameNotifiedAt: null,
-                  createdAt: "2026-01-01T00:00:00.000Z",
-                  updatedAt: "2026-01-01T00:03:00.000Z",
-                }],
-              }),
-              { status: 200 },
-            ),
-          ),
-      );
+    test("ギルドIDを指定して監視設定を取得すると、RPC clientへguildIdを渡す", async () => {
+      const rpc = createRpcClientStub([response({ watchers: [watcher] })]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      const result = await apiClient.getEnabledMatchWatchersByGuild("guild-1");
+      const result = await client.getEnabledMatchWatchersByGuild("guild-1");
 
       assertEquals(result.success, true);
       if (!result.success) return;
       assertEquals(result.watchers[0].guildId, "guild-1");
-      assertEquals(
-        result.watchers[0].lastCheckedAt,
-        new Date("2026-01-01T00:02:00.000Z"),
-      );
-      assertEquals(result.watchers[0].gameStartedAt, null);
-      assertSpyCalls(fetchStub, 1);
-      assertEquals(
-        fetchStub.calls[0].args[0],
-        `${Deno.env.get("API_URL")}/match-watchers/enabled/guild-1`,
-      );
+      assertEquals(rpc.calls[0], {
+        method: "$get",
+        path: "/match-watchers/enabled/:guildId",
+        args: [{ param: { guildId: "guild-1" } }],
+      });
+    });
+
+    test("監視登録APIが404を返す場合、呼び出し側で未連携を識別できるステータスを返す", async () => {
+      const rpc = createRpcClientStub([
+        response({ error: "Riot account not found" }, 404),
+      ]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.watchMatch({
+        guildId: "guild-1",
+        targetDiscordId: "target-1",
+        requesterId: "requester-1",
+        channelId: "channel-1",
+      });
+
+      assertEquals(result.success, false);
+      if (result.success) return;
+      assertEquals(result.error, "Riot account not found");
+      assertEquals("status" in result ? result.status : undefined, 404);
+      assertEquals(rpc.calls[0].path, "/match-watchers");
     });
   });
 
   describe("Riot API facade", () => {
     test("進行中の試合を取得するとき、Backend API経由で結果を返す", async () => {
-      // Arrange
       const activeGame = {
         gameId: 12345,
         gameType: "MATCHED_GAME",
@@ -288,53 +292,34 @@ describe("apiClient", () => {
         gameMode: "CLASSIC",
         participants: [],
       };
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify({ activeGame }), { status: 200 }),
-          ),
-      );
+      const rpc = createRpcClientStub([response({ activeGame })]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.getActiveGameByPuuid("jp1", "puuid-1");
+      const result = await client.getActiveGameByPuuid("jp1", "puuid-1");
 
-      // Assert
       assertEquals(result?.gameId, activeGame.gameId);
       assertEquals(result?.participants, activeGame.participants);
-      assertSpyCalls(fetchStub, 1);
-      assertEquals(
-        fetchStub.calls[0].args[0],
-        `${Deno.env.get("API_URL")}/riot/active-games/jp1/puuid-1`,
-      );
+      assertEquals(rpc.calls[0], {
+        method: "$get",
+        path: "/riot/active-games/:platform/:puuid",
+        args: [{ param: { platform: "jp1", puuid: "puuid-1" } }],
+      });
     });
 
     test("試合結果が未反映のとき、Backend API経由でnullを返す", async () => {
-      // Arrange
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify({ match: null }), { status: 200 }),
-          ),
-      );
+      const rpc = createRpcClientStub([response({ match: null })]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.getMatchById("asia", "JP1_12345");
+      const result = await client.getMatchById("asia", "JP1_12345");
 
-      // Assert
       assertEquals(result, null);
-      assertSpyCalls(fetchStub, 1);
-      assertEquals(
-        fetchStub.calls[0].args[0],
-        `${Deno.env.get("API_URL")}/riot/matches/asia/JP1_12345`,
-      );
+      assertEquals(rpc.calls[0].path, "/riot/matches/:region/:matchId");
+      assertEquals(rpc.calls[0].args, [{
+        param: { region: "asia", matchId: "JP1_12345" },
+      }]);
     });
 
     test("ランク情報を取得するとき、Backend API経由でentry一覧を返す", async () => {
-      // Arrange
       const entries = [{
         queueType: "RANKED_SOLO_5x5",
         tier: "EMERALD",
@@ -343,60 +328,157 @@ describe("apiClient", () => {
         wins: 11,
         losses: 8,
       }];
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify({ entries }), { status: 200 }),
-          ),
-      );
+      const rpc = createRpcClientStub([response({ entries })]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.getLeagueEntriesByPuuid(
-        "jp1",
-        "puuid-1",
-      );
+      const result = await client.getLeagueEntriesByPuuid("jp1", "puuid-1");
 
-      // Assert
       assertEquals(result[0].queueType, entries[0].queueType);
       assertEquals(result[0].leaguePoints, entries[0].leaguePoints);
-      assertSpyCalls(fetchStub, 1);
-      assertEquals(
-        fetchStub.calls[0].args[0],
-        `${Deno.env.get("API_URL")}/riot/league-entries/jp1/puuid-1`,
-      );
+      assertEquals(rpc.calls[0].path, "/riot/league-entries/:platform/:puuid");
     });
 
     test("Riot APIの認証が拒否されたとき、APIサーバーの診断情報をエラーとして返す", async () => {
-      // Arrange
       const errorMessage =
         "Riot API request failed: 403; authorization rejected; " +
         "verify RIOT_API_KEY and endpoint access";
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify({ error: errorMessage }), {
-              status: 502,
-            }),
-          ),
-      );
+      const rpc = createRpcClientStub([
+        response({ error: errorMessage }, 502),
+      ]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act / Assert
       await assertRejects(
-        () => apiClient.getActiveGameByPuuid("jp1", "puuid-1"),
+        () => client.getActiveGameByPuuid("jp1", "puuid-1"),
         Error,
         errorMessage,
       );
-      assertSpyCalls(fetchStub, 1);
+      assertEquals(rpc.calls.length, 1);
+    });
+  });
+
+  describe("matches", () => {
+    test("参加者作成APIがidを返さないとき、契約不整合の失敗結果を返す", async () => {
+      const rpc = createRpcClientStub([response({})]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.createMatchParticipant("JP1_12345", {
+        userId: "user-1",
+        team: "BLUE",
+        win: true,
+        lane: "Top",
+        kills: 1,
+        deaths: 2,
+        assists: 3,
+        cs: 100,
+        gold: 10_000,
+      });
+
+      assertEquals(result, {
+        success: false,
+        error: "API response missing participant id",
+      });
+      assertEquals(rpc.calls[0].path, "/matches/:matchId/participants");
+    });
+  });
+
+  describe("rank snapshots", () => {
+    test("beforeスナップショット保存APIが204を返すと、成功ステータスを返す", async () => {
+      const rpc = createRpcClientStub([response(null, 204)]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+      const payload = {
+        platform: "jp1" as const,
+        gameId: "12345",
+        puuid: "puuid-1",
+        snapshots: [{
+          queueType: "RANKED_SOLO_5x5" as const,
+          tier: "EMERALD",
+          rank: "IV",
+          leaguePoints: 2,
+          wins: 10,
+          losses: 8,
+        }],
+      };
+
+      const result = await client.upsertPendingRankSnapshots(payload);
+
+      assertEquals(result.success, true);
+      assertEquals(rpc.calls[0], {
+        method: "$post",
+        path: "/matches/rank-snapshots/pending",
+        args: [{ json: payload }],
+      });
+    });
+
+    test("afterスナップショット保存APIがbefore/afterを返すと、fetchedAtをDateへ変換する", async () => {
+      const rpc = createRpcClientStub([
+        response({
+          snapshots: {
+            before: [{
+              matchId: "JP1_12345",
+              puuid: "puuid-1",
+              platform: "jp1",
+              queueType: "RANKED_SOLO_5x5",
+              phase: "before",
+              tier: "EMERALD",
+              rank: "IV",
+              leaguePoints: 2,
+              wins: 10,
+              losses: 8,
+              fetchedAt: "2026-01-01T00:00:00.000Z",
+            }],
+            after: [{
+              matchId: "JP1_12345",
+              puuid: "puuid-1",
+              platform: "jp1",
+              queueType: "RANKED_SOLO_5x5",
+              phase: "after",
+              tier: "EMERALD",
+              rank: "IV",
+              leaguePoints: 19,
+              wins: 11,
+              losses: 8,
+              fetchedAt: "2026-01-01T00:10:00.000Z",
+            }],
+          },
+        }),
+      ]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+      const payload = {
+        platform: "jp1" as const,
+        gameId: "12345",
+        puuid: "puuid-1",
+        snapshots: [{
+          queueType: "RANKED_SOLO_5x5" as const,
+          tier: "EMERALD",
+          rank: "IV",
+          leaguePoints: 19,
+          wins: 11,
+          losses: 8,
+        }],
+      };
+
+      const result = await client.finalizeRankSnapshots("JP1_12345", payload);
+
+      assertEquals(result.success, true);
+      if (!result.success) return;
+      assertEquals(
+        result.snapshots.before[0].fetchedAt,
+        new Date("2026-01-01T00:00:00.000Z"),
+      );
+      assertEquals(result.snapshots.after[0].leaguePoints, 19);
+      assertEquals(
+        rpc.calls[0].path,
+        "/matches/:matchId/rank-snapshots/finalize",
+      );
+      assertEquals(rpc.calls[0].args, [{
+        param: { matchId: "JP1_12345" },
+        json: payload,
+      }]);
     });
   });
 
   describe("resolveRiotStaticData", () => {
     test("静的データの解決を依頼したとき、Backend APIからバッチ解決結果を返す", async () => {
-      // Arrange
       const payload = {
         locale: "ja_JP",
         championIds: [17, 18],
@@ -417,198 +499,27 @@ describe("apiClient", () => {
         maps: { "11": "サモナーズリフト" },
         gameModes: { CLASSIC: "クラシック" },
       };
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify(data), { status: 200 }),
-          ),
-      );
+      const rpc = createRpcClientStub([response(data)]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.resolveRiotStaticData(payload);
+      const result = await client.resolveRiotStaticData(payload);
 
-      // Assert
       assertEquals(result, { success: true, data });
-      assertSpyCalls(fetchStub, 1);
-      const [url, init] = fetchStub.calls[0].args;
-      assertEquals(
-        url,
-        `${Deno.env.get("API_URL")}/riot/static-data/resolve`,
-      );
-      assertEquals(init?.method, "POST");
-      assertEquals(init?.body, JSON.stringify(payload));
+      assertEquals(rpc.calls[0], {
+        method: "$post",
+        path: "/riot/static-data/resolve",
+        args: [{ json: payload }],
+      });
     });
 
     test("Backend APIが静的データを解決できないとき、呼び出し側がfallbackできる失敗結果を返す", async () => {
-      // Arrange
       const error = "Failed to resolve Riot static data";
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify({ error }), { status: 502 }),
-          ),
-      );
+      const rpc = createRpcClientStub([response({ error }, 502)]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.resolveRiotStaticData({
-        championIds: [17],
-      });
+      const result = await client.resolveRiotStaticData({ championIds: [17] });
 
-      // Assert
       assertEquals(result, { success: false, error });
-      assertSpyCalls(fetchStub, 1);
-    });
-  });
-
-  describe("watchMatch", () => {
-    test("監視登録APIが404を返す場合、呼び出し側で未連携を識別できるステータスを返す", async () => {
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(
-              JSON.stringify({ error: "Riot account not found" }),
-              { status: 404 },
-            ),
-          ),
-      );
-
-      const result = await apiClient.watchMatch({
-        guildId: "guild-1",
-        targetDiscordId: "target-1",
-        requesterId: "requester-1",
-        channelId: "channel-1",
-      });
-
-      assertEquals(result.success, false);
-      assertEquals(result.error, "Riot account not found");
-      assertEquals("status" in result ? result.status : undefined, 404);
-      assertSpyCalls(fetchStub, 1);
-    });
-  });
-
-  describe("upsertPendingRankSnapshots", () => {
-    test("beforeスナップショット保存APIが204を返すと、成功ステータスを返す", async () => {
-      // Arrange
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () => Promise.resolve(new Response(null, { status: 204 })),
-      );
-      const payload = {
-        platform: "jp1" as const,
-        gameId: "12345",
-        puuid: "puuid-1",
-        snapshots: [{
-          queueType: "RANKED_SOLO_5x5" as const,
-          tier: "EMERALD",
-          rank: "IV",
-          leaguePoints: 2,
-          wins: 10,
-          losses: 8,
-        }],
-      };
-
-      // Act
-      const result = await apiClient.upsertPendingRankSnapshots(payload);
-
-      // Assert
-      assertEquals(result.success, true);
-      assertSpyCalls(fetchStub, 1);
-      const [url, init] = fetchStub.calls[0].args;
-      assertEquals(
-        url,
-        `${Deno.env.get("API_URL")}/matches/rank-snapshots/pending`,
-      );
-      assertEquals(init?.method, "POST");
-      assertEquals(init?.body, JSON.stringify(payload));
-    });
-  });
-
-  describe("finalizeRankSnapshots", () => {
-    test("afterスナップショット保存APIがbefore/afterを返すと、fetchedAtをDateへ変換する", async () => {
-      // Arrange
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(
-              JSON.stringify({
-                snapshots: {
-                  before: [{
-                    matchId: "JP1_12345",
-                    puuid: "puuid-1",
-                    platform: "jp1",
-                    queueType: "RANKED_SOLO_5x5",
-                    phase: "before",
-                    tier: "EMERALD",
-                    rank: "IV",
-                    leaguePoints: 2,
-                    wins: 10,
-                    losses: 8,
-                    fetchedAt: "2026-01-01T00:00:00.000Z",
-                  }],
-                  after: [{
-                    matchId: "JP1_12345",
-                    puuid: "puuid-1",
-                    platform: "jp1",
-                    queueType: "RANKED_SOLO_5x5",
-                    phase: "after",
-                    tier: "EMERALD",
-                    rank: "IV",
-                    leaguePoints: 19,
-                    wins: 11,
-                    losses: 8,
-                    fetchedAt: "2026-01-01T00:10:00.000Z",
-                  }],
-                },
-              }),
-              { status: 200 },
-            ),
-          ),
-      );
-      const payload = {
-        platform: "jp1" as const,
-        gameId: "12345",
-        puuid: "puuid-1",
-        snapshots: [{
-          queueType: "RANKED_SOLO_5x5" as const,
-          tier: "EMERALD",
-          rank: "IV",
-          leaguePoints: 19,
-          wins: 11,
-          losses: 8,
-        }],
-      };
-
-      // Act
-      const result = await apiClient.finalizeRankSnapshots(
-        "JP1_12345",
-        payload,
-      );
-
-      // Assert
-      assertEquals(result.success, true);
-      if (!result.success) return;
-      assertEquals(
-        result.snapshots.before[0].fetchedAt,
-        new Date("2026-01-01T00:00:00.000Z"),
-      );
-      assertEquals(result.snapshots.after[0].leaguePoints, 19);
-      assertSpyCalls(fetchStub, 1);
-      const [url, init] = fetchStub.calls[0].args;
-      assertEquals(
-        url,
-        `${Deno.env.get("API_URL")}/matches/JP1_12345/rank-snapshots/finalize`,
-      );
-      assertEquals(init?.method, "POST");
-      assertEquals(init?.body, JSON.stringify(payload));
     });
   });
 
@@ -629,7 +540,6 @@ describe("apiClient", () => {
     };
 
     test("OP.GG試合詳細が解決されたとき、providerCreatedAtをDateへ復元して返す", async () => {
-      // Arrange
       const detail = {
         provider: "opgg" as const,
         providerRegion: "jp",
@@ -644,19 +554,11 @@ describe("apiClient", () => {
           laneScore: 7.2,
         },
       };
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify({ detail }), { status: 200 }),
-          ),
-      );
+      const rpc = createRpcClientStub([response({ detail })]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.resolveOpggMatchDetail(matchId, payload);
+      const result = await client.resolveOpggMatchDetail(matchId, payload);
 
-      // Assert
       assertEquals(result, {
         success: true,
         detail: {
@@ -664,135 +566,86 @@ describe("apiClient", () => {
           providerCreatedAt: new Date(detail.providerCreatedAt),
         },
       });
-      assertSpyCalls(fetchStub, 1);
-      const [url, init] = fetchStub.calls[0].args;
       assertEquals(
-        url,
-        `${
-          Deno.env.get("API_URL")
-        }/matches/${matchId}/external-details/opgg/resolve`,
+        rpc.calls[0].path,
+        "/matches/:matchId/external-details/opgg/resolve",
       );
-      assertEquals(init?.method, "POST");
-      assertEquals(init?.body, JSON.stringify(payload));
     });
 
     test("OP.GGに対応する試合がないとき、成功結果とdetail nullを返す", async () => {
-      // Arrange
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify({ detail: null }), { status: 200 }),
-          ),
-      );
+      const rpc = createRpcClientStub([response({ detail: null })]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.resolveOpggMatchDetail(matchId, payload);
+      const result = await client.resolveOpggMatchDetail(matchId, payload);
 
-      // Assert
       assertEquals(result, { success: true, detail: null });
-      assertSpyCalls(fetchStub, 1);
     });
 
     test("Backend APIがOP.GG試合詳細を解決できないとき、失敗結果とエラーを返す", async () => {
-      // Arrange
       const error = "Failed to resolve OP.GG match detail";
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(JSON.stringify({ error }), { status: 500 }),
-          ),
-      );
+      const rpc = createRpcClientStub([response({ error }, 500)]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.resolveOpggMatchDetail(matchId, payload);
+      const result = await client.resolveOpggMatchDetail(matchId, payload);
 
-      // Assert
       assertEquals(result, { success: false, error });
-      assertSpyCalls(fetchStub, 1);
     });
 
     test("Backend APIへの通信に失敗したとき、通信失敗の結果を返す", async () => {
-      // Arrange
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () => Promise.reject(new Error("Network error")),
-      );
+      const rpc = createRpcClientStub([new Error("Network error")]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Act
-      const result = await apiClient.resolveOpggMatchDetail(matchId, payload);
+      const result = await client.resolveOpggMatchDetail(matchId, payload);
 
-      // Assert
       assertEquals(result, {
         success: false,
         error: "Failed to communicate with API",
       });
-      assertSpyCalls(fetchStub, 1);
     });
   });
 
   describe("setMainRole", () => {
-    const userId = "test-user";
-    const guildId = "test-guild";
-    const role = "Top";
-
     test("API呼び出しが成功した場合にメインロールを設定すると、成功ステータスが返される", async () => {
-      // Arrange
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () =>
-          Promise.resolve(
-            new Response(null, { status: 204 }),
-          ),
-      );
-      // Act
-      const result = await apiClient.setMainRole(userId, guildId, role);
+      const rpc = createRpcClientStub([response(null, 204)]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Assert
+      const result = await client.setMainRole("test-user", "test-guild", "Top");
+
       assertEquals(result.success, true);
-
-      assertSpyCalls(fetchStub, 1);
-      const [url, init] = fetchStub.calls[0].args;
-      assertEquals(url, `${Deno.env.get("API_URL")}/users/${userId}/main-role`);
-      assertEquals(init?.method, "PUT");
-      assertEquals(init?.body, JSON.stringify({ guildId, role }));
+      assertEquals(rpc.calls[0], {
+        method: "$put",
+        path: "/users/:userId/main-role",
+        args: [{
+          param: { userId: "test-user" },
+          json: { guildId: "test-guild", role: "Top" },
+        }],
+      });
     });
 
     test("APIが200以外のステータスを返す場合にメインロールを設定すると、エラーステータスが返される", async () => {
-      // Arrange
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () => Promise.resolve(new Response("Bad Request", { status: 400 })),
-      );
-      // Act
-      const result = await apiClient.setMainRole(userId, guildId, role);
+      const rpc = createRpcClientStub([response("Bad Request", 400)]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Assert
-      assertEquals(result.success, false);
-      assertEquals(result.error, "Failed to communicate with API");
-      assertSpyCalls(fetchStub, 1);
+      const result = await client.setMainRole("test-user", "test-guild", "Top");
+
+      assertEquals(result, {
+        success: false,
+        error: "Failed to communicate with API",
+      });
+      assertEquals(rpc.calls.length, 1);
     });
 
-    test("fetchに失敗した場合にメインロールを設定すると、通信失敗のエラーが返される", async () => {
-      // Arrange
-      using fetchStub = stub(
-        globalThis,
-        "fetch",
-        () => Promise.reject(new Error("Network error")),
-      );
-      // Act
-      const result = await apiClient.setMainRole(userId, guildId, role);
+    test("RPC clientが失敗した場合にメインロールを設定すると、通信失敗のエラーが返される", async () => {
+      const rpc = createRpcClientStub([new Error("Network error")]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
 
-      // Assert
-      assertEquals(result.success, false);
-      assertEquals(result.error, "Failed to communicate with API");
-      assertSpyCalls(fetchStub, 1);
+      const result = await client.setMainRole("test-user", "test-guild", "Top");
+
+      assertEquals(result, {
+        success: false,
+        error: "Failed to communicate with API",
+      });
+      assertEquals(rpc.calls.length, 1);
     });
   });
 });

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -164,6 +164,10 @@ function logCommunicationError(error: unknown) {
   console.error(COMMUNICATION_ERROR, error);
 }
 
+function unexpectedResponseError(res: ApiResponse): Error {
+  return new Error(`Unexpected response: ${res.status} ${res.statusText}`);
+}
+
 async function resultFromRequest<
   T extends Record<string, unknown>,
   F extends FailureResult = FailureResult,
@@ -182,7 +186,7 @@ async function resultFromRequest<
         return await handleHttpError(res);
       }
 
-      throw new Error(`Unexpected response: ${res}`);
+      throw unexpectedResponseError(res);
     }
 
     return { success: true, ...await parseSuccess(res) };
@@ -215,7 +219,7 @@ export function createApiClient({ rpcClient }: { rpcClient: ApiRpcClient }) {
           return { success: false, error: await readErrorMessage(res) };
         }
 
-        throw new Error(`Unexpected response: ${res}`);
+        throw unexpectedResponseError(res);
       },
     );
   }
@@ -239,7 +243,7 @@ export function createApiClient({ rpcClient }: { rpcClient: ApiRpcClient }) {
           return { success: false, error: await readErrorMessage(res) };
         }
 
-        throw new Error(`Unexpected response: ${res}`);
+        throw unexpectedResponseError(res);
       },
     );
   }
@@ -367,7 +371,7 @@ export function createApiClient({ rpcClient }: { rpcClient: ApiRpcClient }) {
           return { success: false, error: await readErrorMessage(res) };
         }
 
-        throw new Error(`Unexpected response: ${res}`);
+        throw unexpectedResponseError(res);
       },
     );
   }
@@ -387,7 +391,7 @@ export function createApiClient({ rpcClient }: { rpcClient: ApiRpcClient }) {
           return { success: false, error: await readErrorMessage(res) };
         }
 
-        throw new Error(`Unexpected response: ${res}`);
+        throw unexpectedResponseError(res);
       }
 
       const data = await res.json() as { id?: unknown };
@@ -476,14 +480,14 @@ export function createApiClient({ rpcClient }: { rpcClient: ApiRpcClient }) {
         }),
       async (res) => {
         const body = await res.json() as {
-          detail:
+          detail?:
             | (Omit<OpggMatchDetail, "providerCreatedAt"> & {
               providerCreatedAt: string | Date;
             })
             | null;
         };
         return {
-          detail: body.detail === null ? null : {
+          detail: body.detail == null ? null : {
             ...body.detail,
             providerCreatedAt: new Date(body.detail.providerCreatedAt),
           },
@@ -527,7 +531,7 @@ export function createApiClient({ rpcClient }: { rpcClient: ApiRpcClient }) {
           };
         }
 
-        throw new Error(`Unexpected response: ${res}`);
+        throw unexpectedResponseError(res);
       },
     );
   }

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -7,7 +7,7 @@ import type {
   RiotPlatform,
   RiotRegion,
 } from "@adteemo/api/contract";
-import { type Client, hcWithType } from "@adteemo/api/contract";
+import type { Client } from "@adteemo/api/contract";
 import { z } from "zod";
 import {
   createParticipantSchema,
@@ -16,12 +16,16 @@ import {
   upsertPendingRankSnapshotsSchema,
 } from "@adteemo/api/contract";
 
-const API_URL = Deno.env.get("API_URL");
-if (!API_URL) {
-  throw new Error("API_URL environment variable must be set");
-}
+const COMMUNICATION_ERROR = "Failed to communicate with API";
 
-export const client: Client = hcWithType(API_URL);
+type ApiRpcClient = Client;
+type FailureResult = { success: false; error: string };
+type ApiResponse<T = unknown> = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<T>;
+};
 
 function dateOrNull(value: string | Date | null) {
   return value === null ? null : new Date(value);
@@ -82,224 +86,6 @@ function parseMatchWatcher(
     lastInGameNotifiedAt: dateOrNull(watcher.lastInGameNotifiedAt),
     pendingResultStartedAt: dateOrNull(watcher.pendingResultStartedAt),
   };
-}
-
-async function linkAccountByRiotId(
-  discordId: string,
-  gameName: string,
-  tagLine: string,
-  platform?: RiotPlatform,
-  region?: RiotRegion,
-) {
-  try {
-    const res = await client.users["link-by-riot-id"].$patch({
-      json: { discordId, gameName, tagLine, platform, region },
-    });
-
-    if (!res.ok) {
-      if (res.status === 404) {
-        const body = await res.json();
-        return { success: false as const, error: body.error };
-      }
-
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    return { success: true as const };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return {
-      success: false as const,
-      error: "Failed to communicate with API",
-    };
-  }
-}
-
-async function getRiotAccount(discordId: string) {
-  try {
-    const res = await client.users[":userId"]["riot-account"].$get({
-      param: { userId: discordId },
-    });
-
-    if (!res.ok) {
-      if (res.status === 404) {
-        const body = await res.json();
-        return { success: false as const, error: body.error };
-      }
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    const body = await res.json();
-    return { success: true as const, account: parseRiotAccount(body.account) };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
-  }
-}
-
-async function getActiveGameByPuuid(
-  platform: RiotPlatform,
-  puuid: string,
-) {
-  const res = await client.riot["active-games"][":platform"][":puuid"].$get({
-    param: { platform, puuid },
-  });
-  if (!res.ok) {
-    const body = await res.json();
-    throw new Error(body.error);
-  }
-  const body = await res.json();
-  return body.activeGame;
-}
-
-async function getMatchById(region: RiotRegion, matchId: string) {
-  const res = await client.riot.matches[":region"][":matchId"].$get({
-    param: { region, matchId },
-  });
-  if (!res.ok) {
-    const body = await res.json();
-    throw new Error(body.error);
-  }
-  const body = await res.json();
-  return body.match;
-}
-
-async function getLeagueEntriesByPuuid(
-  platform: RiotPlatform,
-  puuid: string,
-) {
-  const res = await client.riot["league-entries"][":platform"][":puuid"].$get({
-    param: { platform, puuid },
-  });
-  if (!res.ok) {
-    const body = await res.json();
-    throw new Error(body.error);
-  }
-  const body = await res.json();
-  return body.entries;
-}
-
-async function checkHealth() {
-  try {
-    const res = await client.health.$get();
-
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    const body = await res.json();
-    return { success: true as const, message: body.message };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return {
-      success: false as const,
-      error: "Failed to communicate with API",
-    };
-  }
-}
-
-async function setMainRole(userId: string, guildId: string, role: Lane) {
-  try {
-    const res = await client.users[":userId"]["main-role"].$put({
-      param: { userId: userId },
-      json: { guildId, role },
-    });
-
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    return { success: true as const };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
-  }
-}
-
-async function createCustomGameEvent(event: {
-  name: string;
-  guildId: string;
-  creatorId: string;
-  discordScheduledEventId: string;
-  recruitmentMessageId: string;
-  scheduledStartAt: Date;
-}) {
-  try {
-    const res = await client.events.$post({ json: event });
-
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    return { success: true as const };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
-  }
-}
-
-async function getCustomGameEventsByCreatorId(creatorId: string) {
-  try {
-    const res = await client.events["by-creator"][":creatorId"].$get({
-      param: { creatorId },
-    });
-
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    const body = await res.json();
-    return { success: true as const, events: body.events.map(parseEvent) };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
-  }
-}
-
-async function deleteCustomGameEvent(discordEventId: string) {
-  try {
-    const res = await client.events[":discordEventId"].$delete({
-      param: { discordEventId },
-    });
-
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    return { success: true as const };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
-  }
-}
-
-async function getEventStartingTodayByCreatorId(creatorId: string) {
-  try {
-    const res = await client.events.today["by-creator"][":creatorId"].$get({
-      param: { creatorId },
-    });
-
-    if (!res.ok) {
-      if (res.status === 404) {
-        const body = await res.json();
-        return { success: false as const, error: body.error };
-      }
-
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    const data = await res.json();
-    return {
-      success: true as const,
-      event: parseEvent(data.event),
-    };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return {
-      success: false as const,
-      error: "Failed to communicate with API",
-    };
-  }
 }
 
 export type MatchParticipant = z.infer<typeof createParticipantSchema>;
@@ -369,301 +155,558 @@ function parseRankSnapshot(
   };
 }
 
-async function createMatchParticipant(
-  matchId: string,
-  participant: MatchParticipant,
-) {
+async function readErrorMessage(res: ApiResponse): Promise<string> {
+  const body = await res.json() as { error?: string };
+  return body.error ?? COMMUNICATION_ERROR;
+}
+
+function logCommunicationError(error: unknown) {
+  console.error(COMMUNICATION_ERROR, error);
+}
+
+async function resultFromRequest<
+  T extends Record<string, unknown>,
+  F extends FailureResult = FailureResult,
+>(
+  request: () => Promise<ApiResponse>,
+  parseSuccess: (res: ApiResponse) => Promise<T> | T,
+  handleHttpError?: (
+    res: ApiResponse,
+  ) => Promise<F> | F,
+): Promise<({ success: true } & T) | F | FailureResult> {
   try {
-    const res = await client.matches[":matchId"].participants.$post({
-      param: { matchId },
-      json: participant,
-    });
+    const res = await request();
 
     if (!res.ok) {
-      if (res.status === 404) {
-        const body = await res.json();
-        console.error(`API Error: ${res.status} ${res.statusText}`, body);
-        return { success: false as const, error: body.error };
+      if (handleHttpError) {
+        return await handleHttpError(res);
       }
 
       throw new Error(`Unexpected response: ${res}`);
     }
 
-    const data = await res.json();
-    if (typeof data.id !== "number") {
-      console.error("API response missing participant id", data);
-      return {
-        success: false as const,
-        error: "API response missing participant id",
-      };
-    }
-
-    return { success: true as const, id: data.id };
+    return { success: true, ...await parseSuccess(res) };
   } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
+    logCommunicationError(error);
+    return { success: false, error: COMMUNICATION_ERROR };
   }
 }
 
-async function upsertPendingRankSnapshots(
-  payload: z.infer<typeof upsertPendingRankSnapshotsSchema>,
-) {
-  try {
-    const res = await client.matches["rank-snapshots"].pending.$post({
-      json: payload,
-    });
-
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    return { success: true as const };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
-  }
+function successOnly() {
+  return {};
 }
 
-async function finalizeRankSnapshots(
-  matchId: string,
-  payload: z.infer<typeof finalizeRankSnapshotsSchema>,
-) {
-  try {
-    const res = await client.matches[":matchId"]["rank-snapshots"].finalize
-      .$post({
-        param: { matchId },
-        json: payload,
-      });
+export function createApiClient({ rpcClient }: { rpcClient: ApiRpcClient }) {
+  async function linkAccountByRiotId(
+    discordId: string,
+    gameName: string,
+    tagLine: string,
+    platform?: RiotPlatform,
+    region?: RiotRegion,
+  ) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.users["link-by-riot-id"].$patch({
+          json: { discordId, gameName, tagLine, platform, region },
+        }),
+      successOnly,
+      async (res) => {
+        if (res.status === 404) {
+          return { success: false, error: await readErrorMessage(res) };
+        }
 
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    const body = await res.json();
-    return {
-      success: true as const,
-      snapshots: {
-        before: body.snapshots.before.map(parseRankSnapshot),
-        after: body.snapshots.after.map(parseRankSnapshot),
+        throw new Error(`Unexpected response: ${res}`);
       },
-    };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
+    );
   }
-}
 
-async function resolveRiotStaticData(
-  payload: RiotStaticDataResolveInput,
-): Promise<RiotStaticDataResolveResult> {
-  try {
-    const res = await client.riot["static-data"].resolve.$post({
-      json: payload,
-    });
+  async function getRiotAccount(discordId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.users[":userId"]["riot-account"].$get({
+          param: { userId: discordId },
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          account: Parameters<
+            typeof parseRiotAccount
+          >[0];
+        };
+        return { account: parseRiotAccount(body.account) };
+      },
+      async (res) => {
+        if (res.status === 404) {
+          return { success: false, error: await readErrorMessage(res) };
+        }
 
+        throw new Error(`Unexpected response: ${res}`);
+      },
+    );
+  }
+
+  async function getActiveGameByPuuid(
+    platform: RiotPlatform,
+    puuid: string,
+  ) {
+    const res = await rpcClient.riot["active-games"][":platform"][":puuid"]
+      .$get({
+        param: { platform, puuid },
+      });
     if (!res.ok) {
       const body = await res.json();
-      return { success: false, error: body.error };
+      throw new Error(body.error);
     }
-
-    const data = await res.json();
-    return { success: true, data };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false, error: "Failed to communicate with API" };
+    const body = await res.json();
+    return body.activeGame;
   }
-}
 
-async function resolveOpggMatchDetail(
-  matchId: string,
-  payload: ResolveOpggMatchDetailPayload,
-): Promise<ResolveOpggMatchDetailResult> {
-  try {
-    const res = await client.matches[":matchId"]["external-details"].opgg
-      .resolve.$post({
-        param: { matchId },
-        json: payload,
-      });
-
+  async function getMatchById(region: RiotRegion, matchId: string) {
+    const res = await rpcClient.riot.matches[":region"][":matchId"].$get({
+      param: { region, matchId },
+    });
     if (!res.ok) {
       const body = await res.json();
-      return { success: false, error: body.error };
+      throw new Error(body.error);
     }
-
     const body = await res.json();
-    return {
-      success: true,
-      detail: body.detail === null ? null : {
-        ...body.detail,
-        providerCreatedAt: new Date(body.detail.providerCreatedAt),
+    return body.match;
+  }
+
+  async function getLeagueEntriesByPuuid(
+    platform: RiotPlatform,
+    puuid: string,
+  ) {
+    const res = await rpcClient.riot["league-entries"][":platform"][":puuid"]
+      .$get({
+        param: { platform, puuid },
+      });
+    if (!res.ok) {
+      const body = await res.json();
+      throw new Error(body.error);
+    }
+    const body = await res.json();
+    return body.entries;
+  }
+
+  async function checkHealth() {
+    return await resultFromRequest(
+      () => rpcClient.health.$get(),
+      async (res) => {
+        const body = await res.json() as { message: string };
+        return { message: body.message };
       },
-    };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false, error: "Failed to communicate with API" };
+    );
   }
-}
 
-async function getLoginUrl(discordId: string) {
-  try {
-    const res = await client.auth.rso["login-url"].$get({
-      query: { discordId },
-    });
-
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    const body = await res.json();
-    return { success: true as const, url: body.url };
-  } catch (e) {
-    console.error("Failed to communicate with API", e);
-    return { success: false as const, error: "Failed to communicate with API" };
+  async function setMainRole(userId: string, guildId: string, role: Lane) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.users[":userId"]["main-role"].$put({
+          param: { userId },
+          json: { guildId, role },
+        }),
+      successOnly,
+    );
   }
-}
 
-async function watchMatch(watcher: {
-  guildId: string;
-  targetDiscordId: string;
-  requesterId: string;
-  channelId: string;
-}) {
-  try {
-    const res = await client["match-watchers"].$post({ json: watcher });
+  async function createCustomGameEvent(event: {
+    name: string;
+    guildId: string;
+    creatorId: string;
+    discordScheduledEventId: string;
+    recruitmentMessageId: string;
+    scheduledStartAt: Date;
+  }) {
+    return await resultFromRequest(
+      () => rpcClient.events.$post({ json: event }),
+      successOnly,
+    );
+  }
 
-    if (!res.ok) {
-      if (res.status === 404 || res.status === 409) {
-        const body = await res.json();
+  async function getCustomGameEventsByCreatorId(creatorId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.events["by-creator"][":creatorId"].$get({
+          param: { creatorId },
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          events: Parameters<typeof parseEvent>[0][];
+        };
+        return { events: body.events.map(parseEvent) };
+      },
+    );
+  }
+
+  async function deleteCustomGameEvent(discordEventId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.events[":discordEventId"].$delete({
+          param: { discordEventId },
+        }),
+      successOnly,
+    );
+  }
+
+  async function getEventStartingTodayByCreatorId(creatorId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.events.today["by-creator"][":creatorId"].$get({
+          param: { creatorId },
+        }),
+      async (res) => {
+        const data = await res.json() as {
+          event: Parameters<
+            typeof parseEvent
+          >[0];
+        };
+        return { event: parseEvent(data.event) };
+      },
+      async (res) => {
+        if (res.status === 404) {
+          return { success: false, error: await readErrorMessage(res) };
+        }
+
+        throw new Error(`Unexpected response: ${res}`);
+      },
+    );
+  }
+
+  async function createMatchParticipant(
+    matchId: string,
+    participant: MatchParticipant,
+  ) {
+    try {
+      const res = await rpcClient.matches[":matchId"].participants.$post({
+        param: { matchId },
+        json: participant,
+      });
+
+      if (!res.ok) {
+        if (res.status === 404) {
+          return { success: false, error: await readErrorMessage(res) };
+        }
+
+        throw new Error(`Unexpected response: ${res}`);
+      }
+
+      const data = await res.json() as { id?: unknown };
+      if (typeof data.id !== "number") {
+        console.error("API response missing participant id", data);
         return {
-          success: false as const,
-          error: body.error,
-          status: res.status,
+          success: false,
+          error: "API response missing participant id",
         };
       }
-      throw new Error(`Unexpected response: ${res}`);
-    }
 
-    return { success: true as const };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
+      return { success: true, id: data.id };
+    } catch (error) {
+      logCommunicationError(error);
+      return { success: false, error: COMMUNICATION_ERROR };
+    }
   }
+
+  async function upsertPendingRankSnapshots(
+    payload: z.infer<typeof upsertPendingRankSnapshotsSchema>,
+  ) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.matches["rank-snapshots"].pending.$post({
+          json: payload,
+        }),
+      successOnly,
+    );
+  }
+
+  async function finalizeRankSnapshots(
+    matchId: string,
+    payload: z.infer<typeof finalizeRankSnapshotsSchema>,
+  ) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.matches[":matchId"]["rank-snapshots"].finalize.$post({
+          param: { matchId },
+          json: payload,
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          snapshots: {
+            before: Parameters<typeof parseRankSnapshot>[0][];
+            after: Parameters<typeof parseRankSnapshot>[0][];
+          };
+        };
+        return {
+          snapshots: {
+            before: body.snapshots.before.map(parseRankSnapshot),
+            after: body.snapshots.after.map(parseRankSnapshot),
+          },
+        };
+      },
+    );
+  }
+
+  async function resolveRiotStaticData(
+    payload: RiotStaticDataResolveInput,
+  ): Promise<RiotStaticDataResolveResult> {
+    return await resultFromRequest(
+      () =>
+        rpcClient.riot["static-data"].resolve.$post({
+          json: payload,
+        }),
+      async (res) => {
+        const data = await res.json() as RiotStaticDataResolveData;
+        return { data };
+      },
+      async (res) => ({
+        success: false,
+        error: await readErrorMessage(res),
+      }),
+    );
+  }
+
+  async function resolveOpggMatchDetail(
+    matchId: string,
+    payload: ResolveOpggMatchDetailPayload,
+  ): Promise<ResolveOpggMatchDetailResult> {
+    return await resultFromRequest(
+      () =>
+        rpcClient.matches[":matchId"]["external-details"].opgg.resolve.$post({
+          param: { matchId },
+          json: payload,
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          detail:
+            | (Omit<OpggMatchDetail, "providerCreatedAt"> & {
+              providerCreatedAt: string | Date;
+            })
+            | null;
+        };
+        return {
+          detail: body.detail === null ? null : {
+            ...body.detail,
+            providerCreatedAt: new Date(body.detail.providerCreatedAt),
+          },
+        };
+      },
+      async (res) => ({
+        success: false,
+        error: await readErrorMessage(res),
+      }),
+    );
+  }
+
+  async function getLoginUrl(discordId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.auth.rso["login-url"].$get({
+          query: { discordId },
+        }),
+      async (res) => {
+        const body = await res.json() as { url: string };
+        return { url: body.url };
+      },
+    );
+  }
+
+  async function watchMatch(watcher: {
+    guildId: string;
+    targetDiscordId: string;
+    requesterId: string;
+    channelId: string;
+  }) {
+    return await resultFromRequest(
+      () => rpcClient["match-watchers"].$post({ json: watcher }),
+      successOnly,
+      async (res) => {
+        if (res.status === 404 || res.status === 409) {
+          return {
+            success: false,
+            error: await readErrorMessage(res),
+            status: res.status,
+          };
+        }
+
+        throw new Error(`Unexpected response: ${res}`);
+      },
+    );
+  }
+
+  async function unwatchMatch(guildId: string, targetDiscordId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient["match-watchers"][":guildId"][":targetDiscordId"].$delete({
+          param: { guildId, targetDiscordId },
+        }),
+      successOnly,
+    );
+  }
+
+  async function getEnabledMatchWatchers() {
+    return await resultFromRequest(
+      () => rpcClient["match-watchers"].enabled.$get(),
+      async (res) => {
+        const body = await res.json() as {
+          watchers: Parameters<typeof parseMatchWatcher>[0][];
+        };
+        return {
+          watchers: body.watchers.map(parseMatchWatcher),
+        };
+      },
+    );
+  }
+
+  async function getEnabledMatchWatchersByGuild(guildId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient["match-watchers"].enabled[":guildId"].$get({
+          param: { guildId },
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          watchers: Parameters<typeof parseMatchWatcher>[0][];
+        };
+        return {
+          watchers: body.watchers.map(parseMatchWatcher),
+        };
+      },
+    );
+  }
+
+  async function updateMatchWatcherState(
+    guildId: string,
+    targetDiscordId: string,
+    state: {
+      lastState: MatchWatcherState;
+      currentGameId?: string | null;
+      currentMatchId?: string | null;
+      currentNotificationMessageId?: string | null;
+      pendingResultMatchId?: string | null;
+      pendingResultNotificationMessageId?: string | null;
+      pendingResultStartedAt?: Date | null;
+      gameStartedAt?: Date | null;
+      lastCheckedAt?: Date | null;
+      lastInGameNotifiedAt?: Date | null;
+    },
+  ) {
+    return await resultFromRequest(
+      () =>
+        rpcClient["match-watchers"][":guildId"][":targetDiscordId"].state
+          .$patch({
+            param: { guildId, targetDiscordId },
+            json: state,
+          }),
+      successOnly,
+    );
+  }
+
+  return {
+    linkAccountByRiotId,
+    getRiotAccount,
+    getActiveGameByPuuid,
+    getMatchById,
+    getLeagueEntriesByPuuid,
+    checkHealth,
+    setMainRole,
+    createCustomGameEvent,
+    getCustomGameEventsByCreatorId,
+    deleteCustomGameEvent,
+    getEventStartingTodayByCreatorId,
+    createMatchParticipant,
+    upsertPendingRankSnapshots,
+    finalizeRankSnapshots,
+    resolveRiotStaticData,
+    resolveOpggMatchDetail,
+    getLoginUrl,
+    watchMatch,
+    unwatchMatch,
+    getEnabledMatchWatchers,
+    getEnabledMatchWatchersByGuild,
+    updateMatchWatcherState,
+  };
 }
 
-async function unwatchMatch(guildId: string, targetDiscordId: string) {
-  try {
-    const res = await client["match-watchers"][":guildId"][
-      ":targetDiscordId"
-    ].$delete({
-      param: { guildId, targetDiscordId },
-    });
+export type ApiClient = ReturnType<typeof createApiClient>;
 
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
+let configuredApiClient: ApiClient | null = null;
 
-    return { success: true as const };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
-  }
+export function configureApiClient(apiClientInstance: ApiClient) {
+  configuredApiClient = apiClientInstance;
 }
 
-async function getEnabledMatchWatchers() {
-  try {
-    const res = await client["match-watchers"].enabled.$get();
-
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    const body = await res.json();
-    return {
-      success: true as const,
-      watchers: body.watchers.map(parseMatchWatcher),
-    };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
+function getConfiguredApiClient(): ApiClient {
+  if (configuredApiClient === null) {
+    throw new Error("apiClient is not configured");
   }
+
+  return configuredApiClient;
 }
 
-async function getEnabledMatchWatchersByGuild(guildId: string) {
-  try {
-    const res = await client["match-watchers"].enabled[":guildId"].$get({
-      param: { guildId },
-    });
-
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    const body = await res.json();
-    return {
-      success: true as const,
-      watchers: body.watchers.map(parseMatchWatcher),
-    };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
-  }
-}
-
-async function updateMatchWatcherState(
-  guildId: string,
-  targetDiscordId: string,
-  state: {
-    lastState: MatchWatcherState;
-    currentGameId?: string | null;
-    currentMatchId?: string | null;
-    currentNotificationMessageId?: string | null;
-    pendingResultMatchId?: string | null;
-    pendingResultNotificationMessageId?: string | null;
-    pendingResultStartedAt?: Date | null;
-    gameStartedAt?: Date | null;
-    lastCheckedAt?: Date | null;
-    lastInGameNotifiedAt?: Date | null;
+export const apiClient: ApiClient = {
+  linkAccountByRiotId(...args) {
+    return getConfiguredApiClient().linkAccountByRiotId(...args);
   },
-) {
-  try {
-    const res = await client["match-watchers"][":guildId"][":targetDiscordId"]
-      .state.$patch({
-        param: { guildId, targetDiscordId },
-        json: state,
-      });
-
-    if (!res.ok) {
-      throw new Error(`Unexpected response: ${res}`);
-    }
-
-    return { success: true as const };
-  } catch (error) {
-    console.error("Failed to communicate with API", error);
-    return { success: false as const, error: "Failed to communicate with API" };
-  }
-}
-
-export const apiClient = {
-  linkAccountByRiotId,
-  getRiotAccount,
-  getActiveGameByPuuid,
-  getMatchById,
-  getLeagueEntriesByPuuid,
-  checkHealth,
-  setMainRole,
-  createCustomGameEvent,
-  getCustomGameEventsByCreatorId,
-  deleteCustomGameEvent,
-  getEventStartingTodayByCreatorId,
-  createMatchParticipant,
-  upsertPendingRankSnapshots,
-  finalizeRankSnapshots,
-  resolveRiotStaticData,
-  resolveOpggMatchDetail,
-  getLoginUrl,
-  watchMatch,
-  unwatchMatch,
-  getEnabledMatchWatchers,
-  getEnabledMatchWatchersByGuild,
-  updateMatchWatcherState,
+  getRiotAccount(...args) {
+    return getConfiguredApiClient().getRiotAccount(...args);
+  },
+  getActiveGameByPuuid(...args) {
+    return getConfiguredApiClient().getActiveGameByPuuid(...args);
+  },
+  getMatchById(...args) {
+    return getConfiguredApiClient().getMatchById(...args);
+  },
+  getLeagueEntriesByPuuid(...args) {
+    return getConfiguredApiClient().getLeagueEntriesByPuuid(...args);
+  },
+  checkHealth(...args) {
+    return getConfiguredApiClient().checkHealth(...args);
+  },
+  setMainRole(...args) {
+    return getConfiguredApiClient().setMainRole(...args);
+  },
+  createCustomGameEvent(...args) {
+    return getConfiguredApiClient().createCustomGameEvent(...args);
+  },
+  getCustomGameEventsByCreatorId(...args) {
+    return getConfiguredApiClient().getCustomGameEventsByCreatorId(...args);
+  },
+  deleteCustomGameEvent(...args) {
+    return getConfiguredApiClient().deleteCustomGameEvent(...args);
+  },
+  getEventStartingTodayByCreatorId(...args) {
+    return getConfiguredApiClient().getEventStartingTodayByCreatorId(...args);
+  },
+  createMatchParticipant(...args) {
+    return getConfiguredApiClient().createMatchParticipant(...args);
+  },
+  upsertPendingRankSnapshots(...args) {
+    return getConfiguredApiClient().upsertPendingRankSnapshots(...args);
+  },
+  finalizeRankSnapshots(...args) {
+    return getConfiguredApiClient().finalizeRankSnapshots(...args);
+  },
+  resolveRiotStaticData(...args) {
+    return getConfiguredApiClient().resolveRiotStaticData(...args);
+  },
+  resolveOpggMatchDetail(...args) {
+    return getConfiguredApiClient().resolveOpggMatchDetail(...args);
+  },
+  getLoginUrl(...args) {
+    return getConfiguredApiClient().getLoginUrl(...args);
+  },
+  watchMatch(...args) {
+    return getConfiguredApiClient().watchMatch(...args);
+  },
+  unwatchMatch(...args) {
+    return getConfiguredApiClient().unwatchMatch(...args);
+  },
+  getEnabledMatchWatchers(...args) {
+    return getConfiguredApiClient().getEnabledMatchWatchers(...args);
+  },
+  getEnabledMatchWatchersByGuild(...args) {
+    return getConfiguredApiClient().getEnabledMatchWatchersByGuild(...args);
+  },
+  updateMatchWatcherState(...args) {
+    return getConfiguredApiClient().updateMatchWatcherState(...args);
+  },
 };

--- a/bot/src/commands/health.test.ts
+++ b/bot/src/commands/health.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from "@std/testing/bdd";
 import { assertEquals } from "@std/assert";
 import { assertSpyCall, assertSpyCalls, spy, stub } from "@std/testing/mock";
 import { data, execute } from "./health.ts";
+import { apiClient } from "../api_client.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 import { MockInteractionBuilder } from "../test_utils.ts";
 
@@ -20,20 +21,14 @@ describe("Health Command", () => {
   describe("execute", () => {
     test("APIが正常な時にコマンドを実行すると、APIからの成功メッセージで応答する", async () => {
       // Arrange
-      const response = new Response(
-        JSON.stringify({
-          ok: true,
-          message: "All systems operational.",
-        }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-      using _fetchStub = stub(
-        globalThis,
-        "fetch",
-        () => Promise.resolve(response),
+      using checkHealthStub = stub(
+        apiClient,
+        "checkHealth",
+        () =>
+          Promise.resolve({
+            success: true,
+            message: "All systems operational.",
+          }),
       );
       const interaction = new MockInteractionBuilder().build();
       using deferSpy = spy(interaction, "deferReply");
@@ -47,15 +42,19 @@ describe("Health Command", () => {
       assertSpyCall(editSpy, 0, {
         args: ["All systems operational."],
       });
+      assertSpyCalls(checkHealthStub, 1);
     });
 
     test("APIがエラーを返す時にコマンドを実行すると、APIのエラーを含んだメッセージで応答する", async () => {
       // Arrange
-      const response = new Response("Internal Server Error", { status: 500 });
-      using _fetchStub = stub(
-        globalThis,
-        "fetch",
-        () => Promise.resolve(response),
+      using checkHealthStub = stub(
+        apiClient,
+        "checkHealth",
+        () =>
+          Promise.resolve({
+            success: false,
+            error: "Failed to communicate with API",
+          }),
       );
       using formatMessageSpy = spy(messageHandler, "formatMessage");
       const interaction = new MockInteractionBuilder().build();
@@ -73,14 +72,19 @@ describe("Health Command", () => {
           error: "Failed to communicate with API",
         }],
       });
+      assertSpyCalls(checkHealthStub, 1);
     });
 
     test("APIとの通信に失敗した時にコマンドを実行すると、通信失敗を示すメッセージで応答する", async () => {
       // Arrange
-      using _fetchStub = stub(
-        globalThis,
-        "fetch",
-        () => Promise.reject(new Error("Network disconnect")),
+      using checkHealthStub = stub(
+        apiClient,
+        "checkHealth",
+        () =>
+          Promise.resolve({
+            success: false,
+            error: "Failed to communicate with API",
+          }),
       );
       using formatMessageSpy = spy(messageHandler, "formatMessage");
       const interaction = new MockInteractionBuilder().build();
@@ -98,6 +102,7 @@ describe("Health Command", () => {
           error: "Failed to communicate with API",
         }],
       });
+      assertSpyCalls(checkHealthStub, 1);
     });
 
     test("ChatInputCommandでないInteractionで実行すると、何もせずに処理を中断する", async () => {

--- a/bot/src/commands/link-riot-account.ts
+++ b/bot/src/commands/link-riot-account.ts
@@ -11,15 +11,27 @@ export async function execute(interaction: CommandInteraction) {
 
   const result = await apiClient.getLoginUrl(discordId);
 
-  if (!result.success || !result.url) {
+  if (!result.success) {
     await interaction.reply({
       content: messageHandler.formatMessage(
         messageKeys.riotAccount.link.error.generic,
         {
-          error: result.error ||
-            messageHandler.formatMessage(
-              messageKeys.riotAccount.link.error.urlNotFound,
-            ),
+          error: result.error,
+        },
+      ),
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (!result.url) {
+    await interaction.reply({
+      content: messageHandler.formatMessage(
+        messageKeys.riotAccount.link.error.generic,
+        {
+          error: messageHandler.formatMessage(
+            messageKeys.riotAccount.link.error.urlNotFound,
+          ),
         },
       ),
       ephemeral: true,

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -255,10 +255,24 @@ async function resultEmbedFields(resultMatch: RiotMatch) {
 
 describe("match_tracking.ts", () => {
   let staticDataStub: { restore(): void } | undefined;
+  let opggDetailStub: { restore(): void } | undefined;
+  let rankSnapshotStubs: { restore(): void }[] = [];
 
   function restoreStaticDataStub() {
     staticDataStub?.restore();
     staticDataStub = undefined;
+  }
+
+  function restoreOpggDetailStub() {
+    opggDetailStub?.restore();
+    opggDetailStub = undefined;
+  }
+
+  function restoreRankSnapshotStubs() {
+    for (const rankSnapshotStub of rankSnapshotStubs) {
+      rankSnapshotStub.restore();
+    }
+    rankSnapshotStubs = [];
   }
 
   beforeEach(() => {
@@ -267,10 +281,38 @@ describe("match_tracking.ts", () => {
       "resolveRiotStaticData",
       () => Promise.resolve(resolvedRiotStaticData()),
     );
+    opggDetailStub = stub(
+      apiClient,
+      "resolveOpggMatchDetail",
+      () => Promise.resolve({ success: true as const, detail: null }),
+    );
+    rankSnapshotStubs = [
+      stub(
+        apiClient,
+        "getLeagueEntriesByPuuid",
+        () => Promise.resolve([]),
+      ),
+      stub(
+        apiClient,
+        "upsertPendingRankSnapshots",
+        () => Promise.resolve({ success: true as const }),
+      ),
+      stub(
+        apiClient,
+        "finalizeRankSnapshots",
+        () =>
+          Promise.resolve({
+            success: true as const,
+            snapshots: { before: [], after: [] },
+          }),
+      ),
+    ];
   });
 
   afterEach(() => {
     restoreStaticDataStub();
+    restoreOpggDetailStub();
+    restoreRankSnapshotStubs();
   });
 
   test("idleの監視対象が試合中になったとき、開始通知を送りIN_GAMEへ更新する", async () => {
@@ -355,6 +397,7 @@ describe("match_tracking.ts", () => {
       "getActiveGameByPuuid",
       () => Promise.resolve(activeGame()),
     );
+    restoreRankSnapshotStubs();
     using _leagueStub = stub(
       apiClient,
       "getLeagueEntriesByPuuid",
@@ -2210,6 +2253,7 @@ describe("match_tracking.ts", () => {
 
   test("BackendがOP.GG詳細なしを返すとき、OP.GG項目を省略して試合結果通知を継続する", async () => {
     // Arrange
+    restoreOpggDetailStub();
     const { client, editSpy } = clientWithSend();
     using _getWatchersStub = stub(
       apiClient,
@@ -2260,6 +2304,7 @@ describe("match_tracking.ts", () => {
 
   test("BackendがOP.GG詳細を解決したとき、試合結果Embedに詳細リンクと補助情報を表示する", async () => {
     // Arrange
+    restoreOpggDetailStub();
     const { client, editSpy } = clientWithSend();
     const resultMatch = match();
     using _getWatchersStub = stub(
@@ -2285,6 +2330,7 @@ describe("match_tracking.ts", () => {
       "getMatchById",
       () => Promise.resolve(resultMatch),
     );
+    restoreRankSnapshotStubs();
     using _leagueStub = stub(
       apiClient,
       "getLeagueEntriesByPuuid",
@@ -2416,6 +2462,7 @@ describe("match_tracking.ts", () => {
       "getMatchById",
       () => Promise.resolve(match()),
     );
+    restoreRankSnapshotStubs();
     using _leagueStub = stub(
       apiClient,
       "getLeagueEntriesByPuuid",
@@ -2510,6 +2557,7 @@ describe("match_tracking.ts", () => {
       "getMatchById",
       () => Promise.resolve(match()),
     );
+    restoreRankSnapshotStubs();
     using _leagueStub = stub(
       apiClient,
       "getLeagueEntriesByPuuid",

--- a/bot/src/main.ts
+++ b/bot/src/main.ts
@@ -6,9 +6,14 @@ import {
   Interaction,
   MessageFlags,
 } from "discord.js";
+import { hcWithType } from "@adteemo/api/contract";
 import { ensureRoles } from "./features/role-management.ts";
 import { loadCommands } from "./common/command_loader.ts";
-import { apiClient } from "./api_client.ts";
+import {
+  apiClient,
+  configureApiClient,
+  createApiClient,
+} from "./api_client.ts";
 import { matchTracker } from "./features/match_tracking.ts";
 import { messageHandler, messageKeys } from "./messages.ts";
 import { botLogger } from "./logger.ts";
@@ -248,6 +253,13 @@ async function startBot() {
     botLogger.error("bot.start.missing_token");
     Deno.exit(1);
   }
+  const apiUrl = Deno.env.get("API_URL");
+  if (!apiUrl) {
+    botLogger.error("bot.start.missing_api_url");
+    Deno.exit(1);
+  }
+  configureApiClient(createApiClient({ rpcClient: hcWithType(apiUrl) }));
+
   const commands = await loadCommands();
   for (const command of commands) {
     client.commands.set(command.data.name, command);


### PR DESCRIPTION
## 概要

- #75 の対応として `createApiClient({ rpcClient })` を導入し、Bot API client の生成を差し替え可能にしました
- `API_URL` 読み取りと Hono RPC client 生成を `bot/src/main.ts` の composition root へ移しました
- API client test を `globalThis.fetch` stub から RPC client stub へ移行しました
- command / match tracking test は、直接依存である `apiClient` 境界を stub する方針へ寄せました

## 判断

- HTTP API の成否は引き続き HTTP status / `res.ok` を基準にし、HTTP body に `success` は要求しません
- 既存の `apiClient` facade は維持し、既存 command / feature からの import と stub 方針を壊さない形にしています
- `match_tracking` の production code はテスト通過目的で変更せず、OP.GG / rank snapshot など副作用 API はテスト側で目的に応じて明示 stub しています

## 検証

- `deno task quality`

Closes #75
Refs #71