### PR TITLE
[codex] refactor(bot): API clientをresource別に分割する

### DIFF
--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertRejects } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { type Client } from "@adteemo/api/contract";
 import { createApiClient, createApiResourceClients } from "./api_client.ts";
+import { dateOrNull } from "./api_clients/transport.ts";
 
 type RpcCall = {
   method: string;
@@ -24,6 +25,15 @@ function response(body: unknown, status = 200): RpcResponse {
     status,
     statusText: status === 200 ? "OK" : "Error",
     json: () => Promise.resolve(body),
+  };
+}
+
+function invalidJsonResponse(status = 502, statusText = "Bad Gateway") {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.reject(new SyntaxError("Unexpected token <")),
   };
 }
 
@@ -69,6 +79,12 @@ function createRpcClientStub(results: QueuedRpcResult[]) {
 }
 
 describe("apiClient", () => {
+  describe("transport", () => {
+    test("任意の日付フィールドがundefinedのとき、Date変換せずnullとして扱う", () => {
+      assertEquals(dateOrNull(undefined), null);
+    });
+  });
+
   describe("createApiClient", () => {
     test("API_URLが未設定でもmodule importとclient生成ができ、環境変数を要求しない", async () => {
       // Arrange
@@ -389,6 +405,35 @@ describe("apiClient", () => {
       );
       assertEquals(rpc.calls.length, 1);
     });
+
+    test("Riot APIがJSONではないエラーを返すとき、HTTPステータスを含むエラーを返す", async () => {
+      const rpc = createRpcClientStub([invalidJsonResponse()]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      await assertRejects(
+        () => client.getActiveGameByPuuid("jp1", "puuid-1"),
+        Error,
+        "HTTP 502 Bad Gateway",
+      );
+    });
+
+    test("試合結果APIがnull bodyを返すとき、未反映としてnullを返す", async () => {
+      const rpc = createRpcClientStub([response(null)]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.getMatchById("asia", "JP1_12345");
+
+      assertEquals(result, null);
+    });
+
+    test("ランク情報APIがnull bodyを返すとき、空配列へfallbackする", async () => {
+      const rpc = createRpcClientStub([response(null)]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.getLeagueEntriesByPuuid("jp1", "puuid-1");
+
+      assertEquals(result, []);
+    });
   });
 
   describe("matches", () => {
@@ -413,6 +458,28 @@ describe("apiClient", () => {
         error: "API response missing participant id",
       });
       assertEquals(rpc.calls[0].path, "/matches/:matchId/participants");
+    });
+
+    test("参加者作成APIがnull bodyを返すとき、契約不整合の失敗結果を返す", async () => {
+      const rpc = createRpcClientStub([response(null)]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.createMatchParticipant("JP1_12345", {
+        userId: "user-1",
+        team: "BLUE",
+        win: true,
+        lane: "Top",
+        kills: 1,
+        deaths: 2,
+        assists: 3,
+        cs: 100,
+        gold: 10_000,
+      });
+
+      assertEquals(result, {
+        success: false,
+        error: "API response missing participant id",
+      });
     });
   });
 

--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { type Client } from "@adteemo/api/contract";
-import { createApiClient } from "./api_client.ts";
+import { createApiClient, createApiResourceClients } from "./api_client.ts";
 
 type RpcCall = {
   method: string;
@@ -96,6 +96,41 @@ describe("apiClient", () => {
           Deno.env.set("API_URL", originalApiUrl);
         }
       }
+    });
+  });
+
+  describe("createApiResourceClients", () => {
+    test("resource clientを生成すると、利用側は必要なresourceだけを参照して既存と同じRPC呼び出しを行える", async () => {
+      const rpc = createRpcClientStub([
+        response({ message: "Healthy" }),
+        response(null, 204),
+      ]);
+      const resources = createApiResourceClients({ rpcClient: rpc.rpcClient });
+
+      const healthResult = await resources.health.checkHealth();
+      const usersResult = await resources.users.setMainRole(
+        "user-1",
+        "guild-1",
+        "Top",
+      );
+
+      assertEquals(healthResult, { success: true, message: "Healthy" });
+      assertEquals(usersResult.success, true);
+      assertEquals(rpc.calls, [
+        {
+          method: "$get",
+          path: "/health",
+          args: [],
+        },
+        {
+          method: "$put",
+          path: "/users/:userId/main-role",
+          args: [{
+            param: { userId: "user-1" },
+            json: { guildId: "guild-1", role: "Top" },
+          }],
+        },
+      ]);
     });
   });
 

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -1,632 +1,76 @@
-import type { Lane } from "@adteemo/api/contract";
-import type {
-  Event,
-  MatchWatcher,
-  MatchWatcherState,
-  RiotAccount,
-  RiotPlatform,
-  RiotRegion,
-} from "@adteemo/api/contract";
-import type { Client } from "@adteemo/api/contract";
-import { z } from "zod";
+import { type AuthApiClient, createAuthApiClient } from "./api_clients/auth.ts";
 import {
-  createParticipantSchema,
-  finalizeRankSnapshotsSchema,
-  resolveOpggMatchDetailSchema,
-  upsertPendingRankSnapshotsSchema,
-} from "@adteemo/api/contract";
+  createEventsApiClient,
+  type EventsApiClient,
+} from "./api_clients/events.ts";
+import {
+  createHealthApiClient,
+  type HealthApiClient,
+} from "./api_clients/health.ts";
+import {
+  createMatchesApiClient,
+  type MatchesApiClient,
+} from "./api_clients/matches.ts";
+import {
+  createMatchWatchersApiClient,
+  type MatchWatchersApiClient,
+} from "./api_clients/match_watchers.ts";
+import { createRiotApiClient, type RiotApiClient } from "./api_clients/riot.ts";
+import {
+  createUsersApiClient,
+  type UsersApiClient,
+} from "./api_clients/users.ts";
+import type { ApiRpcClient } from "./api_clients/transport.ts";
 
-const COMMUNICATION_ERROR = "Failed to communicate with API";
+export type {
+  FinalizedRankSnapshot,
+  MatchParticipant,
+  OpggMatchDetail,
+  RankSnapshotPayload,
+  ResolveOpggMatchDetailPayload,
+  ResolveOpggMatchDetailResult,
+} from "./api_clients/matches.ts";
+export type {
+  RiotStaticDataResolveData,
+  RiotStaticDataResolveInput,
+  RiotStaticDataResolveResult,
+} from "./api_clients/riot.ts";
 
-type ApiRpcClient = Client;
-type FailureResult = { success: false; error: string };
-type ApiResponse<T = unknown> = {
-  ok: boolean;
-  status: number;
-  statusText: string;
-  json(): Promise<T>;
+export type ApiResourceClients = {
+  health: HealthApiClient;
+  users: UsersApiClient;
+  events: EventsApiClient;
+  matches: MatchesApiClient;
+  matchWatchers: MatchWatchersApiClient;
+  riot: RiotApiClient;
+  auth: AuthApiClient;
 };
 
-function dateOrNull(value: string | Date | null) {
-  return value === null ? null : new Date(value);
-}
-
-function parseRiotAccount(
-  account: {
-    createdAt: string | Date;
-    updatedAt: string | Date | null;
-  } & Omit<RiotAccount, "createdAt" | "updatedAt">,
-): RiotAccount {
+export function createApiResourceClients(
+  { rpcClient }: { rpcClient: ApiRpcClient },
+): ApiResourceClients {
   return {
-    ...account,
-    createdAt: new Date(account.createdAt),
-    updatedAt: dateOrNull(account.updatedAt),
+    health: createHealthApiClient({ rpcClient }),
+    users: createUsersApiClient({ rpcClient }),
+    events: createEventsApiClient({ rpcClient }),
+    matches: createMatchesApiClient({ rpcClient }),
+    matchWatchers: createMatchWatchersApiClient({ rpcClient }),
+    riot: createRiotApiClient({ rpcClient }),
+    auth: createAuthApiClient({ rpcClient }),
   };
-}
-
-function parseEvent(
-  event: {
-    scheduledStartAt: string | Date;
-    createdAt: string | Date;
-  } & Omit<Event, "scheduledStartAt" | "createdAt">,
-): Event {
-  return {
-    ...event,
-    scheduledStartAt: new Date(event.scheduledStartAt),
-    createdAt: new Date(event.createdAt),
-  };
-}
-
-function parseMatchWatcher(
-  watcher:
-    & {
-      createdAt: string | Date;
-      updatedAt: string | Date | null;
-      gameStartedAt: string | Date | null;
-      lastCheckedAt: string | Date | null;
-      lastInGameNotifiedAt: string | Date | null;
-      pendingResultStartedAt: string | Date | null;
-    }
-    & Omit<
-      MatchWatcher,
-      | "createdAt"
-      | "updatedAt"
-      | "gameStartedAt"
-      | "lastCheckedAt"
-      | "lastInGameNotifiedAt"
-      | "pendingResultStartedAt"
-    >,
-): MatchWatcher {
-  return {
-    ...watcher,
-    createdAt: new Date(watcher.createdAt),
-    updatedAt: dateOrNull(watcher.updatedAt),
-    gameStartedAt: dateOrNull(watcher.gameStartedAt),
-    lastCheckedAt: dateOrNull(watcher.lastCheckedAt),
-    lastInGameNotifiedAt: dateOrNull(watcher.lastInGameNotifiedAt),
-    pendingResultStartedAt: dateOrNull(watcher.pendingResultStartedAt),
-  };
-}
-
-export type MatchParticipant = z.infer<typeof createParticipantSchema>;
-export type RankSnapshotPayload = z.infer<
-  typeof upsertPendingRankSnapshotsSchema
->["snapshots"][number];
-export type FinalizedRankSnapshot = {
-  matchId: string;
-  puuid: string;
-  platform: RiotPlatform;
-  queueType: RankSnapshotPayload["queueType"];
-  phase: "before" | "after";
-  tier: string | null;
-  rank: string | null;
-  leaguePoints: number | null;
-  wins: number | null;
-  losses: number | null;
-  fetchedAt: Date;
-};
-export type RiotStaticDataResolveInput = {
-  locale?: string;
-  championIds?: number[];
-  queueIds?: number[];
-  mapIds?: number[];
-  gameModes?: string[];
-};
-export type RiotStaticDataResolveData = {
-  champions: Record<
-    string,
-    { name: string | null; iconUrl: string | null }
-  >;
-  queues: Record<string, string | null>;
-  maps: Record<string, string | null>;
-  gameModes: Record<string, string | null>;
-};
-export type RiotStaticDataResolveResult =
-  | { success: true; data: RiotStaticDataResolveData }
-  | { success: false; error: string };
-export type ResolveOpggMatchDetailPayload = z.infer<
-  typeof resolveOpggMatchDetailSchema
->;
-export type OpggMatchDetail = {
-  provider: "opgg";
-  providerRegion: string;
-  providerMatchId: string;
-  detailUrl: string;
-  providerCreatedAt: Date;
-  averageTier: string | null;
-  participant?: {
-    puuid: string;
-    participantId: number | null;
-    laneScore: number | null;
-  };
-};
-export type ResolveOpggMatchDetailResult =
-  | { success: true; detail: OpggMatchDetail | null }
-  | { success: false; error: string };
-
-function parseRankSnapshot(
-  snapshot: Omit<FinalizedRankSnapshot, "fetchedAt"> & {
-    fetchedAt: string | Date;
-  },
-): FinalizedRankSnapshot {
-  return {
-    ...snapshot,
-    fetchedAt: new Date(snapshot.fetchedAt),
-  };
-}
-
-async function readErrorMessage(res: ApiResponse): Promise<string> {
-  const body = await res.json() as { error?: string };
-  return body.error ?? COMMUNICATION_ERROR;
-}
-
-function logCommunicationError(error: unknown) {
-  console.error(COMMUNICATION_ERROR, error);
-}
-
-function unexpectedResponseError(res: ApiResponse): Error {
-  return new Error(`Unexpected response: ${res.status} ${res.statusText}`);
-}
-
-async function resultFromRequest<
-  T extends Record<string, unknown>,
-  F extends FailureResult = FailureResult,
->(
-  request: () => Promise<ApiResponse>,
-  parseSuccess: (res: ApiResponse) => Promise<T> | T,
-  handleHttpError?: (
-    res: ApiResponse,
-  ) => Promise<F> | F,
-): Promise<({ success: true } & T) | F | FailureResult> {
-  try {
-    const res = await request();
-
-    if (!res.ok) {
-      if (handleHttpError) {
-        return await handleHttpError(res);
-      }
-
-      throw unexpectedResponseError(res);
-    }
-
-    return { success: true, ...await parseSuccess(res) };
-  } catch (error) {
-    logCommunicationError(error);
-    return { success: false, error: COMMUNICATION_ERROR };
-  }
-}
-
-function successOnly() {
-  return {};
 }
 
 export function createApiClient({ rpcClient }: { rpcClient: ApiRpcClient }) {
-  async function linkAccountByRiotId(
-    discordId: string,
-    gameName: string,
-    tagLine: string,
-    platform?: RiotPlatform,
-    region?: RiotRegion,
-  ) {
-    return await resultFromRequest(
-      () =>
-        rpcClient.users["link-by-riot-id"].$patch({
-          json: { discordId, gameName, tagLine, platform, region },
-        }),
-      successOnly,
-      async (res) => {
-        if (res.status === 404) {
-          return { success: false, error: await readErrorMessage(res) };
-        }
-
-        throw unexpectedResponseError(res);
-      },
-    );
-  }
-
-  async function getRiotAccount(discordId: string) {
-    return await resultFromRequest(
-      () =>
-        rpcClient.users[":userId"]["riot-account"].$get({
-          param: { userId: discordId },
-        }),
-      async (res) => {
-        const body = await res.json() as {
-          account: Parameters<
-            typeof parseRiotAccount
-          >[0];
-        };
-        return { account: parseRiotAccount(body.account) };
-      },
-      async (res) => {
-        if (res.status === 404) {
-          return { success: false, error: await readErrorMessage(res) };
-        }
-
-        throw unexpectedResponseError(res);
-      },
-    );
-  }
-
-  async function getActiveGameByPuuid(
-    platform: RiotPlatform,
-    puuid: string,
-  ) {
-    const res = await rpcClient.riot["active-games"][":platform"][":puuid"]
-      .$get({
-        param: { platform, puuid },
-      });
-    if (!res.ok) {
-      const body = await res.json();
-      throw new Error(body.error);
-    }
-    const body = await res.json();
-    return body.activeGame;
-  }
-
-  async function getMatchById(region: RiotRegion, matchId: string) {
-    const res = await rpcClient.riot.matches[":region"][":matchId"].$get({
-      param: { region, matchId },
-    });
-    if (!res.ok) {
-      const body = await res.json();
-      throw new Error(body.error);
-    }
-    const body = await res.json();
-    return body.match;
-  }
-
-  async function getLeagueEntriesByPuuid(
-    platform: RiotPlatform,
-    puuid: string,
-  ) {
-    const res = await rpcClient.riot["league-entries"][":platform"][":puuid"]
-      .$get({
-        param: { platform, puuid },
-      });
-    if (!res.ok) {
-      const body = await res.json();
-      throw new Error(body.error);
-    }
-    const body = await res.json();
-    return body.entries;
-  }
-
-  async function checkHealth() {
-    return await resultFromRequest(
-      () => rpcClient.health.$get(),
-      async (res) => {
-        const body = await res.json() as { message: string };
-        return { message: body.message };
-      },
-    );
-  }
-
-  async function setMainRole(userId: string, guildId: string, role: Lane) {
-    return await resultFromRequest(
-      () =>
-        rpcClient.users[":userId"]["main-role"].$put({
-          param: { userId },
-          json: { guildId, role },
-        }),
-      successOnly,
-    );
-  }
-
-  async function createCustomGameEvent(event: {
-    name: string;
-    guildId: string;
-    creatorId: string;
-    discordScheduledEventId: string;
-    recruitmentMessageId: string;
-    scheduledStartAt: Date;
-  }) {
-    return await resultFromRequest(
-      () => rpcClient.events.$post({ json: event }),
-      successOnly,
-    );
-  }
-
-  async function getCustomGameEventsByCreatorId(creatorId: string) {
-    return await resultFromRequest(
-      () =>
-        rpcClient.events["by-creator"][":creatorId"].$get({
-          param: { creatorId },
-        }),
-      async (res) => {
-        const body = await res.json() as {
-          events: Parameters<typeof parseEvent>[0][];
-        };
-        return { events: body.events.map(parseEvent) };
-      },
-    );
-  }
-
-  async function deleteCustomGameEvent(discordEventId: string) {
-    return await resultFromRequest(
-      () =>
-        rpcClient.events[":discordEventId"].$delete({
-          param: { discordEventId },
-        }),
-      successOnly,
-    );
-  }
-
-  async function getEventStartingTodayByCreatorId(creatorId: string) {
-    return await resultFromRequest(
-      () =>
-        rpcClient.events.today["by-creator"][":creatorId"].$get({
-          param: { creatorId },
-        }),
-      async (res) => {
-        const data = await res.json() as {
-          event: Parameters<
-            typeof parseEvent
-          >[0];
-        };
-        return { event: parseEvent(data.event) };
-      },
-      async (res) => {
-        if (res.status === 404) {
-          return { success: false, error: await readErrorMessage(res) };
-        }
-
-        throw unexpectedResponseError(res);
-      },
-    );
-  }
-
-  async function createMatchParticipant(
-    matchId: string,
-    participant: MatchParticipant,
-  ) {
-    try {
-      const res = await rpcClient.matches[":matchId"].participants.$post({
-        param: { matchId },
-        json: participant,
-      });
-
-      if (!res.ok) {
-        if (res.status === 404) {
-          return { success: false, error: await readErrorMessage(res) };
-        }
-
-        throw unexpectedResponseError(res);
-      }
-
-      const data = await res.json() as { id?: unknown };
-      if (typeof data.id !== "number") {
-        console.error("API response missing participant id", data);
-        return {
-          success: false,
-          error: "API response missing participant id",
-        };
-      }
-
-      return { success: true, id: data.id };
-    } catch (error) {
-      logCommunicationError(error);
-      return { success: false, error: COMMUNICATION_ERROR };
-    }
-  }
-
-  async function upsertPendingRankSnapshots(
-    payload: z.infer<typeof upsertPendingRankSnapshotsSchema>,
-  ) {
-    return await resultFromRequest(
-      () =>
-        rpcClient.matches["rank-snapshots"].pending.$post({
-          json: payload,
-        }),
-      successOnly,
-    );
-  }
-
-  async function finalizeRankSnapshots(
-    matchId: string,
-    payload: z.infer<typeof finalizeRankSnapshotsSchema>,
-  ) {
-    return await resultFromRequest(
-      () =>
-        rpcClient.matches[":matchId"]["rank-snapshots"].finalize.$post({
-          param: { matchId },
-          json: payload,
-        }),
-      async (res) => {
-        const body = await res.json() as {
-          snapshots: {
-            before: Parameters<typeof parseRankSnapshot>[0][];
-            after: Parameters<typeof parseRankSnapshot>[0][];
-          };
-        };
-        return {
-          snapshots: {
-            before: body.snapshots.before.map(parseRankSnapshot),
-            after: body.snapshots.after.map(parseRankSnapshot),
-          },
-        };
-      },
-    );
-  }
-
-  async function resolveRiotStaticData(
-    payload: RiotStaticDataResolveInput,
-  ): Promise<RiotStaticDataResolveResult> {
-    return await resultFromRequest(
-      () =>
-        rpcClient.riot["static-data"].resolve.$post({
-          json: payload,
-        }),
-      async (res) => {
-        const data = await res.json() as RiotStaticDataResolveData;
-        return { data };
-      },
-      async (res) => ({
-        success: false,
-        error: await readErrorMessage(res),
-      }),
-    );
-  }
-
-  async function resolveOpggMatchDetail(
-    matchId: string,
-    payload: ResolveOpggMatchDetailPayload,
-  ): Promise<ResolveOpggMatchDetailResult> {
-    return await resultFromRequest(
-      () =>
-        rpcClient.matches[":matchId"]["external-details"].opgg.resolve.$post({
-          param: { matchId },
-          json: payload,
-        }),
-      async (res) => {
-        const body = await res.json() as {
-          detail?:
-            | (Omit<OpggMatchDetail, "providerCreatedAt"> & {
-              providerCreatedAt: string | Date;
-            })
-            | null;
-        };
-        return {
-          detail: body.detail == null ? null : {
-            ...body.detail,
-            providerCreatedAt: new Date(body.detail.providerCreatedAt),
-          },
-        };
-      },
-      async (res) => ({
-        success: false,
-        error: await readErrorMessage(res),
-      }),
-    );
-  }
-
-  async function getLoginUrl(discordId: string) {
-    return await resultFromRequest(
-      () =>
-        rpcClient.auth.rso["login-url"].$get({
-          query: { discordId },
-        }),
-      async (res) => {
-        const body = await res.json() as { url: string };
-        return { url: body.url };
-      },
-    );
-  }
-
-  async function watchMatch(watcher: {
-    guildId: string;
-    targetDiscordId: string;
-    requesterId: string;
-    channelId: string;
-  }) {
-    return await resultFromRequest(
-      () => rpcClient["match-watchers"].$post({ json: watcher }),
-      successOnly,
-      async (res) => {
-        if (res.status === 404 || res.status === 409) {
-          return {
-            success: false,
-            error: await readErrorMessage(res),
-            status: res.status,
-          };
-        }
-
-        throw unexpectedResponseError(res);
-      },
-    );
-  }
-
-  async function unwatchMatch(guildId: string, targetDiscordId: string) {
-    return await resultFromRequest(
-      () =>
-        rpcClient["match-watchers"][":guildId"][":targetDiscordId"].$delete({
-          param: { guildId, targetDiscordId },
-        }),
-      successOnly,
-    );
-  }
-
-  async function getEnabledMatchWatchers() {
-    return await resultFromRequest(
-      () => rpcClient["match-watchers"].enabled.$get(),
-      async (res) => {
-        const body = await res.json() as {
-          watchers: Parameters<typeof parseMatchWatcher>[0][];
-        };
-        return {
-          watchers: body.watchers.map(parseMatchWatcher),
-        };
-      },
-    );
-  }
-
-  async function getEnabledMatchWatchersByGuild(guildId: string) {
-    return await resultFromRequest(
-      () =>
-        rpcClient["match-watchers"].enabled[":guildId"].$get({
-          param: { guildId },
-        }),
-      async (res) => {
-        const body = await res.json() as {
-          watchers: Parameters<typeof parseMatchWatcher>[0][];
-        };
-        return {
-          watchers: body.watchers.map(parseMatchWatcher),
-        };
-      },
-    );
-  }
-
-  async function updateMatchWatcherState(
-    guildId: string,
-    targetDiscordId: string,
-    state: {
-      lastState: MatchWatcherState;
-      currentGameId?: string | null;
-      currentMatchId?: string | null;
-      currentNotificationMessageId?: string | null;
-      pendingResultMatchId?: string | null;
-      pendingResultNotificationMessageId?: string | null;
-      pendingResultStartedAt?: Date | null;
-      gameStartedAt?: Date | null;
-      lastCheckedAt?: Date | null;
-      lastInGameNotifiedAt?: Date | null;
-    },
-  ) {
-    return await resultFromRequest(
-      () =>
-        rpcClient["match-watchers"][":guildId"][":targetDiscordId"].state
-          .$patch({
-            param: { guildId, targetDiscordId },
-            json: state,
-          }),
-      successOnly,
-    );
-  }
+  const resources = createApiResourceClients({ rpcClient });
 
   return {
-    linkAccountByRiotId,
-    getRiotAccount,
-    getActiveGameByPuuid,
-    getMatchById,
-    getLeagueEntriesByPuuid,
-    checkHealth,
-    setMainRole,
-    createCustomGameEvent,
-    getCustomGameEventsByCreatorId,
-    deleteCustomGameEvent,
-    getEventStartingTodayByCreatorId,
-    createMatchParticipant,
-    upsertPendingRankSnapshots,
-    finalizeRankSnapshots,
-    resolveRiotStaticData,
-    resolveOpggMatchDetail,
-    getLoginUrl,
-    watchMatch,
-    unwatchMatch,
-    getEnabledMatchWatchers,
-    getEnabledMatchWatchersByGuild,
-    updateMatchWatcherState,
+    ...resources.users,
+    ...resources.riot,
+    ...resources.health,
+    ...resources.events,
+    ...resources.matches,
+    ...resources.auth,
+    ...resources.matchWatchers,
   };
 }
 

--- a/bot/src/api_clients/auth.ts
+++ b/bot/src/api_clients/auth.ts
@@ -1,0 +1,22 @@
+import { type ApiRpcClient, resultFromRequest } from "./transport.ts";
+
+export function createAuthApiClient(
+  { rpcClient }: { rpcClient: ApiRpcClient },
+) {
+  async function getLoginUrl(discordId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.auth.rso["login-url"].$get({
+          query: { discordId },
+        }),
+      async (res) => {
+        const body = await res.json() as { url: string };
+        return { url: body.url };
+      },
+    );
+  }
+
+  return { getLoginUrl };
+}
+
+export type AuthApiClient = ReturnType<typeof createAuthApiClient>;

--- a/bot/src/api_clients/events.ts
+++ b/bot/src/api_clients/events.ts
@@ -1,0 +1,95 @@
+import type { Event } from "@adteemo/api/contract";
+import {
+  type ApiRpcClient,
+  readErrorMessage,
+  resultFromRequest,
+  successOnly,
+  unexpectedResponseError,
+} from "./transport.ts";
+
+function parseEvent(
+  event: {
+    scheduledStartAt: string | Date;
+    createdAt: string | Date;
+  } & Omit<Event, "scheduledStartAt" | "createdAt">,
+): Event {
+  return {
+    ...event,
+    scheduledStartAt: new Date(event.scheduledStartAt),
+    createdAt: new Date(event.createdAt),
+  };
+}
+
+export function createEventsApiClient(
+  { rpcClient }: { rpcClient: ApiRpcClient },
+) {
+  async function createCustomGameEvent(event: {
+    name: string;
+    guildId: string;
+    creatorId: string;
+    discordScheduledEventId: string;
+    recruitmentMessageId: string;
+    scheduledStartAt: Date;
+  }) {
+    return await resultFromRequest(
+      () => rpcClient.events.$post({ json: event }),
+      successOnly,
+    );
+  }
+
+  async function getCustomGameEventsByCreatorId(creatorId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.events["by-creator"][":creatorId"].$get({
+          param: { creatorId },
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          events: Parameters<typeof parseEvent>[0][];
+        };
+        return { events: body.events.map(parseEvent) };
+      },
+    );
+  }
+
+  async function deleteCustomGameEvent(discordEventId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.events[":discordEventId"].$delete({
+          param: { discordEventId },
+        }),
+      successOnly,
+    );
+  }
+
+  async function getEventStartingTodayByCreatorId(creatorId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.events.today["by-creator"][":creatorId"].$get({
+          param: { creatorId },
+        }),
+      async (res) => {
+        const data = await res.json() as {
+          event: Parameters<typeof parseEvent>[0];
+        };
+        return { event: parseEvent(data.event) };
+      },
+      async (res) => {
+        if (res.status === 404) {
+          return { success: false, error: await readErrorMessage(res) };
+        }
+
+        throw unexpectedResponseError(res);
+      },
+    );
+  }
+
+  return {
+    createCustomGameEvent,
+    getCustomGameEventsByCreatorId,
+    deleteCustomGameEvent,
+    getEventStartingTodayByCreatorId,
+  };
+}
+
+export type EventsApiClient = ReturnType<typeof createEventsApiClient>;

