### PR TITLE
[codex] refactor(bot): record-match参加者取得を分離

### DIFF
--- a/bot/src/commands/record-match.test.ts
+++ b/bot/src/commands/record-match.test.ts
@@ -10,7 +10,7 @@ import { data, execute } from "./record-match.ts";
 import { MockInteractionBuilder } from "../test_utils.ts";
 import { assertEquals } from "@std/assert";
 import type { Lane } from "@adteemo/api/contract";
-import { matchTracker } from "../features/match_tracking.ts";
+import { recordMatchParticipantProvider } from "../features/record_match_participants.ts";
 import { statCollector } from "../features/stat_collector.ts";
 
 describe("/record-match command", () => {
@@ -61,7 +61,7 @@ describe("/record-match command", () => {
   test("対話フローが正常に完了し、全プレイヤーのデータがAPIに送信される", async () => {
     // Arrange
     using _getActiveParticipantsStub = stub(
-      matchTracker,
+      recordMatchParticipantProvider,
       "getActiveParticipants",
       () => Promise.resolve(mockParticipants),
     );

--- a/bot/src/commands/record-match.ts
+++ b/bot/src/commands/record-match.ts
@@ -8,8 +8,8 @@ import {
   SlashCommandBuilder,
 } from "discord.js";
 import { messageHandler, messageKeys } from "../messages.ts";
-import { matchTracker } from "../features/match_tracking.ts";
 import { apiClient, type MatchParticipant } from "../api_client.ts";
+import { recordMatchParticipantProvider } from "../features/record_match_participants.ts";
 import { statCollector } from "../features/stat_collector.ts";
 import { MessageFlags } from "discord.js";
 
@@ -54,7 +54,8 @@ export async function execute(interaction: CommandInteraction) {
       flags: MessageFlags.Ephemeral,
     });
 
-    const participants = await matchTracker.getActiveParticipants();
+    const participants = await recordMatchParticipantProvider
+      .getActiveParticipants();
     const allStats: Map<string, Stats> = new Map();
 
     for (const participant of participants) {

--- a/bot/src/component_boundary.test.ts
+++ b/bot/src/component_boundary.test.ts
@@ -89,3 +89,13 @@ test("Bot実行環境がBackend内部実装とDB設定に依存しない", async
   // Act / Assert
   assertEquals(violations, []);
 });
+
+test("record-matchコマンドがmatch tracking機能に依存しない", async () => {
+  // Arrange
+  const source = await Deno.readTextFile(
+    new URL("./commands/record-match.ts", import.meta.url),
+  );
+
+  // Act / Assert
+  assertEquals(source.includes("../features/match_tracking.ts"), false);
+});

--- a/bot/src/component_boundary.test.ts
+++ b/bot/src/component_boundary.test.ts
@@ -36,6 +36,21 @@ const forbiddenBackendRuntimeImportPatterns = [
   /from\s+["']drizzle-orm\/sqlite-core["']/,
 ];
 
+function relativeImportUrls(source: string, sourceFile: URL): string[] {
+  const importPattern =
+    /\b(?:import|export)\s+(?:type\s+)?(?:[^"']*?\s+from\s+)?["']([^"']+)["']/g;
+  const urls: string[] = [];
+
+  for (const match of source.matchAll(importPattern)) {
+    const specifier = match[1];
+    if (!specifier.startsWith(".")) continue;
+
+    urls.push(new URL(specifier, sourceFile).href);
+  }
+
+  return urls;
+}
+
 test("Bot実行環境がBackend内部実装とDB設定に依存しない", async () => {
   // Arrange
   const violations: string[] = [];
@@ -92,11 +107,16 @@ test("Bot実行環境がBackend内部実装とDB設定に依存しない", async
 
 test("record-matchコマンドがmatch tracking機能に依存しない", async () => {
   // Arrange
-  const source = await Deno.readTextFile(
-    new URL("./commands/record-match.ts", import.meta.url),
+  const commandFile = new URL("./commands/record-match.ts", import.meta.url);
+  const matchTrackingFile = new URL(
+    "./features/match_tracking.ts",
+    import.meta.url,
   );
-  const forbiddenImport = /from\s+["'][^"']*match_tracking(?:\.ts)?["']/;
+  const source = await Deno.readTextFile(commandFile);
 
   // Act / Assert
-  assertEquals(forbiddenImport.test(source), false);
+  assertEquals(
+    relativeImportUrls(source, commandFile).includes(matchTrackingFile.href),
+    false,
+  );
 });

--- a/bot/src/component_boundary.test.ts
+++ b/bot/src/component_boundary.test.ts
@@ -95,7 +95,8 @@ test("record-matchコマンドがmatch tracking機能に依存しない", async 
   const source = await Deno.readTextFile(
     new URL("./commands/record-match.ts", import.meta.url),
   );
+  const forbiddenImport = /from\s+["'][^"']*match_tracking(?:\.ts)?["']/;
 
   // Act / Assert
-  assertEquals(source.includes("../features/match_tracking.ts"), false);
+  assertEquals(forbiddenImport.test(source), false);
 });

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -1,5 +1,5 @@
 import { type Client, EmbedBuilder } from "discord.js";
-import type { Lane, MatchWatcher, RiotAccount } from "@adteemo/api/contract";
+import type { MatchWatcher, RiotAccount } from "@adteemo/api/contract";
 import {
   apiClient,
   type FinalizedRankSnapshot,
@@ -1963,45 +1963,7 @@ function stopMatchTrackingWorker() {
   workerId = undefined;
 }
 
-function getActiveParticipants(): Promise<
-  { user: { id: string; username: string }; lane: Lane; team: "BLUE" | "RED" }[]
-> {
-  return Promise.resolve([
-    { user: { id: "user1", username: "Player1" }, lane: "Top", team: "BLUE" },
-    {
-      user: { id: "user2", username: "Player2" },
-      lane: "Jungle",
-      team: "BLUE",
-    },
-    {
-      user: { id: "user3", username: "Player3" },
-      lane: "Middle",
-      team: "BLUE",
-    },
-    {
-      user: { id: "user4", username: "Player4" },
-      lane: "Bottom",
-      team: "BLUE",
-    },
-    {
-      user: { id: "user5", username: "Player5" },
-      lane: "Support",
-      team: "BLUE",
-    },
-    { user: { id: "user6", username: "Player6" }, lane: "Top", team: "RED" },
-    { user: { id: "user7", username: "Player7" }, lane: "Jungle", team: "RED" },
-    { user: { id: "user8", username: "Player8" }, lane: "Middle", team: "RED" },
-    { user: { id: "user9", username: "Player9" }, lane: "Bottom", team: "RED" },
-    {
-      user: { id: "user10", username: "Player10" },
-      lane: "Support",
-      team: "RED",
-    },
-  ]);
-}
-
 export const matchTracker = {
-  getActiveParticipants,
   processMatchWatchers,
   startMatchTrackingWorker,
   stopMatchTrackingWorker,

--- a/bot/src/features/record_match_participants.test.ts
+++ b/bot/src/features/record_match_participants.test.ts
@@ -1,0 +1,24 @@
+import { assertEquals } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import { recordMatchParticipantProvider } from "./record_match_participants.ts";
+
+describe("record-match participant provider", () => {
+  test("暫定providerがrecord-match用の固定参加者を返す", async () => {
+    // Act
+    const participants = await recordMatchParticipantProvider
+      .getActiveParticipants();
+
+    // Assert
+    assertEquals(participants.length, 10);
+    assertEquals(participants[0], {
+      user: { id: "user1", username: "Player1" },
+      lane: "Top",
+      team: "BLUE",
+    });
+    assertEquals(participants[9], {
+      user: { id: "user10", username: "Player10" },
+      lane: "Support",
+      team: "RED",
+    });
+  });
+});

--- a/bot/src/features/record_match_participants.ts
+++ b/bot/src/features/record_match_participants.ts
@@ -1,0 +1,49 @@
+import type { Lane } from "@adteemo/api/contract";
+
+export type RecordMatchParticipant = {
+  user: {
+    id: string;
+    username: string;
+  };
+  lane: Lane;
+  team: "BLUE" | "RED";
+};
+
+function getActiveParticipants(): Promise<RecordMatchParticipant[]> {
+  return Promise.resolve([
+    { user: { id: "user1", username: "Player1" }, lane: "Top", team: "BLUE" },
+    {
+      user: { id: "user2", username: "Player2" },
+      lane: "Jungle",
+      team: "BLUE",
+    },
+    {
+      user: { id: "user3", username: "Player3" },
+      lane: "Middle",
+      team: "BLUE",
+    },
+    {
+      user: { id: "user4", username: "Player4" },
+      lane: "Bottom",
+      team: "BLUE",
+    },
+    {
+      user: { id: "user5", username: "Player5" },
+      lane: "Support",
+      team: "BLUE",
+    },
+    { user: { id: "user6", username: "Player6" }, lane: "Top", team: "RED" },
+    { user: { id: "user7", username: "Player7" }, lane: "Jungle", team: "RED" },
+    { user: { id: "user8", username: "Player8" }, lane: "Middle", team: "RED" },
+    { user: { id: "user9", username: "Player9" }, lane: "Bottom", team: "RED" },
+    {
+      user: { id: "user10", username: "Player10" },
+      lane: "Support",
+      team: "RED",
+    },
+  ]);
+}
+
+export const recordMatchParticipantProvider = {
+  getActiveParticipants,
+};


### PR DESCRIPTION
## 概要

- `record-match`用の暫定参加者providerを追加
- `record-match.ts`の参加者取得依存を`matchTracker`から新providerへ変更
- `match_tracking.ts`から固定参加者取得責務を削除
- 依存逆戻りを検出する境界テストとproviderテストを追加

## 背景

`record-match`用の固定参加者データがmatch tracking責務に混在していたため、Issue #77の受け入れ条件に沿って参加者取得をrecord-match側の責務へ分離しました。実際の参加者取得仕様は対象外のため、既存の固定データは暫定providerに移しています。

Closes #77

## 検証

- `deno test --allow-env --allow-read --allow-sys --allow-ffi --env-file=.env.example bot/src/component_boundary.test.ts bot/src/features/record_match_participants.test.ts bot/src/commands/record-match.test.ts`
- `deno task quality`