--- a/bot/src/api_clients/health.ts
+++ b/bot/src/api_clients/health.ts
@@ -1,0 +1,19 @@
+import { type ApiRpcClient, resultFromRequest } from "./transport.ts";
+
+export function createHealthApiClient(
+  { rpcClient }: { rpcClient: ApiRpcClient },
+) {
+  async function checkHealth() {
+    return await resultFromRequest(
+      () => rpcClient.health.$get(),
+      async (res) => {
+        const body = await res.json() as { message: string };
+        return { message: body.message };
+      },
+    );
+  }
+
+  return { checkHealth };
+}
+
+export type HealthApiClient = ReturnType<typeof createHealthApiClient>;

--- a/bot/src/api_clients/match_watchers.ts
+++ b/bot/src/api_clients/match_watchers.ts
@@ -1,0 +1,147 @@
+import type { MatchWatcher, MatchWatcherState } from "@adteemo/api/contract";
+import {
+  type ApiRpcClient,
+  dateOrNull,
+  readErrorMessage,
+  resultFromRequest,
+  successOnly,
+  unexpectedResponseError,
+} from "./transport.ts";
+
+function parseMatchWatcher(
+  watcher:
+    & {
+      createdAt: string | Date;
+      updatedAt: string | Date | null;
+      gameStartedAt: string | Date | null;
+      lastCheckedAt: string | Date | null;
+      lastInGameNotifiedAt: string | Date | null;
+      pendingResultStartedAt: string | Date | null;
+    }
+    & Omit<
+      MatchWatcher,
+      | "createdAt"
+      | "updatedAt"
+      | "gameStartedAt"
+      | "lastCheckedAt"
+      | "lastInGameNotifiedAt"
+      | "pendingResultStartedAt"
+    >,
+): MatchWatcher {
+  return {
+    ...watcher,
+    createdAt: new Date(watcher.createdAt),
+    updatedAt: dateOrNull(watcher.updatedAt),
+    gameStartedAt: dateOrNull(watcher.gameStartedAt),
+    lastCheckedAt: dateOrNull(watcher.lastCheckedAt),
+    lastInGameNotifiedAt: dateOrNull(watcher.lastInGameNotifiedAt),
+    pendingResultStartedAt: dateOrNull(watcher.pendingResultStartedAt),
+  };
+}
+
+export function createMatchWatchersApiClient(
+  { rpcClient }: { rpcClient: ApiRpcClient },
+) {
+  async function watchMatch(watcher: {
+    guildId: string;
+    targetDiscordId: string;
+    requesterId: string;
+    channelId: string;
+  }) {
+    return await resultFromRequest(
+      () => rpcClient["match-watchers"].$post({ json: watcher }),
+      successOnly,
+      async (res) => {
+        if (res.status === 404 || res.status === 409) {
+          return {
+            success: false,
+            error: await readErrorMessage(res),
+            status: res.status,
+          };
+        }
+
+        throw unexpectedResponseError(res);
+      },
+    );
+  }
+
+  async function unwatchMatch(guildId: string, targetDiscordId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient["match-watchers"][":guildId"][":targetDiscordId"].$delete({
+          param: { guildId, targetDiscordId },
+        }),
+      successOnly,
+    );
+  }
+
+  async function getEnabledMatchWatchers() {
+    return await resultFromRequest(
+      () => rpcClient["match-watchers"].enabled.$get(),
+      async (res) => {
+        const body = await res.json() as {
+          watchers: Parameters<typeof parseMatchWatcher>[0][];
+        };
+        return {
+          watchers: body.watchers.map(parseMatchWatcher),
+        };
+      },
+    );
+  }
+
+  async function getEnabledMatchWatchersByGuild(guildId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient["match-watchers"].enabled[":guildId"].$get({
+          param: { guildId },
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          watchers: Parameters<typeof parseMatchWatcher>[0][];
+        };
+        return {
+          watchers: body.watchers.map(parseMatchWatcher),
+        };
+      },
+    );
+  }
+
+  async function updateMatchWatcherState(
+    guildId: string,
+    targetDiscordId: string,
+    state: {
+      lastState: MatchWatcherState;
+      currentGameId?: string | null;
+      currentMatchId?: string | null;
+      currentNotificationMessageId?: string | null;
+      pendingResultMatchId?: string | null;
+      pendingResultNotificationMessageId?: string | null;
+      pendingResultStartedAt?: Date | null;
+      gameStartedAt?: Date | null;
+      lastCheckedAt?: Date | null;
+      lastInGameNotifiedAt?: Date | null;
+    },
+  ) {
+    return await resultFromRequest(
+      () =>
+        rpcClient["match-watchers"][":guildId"][":targetDiscordId"].state
+          .$patch({
+            param: { guildId, targetDiscordId },
+            json: state,
+          }),
+      successOnly,
+    );
+  }
+
+  return {
+    watchMatch,
+    unwatchMatch,
+    getEnabledMatchWatchers,
+    getEnabledMatchWatchersByGuild,
+    updateMatchWatcherState,
+  };
+}
+
+export type MatchWatchersApiClient = ReturnType<
+  typeof createMatchWatchersApiClient
+>;

--- a/bot/src/api_clients/matches.ts
+++ b/bot/src/api_clients/matches.ts
@@ -85,8 +85,8 @@ export function createMatchesApiClient(
         throw unexpectedResponseError(res);
       }
 
-      const data = await res.json() as { id?: unknown };
-      if (typeof data.id !== "number") {
+      const data = await res.json() as { id?: unknown } | null;
+      if (typeof data?.id !== "number") {
         console.error("API response missing participant id", data);
         return {
           success: false,

--- a/bot/src/api_clients/matches.ts
+++ b/bot/src/api_clients/matches.ts
@@ -1,0 +1,183 @@
+import { z } from "zod";
+import {
+  createParticipantSchema,
+  finalizeRankSnapshotsSchema,
+  resolveOpggMatchDetailSchema,
+  upsertPendingRankSnapshotsSchema,
+} from "@adteemo/api/contract";
+import type { RiotPlatform } from "@adteemo/api/contract";
+import {
+  type ApiRpcClient,
+  COMMUNICATION_ERROR,
+  logCommunicationError,
+  readErrorMessage,
+  resultFromRequest,
+  successOnly,
+  unexpectedResponseError,
+} from "./transport.ts";
+
+export type MatchParticipant = z.infer<typeof createParticipantSchema>;
+export type RankSnapshotPayload = z.infer<
+  typeof upsertPendingRankSnapshotsSchema
+>["snapshots"][number];
+export type FinalizedRankSnapshot = {
+  matchId: string;
+  puuid: string;
+  platform: RiotPlatform;
+  queueType: RankSnapshotPayload["queueType"];
+  phase: "before" | "after";
+  tier: string | null;
+  rank: string | null;
+  leaguePoints: number | null;
+  wins: number | null;
+  losses: number | null;
+  fetchedAt: Date;
+};
+export type ResolveOpggMatchDetailPayload = z.infer<
+  typeof resolveOpggMatchDetailSchema
+>;
+export type OpggMatchDetail = {
+  provider: "opgg";
+  providerRegion: string;
+  providerMatchId: string;
+  detailUrl: string;
+  providerCreatedAt: Date;
+  averageTier: string | null;
+  participant?: {
+    puuid: string;
+    participantId: number | null;
+    laneScore: number | null;
+  };
+};
+export type ResolveOpggMatchDetailResult =
+  | { success: true; detail: OpggMatchDetail | null }
+  | { success: false; error: string };
+
+function parseRankSnapshot(
+  snapshot: Omit<FinalizedRankSnapshot, "fetchedAt"> & {
+    fetchedAt: string | Date;
+  },
+): FinalizedRankSnapshot {
+  return {
+    ...snapshot,
+    fetchedAt: new Date(snapshot.fetchedAt),
+  };
+}
+
+export function createMatchesApiClient(
+  { rpcClient }: { rpcClient: ApiRpcClient },
+) {
+  async function createMatchParticipant(
+    matchId: string,
+    participant: MatchParticipant,
+  ) {
+    try {
+      const res = await rpcClient.matches[":matchId"].participants.$post({
+        param: { matchId },
+        json: participant,
+      });
+
+      if (!res.ok) {
+        if (res.status === 404) {
+          return { success: false, error: await readErrorMessage(res) };
+        }
+
+        throw unexpectedResponseError(res);
+      }
+
+      const data = await res.json() as { id?: unknown };
+      if (typeof data.id !== "number") {
+        console.error("API response missing participant id", data);
+        return {
+          success: false,
+          error: "API response missing participant id",
+        };
+      }
+
+      return { success: true, id: data.id };
+    } catch (error) {
+      logCommunicationError(error);
+      return { success: false, error: COMMUNICATION_ERROR };
+    }
+  }
+
+  async function upsertPendingRankSnapshots(
+    payload: z.infer<typeof upsertPendingRankSnapshotsSchema>,
+  ) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.matches["rank-snapshots"].pending.$post({
+          json: payload,
+        }),
+      successOnly,
+    );
+  }
+
+  async function finalizeRankSnapshots(
+    matchId: string,
+    payload: z.infer<typeof finalizeRankSnapshotsSchema>,
+  ) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.matches[":matchId"]["rank-snapshots"].finalize.$post({
+          param: { matchId },
+          json: payload,
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          snapshots: {
+            before: Parameters<typeof parseRankSnapshot>[0][];
+            after: Parameters<typeof parseRankSnapshot>[0][];
+          };
+        };
+        return {
+          snapshots: {
+            before: body.snapshots.before.map(parseRankSnapshot),
+            after: body.snapshots.after.map(parseRankSnapshot),
+          },
+        };
+      },
+    );
+  }
+
+  async function resolveOpggMatchDetail(
+    matchId: string,
+    payload: ResolveOpggMatchDetailPayload,
+  ): Promise<ResolveOpggMatchDetailResult> {
+    return await resultFromRequest(
+      () =>
+        rpcClient.matches[":matchId"]["external-details"].opgg.resolve.$post({
+          param: { matchId },
+          json: payload,
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          detail?:
+            | (Omit<OpggMatchDetail, "providerCreatedAt"> & {
+              providerCreatedAt: string | Date;
+            })
+            | null;
+        };
+        return {
+          detail: body.detail == null ? null : {
+            ...body.detail,
+            providerCreatedAt: new Date(body.detail.providerCreatedAt),
+          },
+        };
+      },
+      async (res) => ({
+        success: false,
+        error: await readErrorMessage(res),
+      }),
+    );
+  }
+
+  return {
+    createMatchParticipant,
+    upsertPendingRankSnapshots,
+    finalizeRankSnapshots,
+    resolveOpggMatchDetail,
+  };
+}
+
+export type MatchesApiClient = ReturnType<typeof createMatchesApiClient>;

--- a/bot/src/api_clients/riot.ts
+++ b/bot/src/api_clients/riot.ts
@@ -1,5 +1,12 @@
-import type { RiotPlatform, RiotRegion } from "@adteemo/api/contract";
+import type {
+  ActiveGame,
+  LeagueEntry,
+  RiotMatch,
+  RiotPlatform,
+  RiotRegion,
+} from "@adteemo/api/contract";
 import {
+  type ApiResponse,
   type ApiRpcClient,
   readErrorMessage,
   resultFromRequest,
@@ -25,6 +32,19 @@ export type RiotStaticDataResolveResult =
   | { success: true; data: RiotStaticDataResolveData }
   | { success: false; error: string };
 
+async function readRiotApiErrorMessage(res: ApiResponse): Promise<string> {
+  try {
+    const body = await res.json() as { error?: string } | null;
+    return body?.error ?? "Unknown error";
+  } catch {
+    return `HTTP ${res.status} ${res.statusText}`;
+  }
+}
+
+async function throwRiotApiError(res: ApiResponse): Promise<never> {
+  throw new Error(await readRiotApiErrorMessage(res));
+}
+
 export function createRiotApiClient(
   { rpcClient }: { rpcClient: ApiRpcClient },
 ) {
@@ -37,11 +57,10 @@ export function createRiotApiClient(
         param: { platform, puuid },
       });
     if (!res.ok) {
-      const body = await res.json();
-      throw new Error(body.error);
+      await throwRiotApiError(res);
     }
-    const body = await res.json();
-    return body.activeGame;
+    const body = await res.json() as { activeGame?: ActiveGame | null } | null;
+    return body?.activeGame ?? null;
   }
 
   async function getMatchById(region: RiotRegion, matchId: string) {
@@ -49,11 +68,10 @@ export function createRiotApiClient(
       param: { region, matchId },
     });
     if (!res.ok) {
-      const body = await res.json();
-      throw new Error(body.error);
+      await throwRiotApiError(res);
     }
-    const body = await res.json();
-    return body.match;
+    const body = await res.json() as { match?: RiotMatch | null } | null;
+    return body?.match ?? null;
   }
 
   async function getLeagueEntriesByPuuid(
@@ -65,11 +83,10 @@ export function createRiotApiClient(
         param: { platform, puuid },
       });
     if (!res.ok) {
-      const body = await res.json();
-      throw new Error(body.error);
+      await throwRiotApiError(res);
     }
-    const body = await res.json();
-    return body.entries;
+    const body = await res.json() as { entries?: LeagueEntry[] } | null;
+    return body?.entries ?? [];
   }
 
   async function resolveRiotStaticData(

--- a/bot/src/api_clients/riot.ts
+++ b/bot/src/api_clients/riot.ts
@@ -1,0 +1,102 @@
+import type { RiotPlatform, RiotRegion } from "@adteemo/api/contract";
+import {
+  type ApiRpcClient,
+  readErrorMessage,
+  resultFromRequest,
+} from "./transport.ts";
+
+export type RiotStaticDataResolveInput = {
+  locale?: string;
+  championIds?: number[];
+  queueIds?: number[];
+  mapIds?: number[];
+  gameModes?: string[];
+};
+export type RiotStaticDataResolveData = {
+  champions: Record<
+    string,
+    { name: string | null; iconUrl: string | null }
+  >;
+  queues: Record<string, string | null>;
+  maps: Record<string, string | null>;
+  gameModes: Record<string, string | null>;
+};
+export type RiotStaticDataResolveResult =
+  | { success: true; data: RiotStaticDataResolveData }
+  | { success: false; error: string };
+
+export function createRiotApiClient(
+  { rpcClient }: { rpcClient: ApiRpcClient },
+) {
+  async function getActiveGameByPuuid(
+    platform: RiotPlatform,
+    puuid: string,
+  ) {
+    const res = await rpcClient.riot["active-games"][":platform"][":puuid"]
+      .$get({
+        param: { platform, puuid },
+      });
+    if (!res.ok) {
+      const body = await res.json();
+      throw new Error(body.error);
+    }
+    const body = await res.json();
+    return body.activeGame;
+  }
+
+  async function getMatchById(region: RiotRegion, matchId: string) {
+    const res = await rpcClient.riot.matches[":region"][":matchId"].$get({
+      param: { region, matchId },
+    });
+    if (!res.ok) {
+      const body = await res.json();
+      throw new Error(body.error);
+    }
+    const body = await res.json();
+    return body.match;
+  }
+
+  async function getLeagueEntriesByPuuid(
+    platform: RiotPlatform,
+    puuid: string,
+  ) {
+    const res = await rpcClient.riot["league-entries"][":platform"][":puuid"]
+      .$get({
+        param: { platform, puuid },
+      });
+    if (!res.ok) {
+      const body = await res.json();
+      throw new Error(body.error);
+    }
+    const body = await res.json();
+    return body.entries;
+  }
+
+  async function resolveRiotStaticData(
+    payload: RiotStaticDataResolveInput,
+  ): Promise<RiotStaticDataResolveResult> {
+    return await resultFromRequest(
+      () =>
+        rpcClient.riot["static-data"].resolve.$post({
+          json: payload,
+        }),
+      async (res) => {
+        const data = await res.json() as RiotStaticDataResolveData;
+        return { data };
+      },
+      async (res) => ({
+        success: false,
+        error: await readErrorMessage(res),
+      }),
+    );
+  }
+
+  return {
+    getActiveGameByPuuid,
+    getMatchById,
+    getLeagueEntriesByPuuid,
+    resolveRiotStaticData,
+  };
+}
+
+export type RiotApiClient = ReturnType<typeof createRiotApiClient>;

--- a/bot/src/api_clients/transport.ts
+++ b/bot/src/api_clients/transport.ts
@@ -11,8 +11,8 @@ export type ApiResponse<T = unknown> = {
   json(): Promise<T>;
 };
 
-export function dateOrNull(value: string | Date | null) {
-  return value === null ? null : new Date(value);
+export function dateOrNull(value: string | Date | null | undefined) {
+  return value == null ? null : new Date(value);
 }
 
 export async function readErrorMessage(res: ApiResponse): Promise<string> {

--- a/bot/src/api_clients/transport.ts
+++ b/bot/src/api_clients/transport.ts
@@ -1,0 +1,61 @@
+import type { Client } from "@adteemo/api/contract";
+
+export const COMMUNICATION_ERROR = "Failed to communicate with API";
+
+export type ApiRpcClient = Client;
+export type FailureResult = { success: false; error: string };
+export type ApiResponse<T = unknown> = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<T>;
+};
+
+export function dateOrNull(value: string | Date | null) {
+  return value === null ? null : new Date(value);
+}
+
+export async function readErrorMessage(res: ApiResponse): Promise<string> {
+  const body = await res.json() as { error?: string };
+  return body.error ?? COMMUNICATION_ERROR;
+}
+
+export function logCommunicationError(error: unknown) {
+  console.error(COMMUNICATION_ERROR, error);
+}
+
+export function unexpectedResponseError(res: ApiResponse): Error {
+  return new Error(`Unexpected response: ${res.status} ${res.statusText}`);
+}
+
+export async function resultFromRequest<
+  T extends Record<string, unknown>,
+  F extends FailureResult = FailureResult,
+>(
+  request: () => Promise<ApiResponse>,
+  parseSuccess: (res: ApiResponse) => Promise<T> | T,
+  handleHttpError?: (
+    res: ApiResponse,
+  ) => Promise<F> | F,
+): Promise<({ success: true } & T) | F | FailureResult> {
+  try {
+    const res = await request();
+
+    if (!res.ok) {
+      if (handleHttpError) {
+        return await handleHttpError(res);
+      }
+
+      throw unexpectedResponseError(res);
+    }
+
+    return { success: true, ...await parseSuccess(res) };
+  } catch (error) {
+    logCommunicationError(error);
+    return { success: false, error: COMMUNICATION_ERROR };
+  }
+}
+
+export function successOnly() {
+  return {};
+}

--- a/bot/src/api_clients/users.ts
+++ b/bot/src/api_clients/users.ts
@@ -1,0 +1,95 @@
+import type {
+  Lane,
+  RiotAccount,
+  RiotPlatform,
+  RiotRegion,
+} from "@adteemo/api/contract";
+import {
+  type ApiRpcClient,
+  dateOrNull,
+  readErrorMessage,
+  resultFromRequest,
+  successOnly,
+  unexpectedResponseError,
+} from "./transport.ts";
+
+function parseRiotAccount(
+  account: {
+    createdAt: string | Date;
+    updatedAt: string | Date | null;
+  } & Omit<RiotAccount, "createdAt" | "updatedAt">,
+): RiotAccount {
+  return {
+    ...account,
+    createdAt: new Date(account.createdAt),
+    updatedAt: dateOrNull(account.updatedAt),
+  };
+}
+
+export function createUsersApiClient(
+  { rpcClient }: { rpcClient: ApiRpcClient },
+) {
+  async function linkAccountByRiotId(
+    discordId: string,
+    gameName: string,
+    tagLine: string,
+    platform?: RiotPlatform,
+    region?: RiotRegion,
+  ) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.users["link-by-riot-id"].$patch({
+          json: { discordId, gameName, tagLine, platform, region },
+        }),
+      successOnly,
+      async (res) => {
+        if (res.status === 404) {
+          return { success: false, error: await readErrorMessage(res) };
+        }
+
+        throw unexpectedResponseError(res);
+      },
+    );
+  }
+
+  async function getRiotAccount(discordId: string) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.users[":userId"]["riot-account"].$get({
+          param: { userId: discordId },
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          account: Parameters<typeof parseRiotAccount>[0];
+        };
+        return { account: parseRiotAccount(body.account) };
+      },
+      async (res) => {
+        if (res.status === 404) {
+          return { success: false, error: await readErrorMessage(res) };
+        }
+
+        throw unexpectedResponseError(res);
+      },
+    );
+  }
+
+  async function setMainRole(userId: string, guildId: string, role: Lane) {
+    return await resultFromRequest(
+      () =>
+        rpcClient.users[":userId"]["main-role"].$put({
+          param: { userId },
+          json: { guildId, role },
+        }),
+      successOnly,
+    );
+  }
+
+  return {
+    linkAccountByRiotId,
+    getRiotAccount,
+    setMainRole,
+  };
+}
+
+export type UsersApiClient = ReturnType<typeof createUsersApiClient>;


### PR DESCRIPTION
## 概要

- Bot API clientを `health` / `users` / `events` / `matches` / `match-watchers` / `riot` / `auth` のresource別clientへ分割
- 共通transport、HTTP error handling、日時変換の共通処理を `bot/src/api_clients/transport.ts` へ移動
- 既存のflatな `createApiClient` / `apiClient` facadeは互換層として維持
- `createApiResourceClients` を追加し、利用側が必要なresource interfaceだけを参照できる入口を追加

## 背景

#71 の Bot API境界フェーズのうち、#74 のresource別client分割を進める変更です。既存HTTP API契約、既存method名、戻り値は変更しません。

## 検証

- `deno test --allow-env --allow-read bot/src/api_client.test.ts`
- `deno task fmt:check`
- `deno task check`
- `deno task quality`
- サブエージェントレビュー実施: 新規 `bot/src/api_clients/` をPRに含める点を確認し、実装互換性の追加指摘なし

Refs #74
Refs #71