### PR TITLE
refactor(bot): MatchTrackingServiceへ監視処理を集約

### DIFF
--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { assertSpyCall, assertSpyCalls, spy, stub } from "@std/testing/mock";
+import { FakeTime } from "@std/testing/time";
 import type { Client } from "discord.js";
 import type { MatchWatcher, RiotAccount } from "@adteemo/api/contract";
 import { apiClient } from "../api_client.ts";
@@ -84,6 +85,12 @@ function activeGameForPuuid(puuid: string, gameId = 12345) {
   const game = activeGame(gameId);
   game.participants[0].puuid = puuid;
   return game;
+}
+
+async function flushMicrotasks(count = 100) {
+  for (let index = 0; index < count; index++) {
+    await Promise.resolve();
+  }
 }
 
 function match(): RiotMatch {
@@ -3517,5 +3524,77 @@ describe("match_tracking.ts", () => {
 
     assertEquals(updateStub.calls[0].args[2].lastState, "IN_GAME");
     assertEquals(updateStub.calls[0].args[2].currentGameId, "12345");
+  });
+
+  test("workerの複数tickでRiotリクエスト予算警告をlong window内に再出力しない", async () => {
+    const time = new FakeTime(new Date("2026-01-01T00:00:00Z"));
+    const originalPollInterval = Deno.env.get("MATCH_WATCH_POLL_INTERVAL_MS");
+    const originalLongWindowLimit = Deno.env.get(
+      "RIOT_RATE_LIMIT_LONG_WINDOW_LIMIT",
+    );
+    const originalLongWindowMs = Deno.env.get("RIOT_RATE_LIMIT_LONG_WINDOW_MS");
+    Deno.env.set("MATCH_WATCH_POLL_INTERVAL_MS", "60000");
+    Deno.env.set("RIOT_RATE_LIMIT_LONG_WINDOW_LIMIT", "100");
+    Deno.env.set("RIOT_RATE_LIMIT_LONG_WINDOW_MS", "120000");
+    const warnings: string[] = [];
+    using _loggerStub = stub(botLogger, "warn", (message) => {
+      warnings.push(message);
+    });
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: Array.from({ length: 40 }, (_, index) =>
+            watcher({ targetDiscordId: `target-${index + 1}` })),
+        }),
+    );
+    using _getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () =>
+        Promise.resolve({
+          success: false as const,
+          error: "Riot account fetch failed",
+        }),
+    );
+    const { client } = clientWithSend();
+
+    try {
+      matchTracker.startMatchTrackingWorker(client);
+      await time.tickAsync(0);
+      await flushMicrotasks();
+      await time.tickAsync(60_000);
+      await flushMicrotasks();
+
+      assertEquals(
+        warnings.filter((message) =>
+          message === "match_tracking.riot_request_budget_risk"
+        ).length,
+        1,
+      );
+    } finally {
+      matchTracker.stopMatchTrackingWorker();
+      time.restore();
+      if (originalPollInterval === undefined) {
+        Deno.env.delete("MATCH_WATCH_POLL_INTERVAL_MS");
+      } else {
+        Deno.env.set("MATCH_WATCH_POLL_INTERVAL_MS", originalPollInterval);
+      }
+      if (originalLongWindowLimit === undefined) {
+        Deno.env.delete("RIOT_RATE_LIMIT_LONG_WINDOW_LIMIT");
+      } else {
+        Deno.env.set(
+          "RIOT_RATE_LIMIT_LONG_WINDOW_LIMIT",
+          originalLongWindowLimit,
+        );
+      }
+      if (originalLongWindowMs === undefined) {
+        Deno.env.delete("RIOT_RATE_LIMIT_LONG_WINDOW_MS");
+      } else {
+        Deno.env.set("RIOT_RATE_LIMIT_LONG_WINDOW_MS", originalLongWindowMs);
+      }
+    }
   });
 });

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -1,28 +1,10 @@
 import type { Client } from "discord.js";
-import type { MatchWatcher, RiotAccount } from "@adteemo/api/contract";
+import type { MatchWatcher } from "@adteemo/api/contract";
 import { apiClient } from "../api_client.ts";
 import { botLogger } from "../logger.ts";
 import { messageHandler, messageKeys } from "../messages.ts";
 import {
-  activeGameCacheKey,
-  type ActiveNotificationGroup,
-  activeNotificationGroupKey,
-  currentStateFromWatcher,
   hasResultFetchTimedOut as hasResultFetchTimedOutWithConfig,
-  isAfterDate,
-  isResultFetchTimedOut as isResultFetchTimedOutWithConfig,
-  matchCacheKey,
-  matchIdForGame,
-  matchIdParts,
-  newerDate,
-  type PendingResult,
-  pendingResultFromWatcher,
-  rankedQueueTypeByQueueId,
-  rankSnapshotPayloadsFromEntries,
-  type RankSummary,
-  selectResultNotificationMessageId,
-  shouldNotifyActiveNotificationGroup
-    as shouldNotifyActiveNotificationGroupWithConfig,
   shouldNotifyInGame as shouldNotifyInGameWithConfig,
 } from "./match_tracking_state.ts";
 import {
@@ -30,6 +12,10 @@ import {
   type WatcherChannel,
 } from "./match_tracking_notifier.ts";
 import { createMatchTrackingRenderer } from "./match_tracking_renderer.ts";
+import {
+  createMatchTrackingService,
+  type MatchTrackingServiceConfig,
+} from "./match_tracking_service.ts";
 
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 const DEFAULT_IN_GAME_NOTIFY_INTERVAL_MS = 300_000;
@@ -37,36 +23,6 @@ const DEFAULT_RESULT_FETCH_TIMEOUT_MS = 3 * 60 * 60 * 1000;
 const DEFAULT_RIOT_LONG_WINDOW_LIMIT = 100;
 const DEFAULT_RIOT_LONG_WINDOW_MS = 2 * 60 * 1000;
 
-type ActiveGame = NonNullable<
-  Awaited<ReturnType<typeof apiClient.getActiveGameByPuuid>>
->;
-type ActiveGameResult = Awaited<
-  ReturnType<typeof apiClient.getActiveGameByPuuid>
->;
-type RiotAccountResult = Awaited<ReturnType<typeof apiClient.getRiotAccount>>;
-type RiotMatch = NonNullable<
-  Awaited<ReturnType<typeof apiClient.getMatchById>>
->;
-type WatcherState = Parameters<typeof apiClient.updateMatchWatcherState>[2];
-type MatchTrackingRenderer = ReturnType<typeof createMatchTrackingRenderer>;
-type MatchTrackingNotifier = ReturnType<typeof createMatchTrackingNotifier>;
-type MatchWatcherProcessingContext = {
-  activeNotificationGroups: Map<string, ActiveNotificationGroup>;
-  riotAccountsByTargetDiscordId: Map<string, Promise<RiotAccountResult>>;
-  activeGamesByRiotAccount: Map<string, Promise<ActiveGameResult>>;
-  matchesByRegionAndMatchId: Map<string, Promise<RiotMatch | null>>;
-};
-type ActiveGameTargetDetail = {
-  targetDiscordId: string;
-  championId?: number;
-};
-type RiotStaticDataResult = Awaited<
-  ReturnType<typeof apiClient.resolveRiotStaticData>
->;
-type ResolvedRiotStaticData = Extract<
-  RiotStaticDataResult,
-  { success: true }
->["data"];
 function numberEnv(name: string, fallback: number) {
   const value = Number(Deno.env.get(name));
   return Number.isFinite(value) && value > 0 ? value : fallback;
@@ -77,434 +33,29 @@ function messageLocale() {
     Deno.env.get("LC_ALL") ?? "ja_JP").replace("-", "_").split(".")[0];
 }
 
-function createMatchWatcherProcessingContext(): MatchWatcherProcessingContext {
+function matchTrackingServiceConfig(): MatchTrackingServiceConfig {
   return {
-    activeNotificationGroups: new Map(),
-    riotAccountsByTargetDiscordId: new Map(),
-    activeGamesByRiotAccount: new Map(),
-    matchesByRegionAndMatchId: new Map(),
-  };
-}
-
-async function seedMatchWatcherProcessingContext(
-  context: MatchWatcherProcessingContext,
-  watchers: MatchWatcher[],
-) {
-  for (const watcher of watchers) {
-    rememberPendingResultNotificationMessage(
-      context.activeNotificationGroups,
-      watcher,
-    );
-
-    if (
-      watcher.lastState !== "IN_GAME" || !watcher.currentGameId
-    ) {
-      continue;
-    }
-
-    const accountResult = await getRiotAccountForWatcher(
-      context,
-      watcher.targetDiscordId,
-    );
-    if (!accountResult.success) continue;
-
-    const key = activeNotificationGroupKey(
-      watcher,
-      accountResult.account.platform,
-      watcher.currentGameId,
-    );
-    const existingGroup = context.activeNotificationGroups.get(key);
-    if (existingGroup) {
-      existingGroup.targetDiscordIds.add(watcher.targetDiscordId);
-      rememberActiveNotificationWatcher(existingGroup, watcher);
-      rememberActiveNotificationMessage(existingGroup, watcher);
-      continue;
-    }
-
-    const group: ActiveNotificationGroup = {
-      messageId: watcher.currentNotificationMessageId,
-      targetDiscordIds: new Set([watcher.targetDiscordId]),
-      activeWatchers: new Map([[watcher.targetDiscordId, watcher]]),
-      messageIdTargetDiscordIds: new Map(),
-      resultMessageIdsInUse: new Set(),
-    };
-    rememberActiveNotificationMessage(group, watcher);
-    context.activeNotificationGroups.set(key, group);
-  }
-}
-
-function rememberPendingResultNotificationMessage(
-  activeNotificationGroups: Map<string, ActiveNotificationGroup>,
-  watcher: MatchWatcher,
-) {
-  const pending = pendingResultFromWatcher(watcher);
-  if (!pending?.messageId) return;
-
-  const parts = matchIdParts(pending.matchId);
-  if (!parts) return;
-
-  const key = activeNotificationGroupKey(watcher, parts.platform, parts.gameId);
-  const existingGroup = activeNotificationGroups.get(key);
-  if (existingGroup) {
-    existingGroup.resultMessageIdsInUse.add(pending.messageId);
-    return;
-  }
-
-  activeNotificationGroups.set(key, {
-    messageId: null,
-    targetDiscordIds: new Set(),
-    activeWatchers: new Map(),
-    messageIdTargetDiscordIds: new Map(),
-    resultMessageIdsInUse: new Set([pending.messageId]),
-  });
-}
-
-function rememberActiveNotificationWatcher(
-  group: ActiveNotificationGroup,
-  watcher: MatchWatcher,
-) {
-  const existing = group.activeWatchers.get(watcher.targetDiscordId);
-  if (!existing) {
-    group.activeWatchers.set(watcher.targetDiscordId, watcher);
-    return;
-  }
-
-  const shouldKeepSyncedGroupMessageId = group.messageId !== null &&
-    existing.currentNotificationMessageId === group.messageId &&
-    watcher.currentNotificationMessageId !== group.messageId;
-  const currentNotificationMessageId = shouldKeepSyncedGroupMessageId
-    ? existing.currentNotificationMessageId
-    : watcher.currentNotificationMessageId ??
-      existing.currentNotificationMessageId;
-
-  group.activeWatchers.set(watcher.targetDiscordId, {
-    ...watcher,
-    currentGameId: watcher.currentGameId ?? existing.currentGameId,
-    currentNotificationMessageId,
-    lastInGameNotifiedAt: newerDate(
-      existing.lastInGameNotifiedAt,
-      watcher.lastInGameNotifiedAt,
+    pollIntervalMs: numberEnv(
+      "MATCH_WATCH_POLL_INTERVAL_MS",
+      DEFAULT_POLL_INTERVAL_MS,
     ),
-  });
-}
-
-function rememberActiveNotificationMessage(
-  group: ActiveNotificationGroup,
-  watcher: MatchWatcher,
-  messageId = watcher.currentNotificationMessageId,
-) {
-  if (!messageId) return;
-  group.messageId ??= messageId;
-  const targetDiscordIds = group.messageIdTargetDiscordIds.get(messageId) ??
-    new Set<string>();
-  targetDiscordIds.add(watcher.targetDiscordId);
-  group.messageIdTargetDiscordIds.set(messageId, targetDiscordIds);
-}
-
-function resultNotificationMessageId(
-  group: ActiveNotificationGroup | undefined,
-  watcher: MatchWatcher,
-) {
-  if (!group) return watcher.currentNotificationMessageId ?? null;
-
-  const activeWatcher = group.activeWatchers.get(watcher.targetDiscordId);
-  const messageId = selectResultNotificationMessageId({
-    groupMessageId: group.messageId,
-    watcherMessageId: watcher.currentNotificationMessageId,
-    activeWatcherMessageId: activeWatcher?.currentNotificationMessageId,
-    usedMessageIds: group.resultMessageIdsInUse,
-  });
-  if (!messageId) return null;
-  group.resultMessageIdsInUse.add(messageId);
-  return messageId;
-}
-
-function getActiveNotificationGroup(
-  context: MatchWatcherProcessingContext,
-  watcher: MatchWatcher,
-  account: RiotAccount,
-  gameId: string | number,
-) {
-  const key = activeNotificationGroupKey(watcher, account.platform, gameId);
-  const existing = context.activeNotificationGroups.get(key);
-  if (existing) {
-    existing.targetDiscordIds.add(watcher.targetDiscordId);
-    if (
-      !existing.messageId && watcher.currentGameId === String(gameId) &&
-      watcher.currentNotificationMessageId
-    ) {
-      existing.messageId = watcher.currentNotificationMessageId;
-    }
-    if (watcher.currentGameId === String(gameId)) {
-      rememberActiveNotificationWatcher(existing, watcher);
-      rememberActiveNotificationMessage(existing, watcher);
-    }
-    return existing;
-  }
-
-  const group: ActiveNotificationGroup = {
-    messageId: watcher.currentGameId === String(gameId)
-      ? watcher.currentNotificationMessageId
-      : null,
-    targetDiscordIds: new Set([watcher.targetDiscordId]),
-    activeWatchers: new Map(),
-    messageIdTargetDiscordIds: new Map(),
-    resultMessageIdsInUse: new Set(),
+    inGameNotifyIntervalMs: numberEnv(
+      "MATCH_WATCH_IN_GAME_NOTIFY_INTERVAL_MS",
+      DEFAULT_IN_GAME_NOTIFY_INTERVAL_MS,
+    ),
+    resultFetchTimeoutMs: numberEnv(
+      "MATCH_WATCH_RESULT_FETCH_TIMEOUT_MS",
+      DEFAULT_RESULT_FETCH_TIMEOUT_MS,
+    ),
+    riotLongWindowLimit: numberEnv(
+      "RIOT_RATE_LIMIT_LONG_WINDOW_LIMIT",
+      DEFAULT_RIOT_LONG_WINDOW_LIMIT,
+    ),
+    riotLongWindowMs: numberEnv(
+      "RIOT_RATE_LIMIT_LONG_WINDOW_MS",
+      DEFAULT_RIOT_LONG_WINDOW_MS,
+    ),
   };
-  if (watcher.currentGameId === String(gameId)) {
-    rememberActiveNotificationWatcher(group, watcher);
-    rememberActiveNotificationMessage(group, watcher);
-  }
-  context.activeNotificationGroups.set(key, group);
-  return group;
-}
-
-async function updateActiveNotificationGroupMessage(
-  group: ActiveNotificationGroup,
-  currentWatcher: MatchWatcher,
-  gameId: string,
-  messageId: string | null,
-  notifiedAt?: Date,
-) {
-  group.messageId = messageId;
-  rememberActiveNotificationWatcher(group, {
-    ...currentWatcher,
-    lastState: "IN_GAME",
-    currentGameId: gameId,
-    currentNotificationMessageId: messageId,
-    lastInGameNotifiedAt: notifiedAt &&
-        isAfterDate(notifiedAt, currentWatcher.lastInGameNotifiedAt)
-      ? notifiedAt
-      : currentWatcher.lastInGameNotifiedAt,
-  });
-  rememberActiveNotificationMessage(group, currentWatcher, messageId);
-  if (!messageId) {
-    return;
-  }
-
-  for (const watcher of group.activeWatchers.values()) {
-    if (watcher.targetDiscordId === currentWatcher.targetDiscordId) continue;
-    await syncActiveNotificationWatcherState(
-      group,
-      watcher,
-      gameId,
-      messageId,
-      notifiedAt,
-    );
-  }
-}
-
-async function syncActiveNotificationWatcherState(
-  group: ActiveNotificationGroup,
-  watcher: MatchWatcher,
-  gameId: string,
-  messageId: string | null,
-  notifiedAt?: Date,
-) {
-  if (!messageId) return false;
-
-  const shouldSyncMessageId = watcher.currentNotificationMessageId !==
-    messageId;
-  const shouldSyncNotifiedAt = notifiedAt &&
-    isAfterDate(notifiedAt, watcher.lastInGameNotifiedAt);
-  if (!shouldSyncMessageId && !shouldSyncNotifiedAt) return false;
-
-  await setWatcherState(watcher, {
-    lastState: "IN_GAME",
-    currentGameId: gameId,
-    currentNotificationMessageId: messageId,
-    lastCheckedAt: new Date(),
-    ...(shouldSyncNotifiedAt ? { lastInGameNotifiedAt: notifiedAt } : {}),
-  });
-  rememberActiveNotificationWatcher(group, {
-    ...watcher,
-    lastState: "IN_GAME",
-    currentGameId: gameId,
-    currentNotificationMessageId: messageId,
-    lastInGameNotifiedAt: shouldSyncNotifiedAt
-      ? notifiedAt
-      : watcher.lastInGameNotifiedAt,
-  });
-  rememberActiveNotificationMessage(group, watcher, messageId);
-  return true;
-}
-
-function getRiotAccountForWatcher(
-  context: MatchWatcherProcessingContext,
-  targetDiscordId: string,
-) {
-  const cached = context.riotAccountsByTargetDiscordId.get(targetDiscordId);
-  if (cached) return cached;
-
-  const result = apiClient.getRiotAccount(targetDiscordId);
-  context.riotAccountsByTargetDiscordId.set(targetDiscordId, result);
-  return result;
-}
-
-function getActiveGameForAccount(
-  context: MatchWatcherProcessingContext,
-  account: RiotAccount,
-) {
-  const cacheKey = activeGameCacheKey(account);
-  const cached = context.activeGamesByRiotAccount.get(cacheKey);
-  if (cached) return cached;
-
-  const result = apiClient.getActiveGameByPuuid(
-    account.platform,
-    account.puuid,
-  );
-  context.activeGamesByRiotAccount.set(cacheKey, result);
-  return result;
-}
-
-function getMatchForPendingResult(
-  context: MatchWatcherProcessingContext,
-  account: RiotAccount,
-  matchId: string,
-) {
-  const cacheKey = matchCacheKey(account, matchId);
-  const cached = context.matchesByRegionAndMatchId.get(cacheKey);
-  if (cached) return cached;
-
-  const result = apiClient.getMatchById(account.region, matchId);
-  context.matchesByRegionAndMatchId.set(cacheKey, result);
-  return result;
-}
-
-async function capturePendingRankSnapshots(
-  watcher: MatchWatcher,
-  account: RiotAccount,
-  activeGame: ActiveGame,
-) {
-  if (!rankedQueueTypeByQueueId(activeGame.gameQueueConfigId)) return;
-
-  try {
-    const entries = await apiClient.getLeagueEntriesByPuuid(
-      account.platform,
-      account.puuid,
-    );
-    const result = await apiClient.upsertPendingRankSnapshots({
-      platform: account.platform,
-      gameId: String(activeGame.gameId),
-      puuid: account.puuid,
-      snapshots: rankSnapshotPayloadsFromEntries(entries, new Date()),
-    });
-    if (!result.success) {
-      botLogger.warn("match_tracking.rank_snapshot_pending_save_failed", {
-        guildId: watcher.guildId,
-        targetDiscordId: watcher.targetDiscordId,
-        error: result.error,
-      });
-    }
-  } catch (error) {
-    botLogger.warn("match_tracking.rank_snapshot_before_fetch_failed", {
-      guildId: watcher.guildId,
-      targetDiscordId: watcher.targetDiscordId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
-
-async function finalizeRankSnapshotsForResult(
-  watcher: MatchWatcher,
-  account: RiotAccount,
-  match: RiotMatch,
-): Promise<RankSummary | null> {
-  const queueType = rankedQueueTypeByQueueId(match.info.queueId);
-  if (!queueType) return null;
-
-  try {
-    const entries = await apiClient.getLeagueEntriesByPuuid(
-      account.platform,
-      account.puuid,
-    );
-    const result = await apiClient.finalizeRankSnapshots(
-      match.metadata.matchId,
-      {
-        platform: account.platform,
-        gameId: String(match.info.gameId),
-        puuid: account.puuid,
-        snapshots: rankSnapshotPayloadsFromEntries(entries, new Date()),
-      },
-    );
-    if (!result.success) {
-      botLogger.warn("match_tracking.rank_snapshot_finalize_failed", {
-        guildId: watcher.guildId,
-        targetDiscordId: watcher.targetDiscordId,
-        matchId: match.metadata.matchId,
-        error: result.error,
-      });
-      return null;
-    }
-
-    return {
-      queueType,
-      before: result.snapshots.before.find((snapshot) =>
-        snapshot.queueType === queueType
-      ) ?? null,
-      after: result.snapshots.after.find((snapshot) =>
-        snapshot.queueType === queueType
-      ) ?? null,
-    };
-  } catch (error) {
-    botLogger.warn("match_tracking.rank_snapshot_after_fetch_failed", {
-      guildId: watcher.guildId,
-      targetDiscordId: watcher.targetDiscordId,
-      matchId: match.metadata.matchId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  }
-}
-
-function shouldNotifyInGame(
-  watcher: MatchWatcher,
-  intervalMs = numberEnv(
-    "MATCH_WATCH_IN_GAME_NOTIFY_INTERVAL_MS",
-    DEFAULT_IN_GAME_NOTIFY_INTERVAL_MS,
-  ),
-  now = new Date(),
-) {
-  return shouldNotifyInGameWithConfig(watcher, intervalMs, now);
-}
-
-function shouldNotifyActiveNotificationGroup(
-  group: ActiveNotificationGroup,
-  watcher: MatchWatcher,
-  intervalMs = numberEnv(
-    "MATCH_WATCH_IN_GAME_NOTIFY_INTERVAL_MS",
-    DEFAULT_IN_GAME_NOTIFY_INTERVAL_MS,
-  ),
-  now = new Date(),
-) {
-  return shouldNotifyActiveNotificationGroupWithConfig(
-    group,
-    watcher,
-    intervalMs,
-    now,
-  );
-}
-
-function hasResultFetchTimedOut(
-  watcher: MatchWatcher,
-  timeoutMs = numberEnv(
-    "MATCH_WATCH_RESULT_FETCH_TIMEOUT_MS",
-    DEFAULT_RESULT_FETCH_TIMEOUT_MS,
-  ),
-  now = new Date(),
-) {
-  return hasResultFetchTimedOutWithConfig(watcher, timeoutMs, now);
-}
-
-function isResultFetchTimedOut(
-  startedAt: Date,
-  timeoutMs = numberEnv(
-    "MATCH_WATCH_RESULT_FETCH_TIMEOUT_MS",
-    DEFAULT_RESULT_FETCH_TIMEOUT_MS,
-  ),
-  now = new Date(),
-) {
-  return isResultFetchTimedOutWithConfig(startedAt, timeoutMs, now);
 }
 
 async function resolveRiotStaticData(input: {
@@ -533,510 +84,51 @@ function createDefaultMatchTrackingRenderer() {
   });
 }
 
-async function activeGameTargetDetails(
-  context: MatchWatcherProcessingContext,
-  currentWatcher: MatchWatcher,
-  currentAccount: RiotAccount,
-  activeGame: ActiveGame,
-  targetDiscordIds: Iterable<string>,
-): Promise<ActiveGameTargetDetail[]> {
-  const details: ActiveGameTargetDetail[] = [];
-  for (const targetDiscordId of targetDiscordIds) {
-    const accountResult = targetDiscordId === currentWatcher.targetDiscordId
-      ? { success: true as const, account: currentAccount }
-      : await getRiotAccountForWatcher(context, targetDiscordId);
-    if (!accountResult.success) {
-      details.push({
-        targetDiscordId,
-      });
-      continue;
-    }
-
-    const participant = activeGame.participants.find((p) =>
-      p.puuid === accountResult.account.puuid
-    );
-    details.push({
-      targetDiscordId,
-      championId: participant?.championId,
-    });
-  }
-  return details;
-}
-
-async function resolveOpggMatchDetailForResult(
-  watcher: MatchWatcher,
-  account: RiotAccount,
-  match: RiotMatch,
-) {
-  const participant = match.info.participants.find((candidate) =>
-    candidate.puuid === account.puuid
-  );
-  if (!participant) return null;
-
-  const result = await apiClient.resolveOpggMatchDetail(
-    match.metadata.matchId,
-    {
-      targetDiscordId: watcher.targetDiscordId,
-      match: {
-        gameCreation: match.info.gameCreation,
-        gameDuration: match.info.gameDuration,
-        queueId: match.info.queueId,
-        participant: {
-          puuid: participant.puuid,
-          championId: participant.championId,
-          championName: participant.championName,
+function createDefaultMatchTrackingService(client: Client) {
+  return createMatchTrackingService({
+    apiClient,
+    notifier: createMatchTrackingNotifier({
+      client: {
+        channels: {
+          fetch: async (channelId) =>
+            await client.channels.fetch(channelId) as WatcherChannel | null,
         },
       },
+      logger: botLogger,
+    }),
+    renderer: createDefaultMatchTrackingRenderer(),
+    clock: {
+      now: () => new Date(),
     },
-  );
-  if (!result.success) {
-    botLogger.warn("match_tracking.opgg_detail_resolve_failed", {
-      guildId: watcher.guildId,
-      targetDiscordId: watcher.targetDiscordId,
-      matchId: match.metadata.matchId,
-      error: result.error,
-    });
-    return null;
-  }
-  return result.detail;
-}
-
-async function setWatcherState(
-  watcher: MatchWatcher,
-  state: Parameters<typeof apiClient.updateMatchWatcherState>[2],
-) {
-  const result = await apiClient.updateMatchWatcherState(
-    watcher.guildId,
-    watcher.targetDiscordId,
-    state,
-  );
-  if (!result.success) {
-    botLogger.error("match_tracking.state_update_failed", {
-      guildId: watcher.guildId,
-      targetDiscordId: watcher.targetDiscordId,
-      error: result.error,
-    });
-  }
-}
-
-async function tryFetchAndNotifyResult(
-  notifier: MatchTrackingNotifier,
-  renderer: MatchTrackingRenderer,
-  watcher: MatchWatcher,
-  account: RiotAccount,
-  context: MatchWatcherProcessingContext,
-  pending: PendingResult,
-  currentState: WatcherState = currentStateFromWatcher(watcher),
-) {
-  if (pending.startedAt && isResultFetchTimedOut(pending.startedAt)) {
-    botLogger.warn("match_tracking.fetch_result_timeout", {
-      guildId: watcher.guildId,
-      targetDiscordId: watcher.targetDiscordId,
-      matchId: pending.matchId,
-    });
-    const messageId = await notifier.sendOrEditWatcherMessage(
-      watcher,
-      pending.messageId,
-      renderer.resultFetchTimeout(watcher, pending.matchId),
-    );
-    await setWatcherState(watcher, {
-      ...currentState,
-      pendingResultMatchId: null,
-      pendingResultNotificationMessageId: null,
-      pendingResultStartedAt: null,
-      currentMatchId: null,
-      lastCheckedAt: new Date(),
-    });
-    return { status: "cleared" as const, messageId };
-  }
-
-  const match = await getMatchForPendingResult(
-    context,
-    account,
-    pending.matchId,
-  );
-  if (!match) {
-    await setWatcherState(watcher, {
-      ...currentState,
-      pendingResultMatchId: pending.matchId,
-      pendingResultNotificationMessageId: pending.messageId,
-      pendingResultStartedAt: pending.startedAt,
-      currentMatchId: null,
-      lastCheckedAt: new Date(),
-    });
-    return { status: "pending" as const, messageId: pending.messageId };
-  }
-
-  const rankSummary = await finalizeRankSnapshotsForResult(
-    watcher,
-    account,
-    match,
-  );
-  const opggDetail = await resolveOpggMatchDetailForResult(
-    watcher,
-    account,
-    match,
-  );
-  const messageId = await notifier.sendOrEditWatcherMessage(
-    watcher,
-    pending.messageId,
-    await renderer.matchResult(
-      watcher,
-      account,
-      match,
-      rankSummary,
-      opggDetail,
-    ),
-  );
-  await setWatcherState(watcher, {
-    ...currentState,
-    currentMatchId: null,
-    pendingResultMatchId: null,
-    pendingResultNotificationMessageId: null,
-    pendingResultStartedAt: null,
-    lastCheckedAt: new Date(),
-  });
-  return { status: "cleared" as const, messageId };
-}
-
-async function processWatcher(
-  notifier: MatchTrackingNotifier,
-  renderer: MatchTrackingRenderer,
-  watcher: MatchWatcher,
-  context: MatchWatcherProcessingContext,
-) {
-  const accountResult = await getRiotAccountForWatcher(
-    context,
-    watcher.targetDiscordId,
-  );
-  if (!accountResult.success) {
-    botLogger.warn("match_tracking.riot_account_not_found", {
-      guildId: watcher.guildId,
-      targetDiscordId: watcher.targetDiscordId,
-      error: accountResult.error,
-    });
-    return;
-  }
-  const account = accountResult.account;
-
-  const pending = pendingResultFromWatcher(watcher);
-  let pendingStatus: "none" | "pending" | "cleared" = "none";
-  if (pending) {
-    const result = await tryFetchAndNotifyResult(
-      notifier,
-      renderer,
-      watcher,
-      account,
-      context,
-      pending,
-    );
-    pendingStatus = result.status;
-    if (watcher.lastState === "FETCHING_RESULT" && watcher.currentMatchId) {
-      return;
-    }
-  }
-
-  const activeGame = await getActiveGameForAccount(context, account);
-  if (!activeGame) {
-    if (watcher.lastState === "IN_GAME" && watcher.currentGameId) {
-      const activeNotificationGroup = getActiveNotificationGroup(
-        context,
-        watcher,
-        account,
-        watcher.currentGameId,
-      );
-      const matchId = matchIdForGame(account, watcher.currentGameId);
-      const messageId = await notifier.sendOrEditWatcherMessage(
-        watcher,
-        resultNotificationMessageId(activeNotificationGroup, watcher),
-        renderer.resultPending(watcher, matchId),
-      );
-      await tryFetchAndNotifyResult(
-        notifier,
-        renderer,
-        watcher,
-        account,
-        context,
-        {
-          matchId,
-          messageId,
-          startedAt: watcher.gameStartedAt,
-        },
-        {
-          lastState: "IDLE",
-          currentGameId: null,
-          currentMatchId: null,
-          currentNotificationMessageId: null,
-          gameStartedAt: null,
-          lastInGameNotifiedAt: null,
-        },
-      );
-      return;
-    }
-
-    if (watcher.lastState === "IDLE" && watcher.currentGameId === null) {
-      return;
-    }
-
-    await setWatcherState(watcher, {
-      lastState: "IDLE",
-      currentGameId: null,
-      currentNotificationMessageId: null,
-      lastCheckedAt: new Date(),
-    });
-    return;
-  }
-
-  const currentGameId = String(activeGame.gameId);
-  const activeNotificationGroup = getActiveNotificationGroup(
-    context,
-    watcher,
-    account,
-    currentGameId,
-  );
-  if (
-    watcher.lastState === "IN_GAME" &&
-    watcher.currentGameId &&
-    watcher.currentGameId !== currentGameId
-  ) {
-    if (pendingStatus === "pending") {
-      botLogger.warn("match_tracking.pending_result_replaced", {
-        guildId: watcher.guildId,
-        targetDiscordId: watcher.targetDiscordId,
-        pendingMatchId: pending?.matchId,
-      });
-    }
-    const previousMatchId = matchIdForGame(account, watcher.currentGameId);
-    const previousActiveNotificationGroup = getActiveNotificationGroup(
-      context,
-      watcher,
-      account,
-      watcher.currentGameId,
-    );
-    const notifiedAt = new Date();
-    const previousMessageId = await notifier.sendOrEditWatcherMessage(
-      watcher,
-      resultNotificationMessageId(previousActiveNotificationGroup, watcher),
-      renderer.resultPending(watcher, previousMatchId),
-    );
-    await capturePendingRankSnapshots(watcher, account, activeGame);
-    const newMessageId = await notifier.sendOrEditWatcherMessage(
-      watcher,
-      activeNotificationGroup.messageId,
-      await renderer.activeGame(
-        watcher,
-        account,
-        activeGame,
-        "started",
-        await activeGameTargetDetails(
-          context,
-          watcher,
-          account,
-          activeGame,
-          activeNotificationGroup.targetDiscordIds,
-        ),
-      ),
-    );
-    await updateActiveNotificationGroupMessage(
-      activeNotificationGroup,
-      watcher,
-      currentGameId,
-      newMessageId,
-      notifiedAt,
-    );
-    const currentState = {
-      lastState: "IN_GAME" as const,
-      currentGameId,
-      currentMatchId: null,
-      currentNotificationMessageId: newMessageId,
-      gameStartedAt: new Date(activeGame.gameStartTime),
-      lastInGameNotifiedAt: notifiedAt,
-    };
-    await setWatcherState(watcher, {
-      ...currentState,
-      pendingResultMatchId: previousMatchId,
-      pendingResultNotificationMessageId: previousMessageId,
-      pendingResultStartedAt: watcher.gameStartedAt,
-      lastCheckedAt: new Date(),
-    });
-    await tryFetchAndNotifyResult(
-      notifier,
-      renderer,
-      watcher,
-      account,
-      context,
-      {
-        matchId: previousMatchId,
-        messageId: previousMessageId,
-        startedAt: watcher.gameStartedAt,
-      },
-      currentState,
-    );
-    return;
-  }
-
-  const started = watcher.lastState !== "IN_GAME" ||
-    watcher.currentGameId !== currentGameId;
-  if (started) {
-    const notifiedAt = new Date();
-    await capturePendingRankSnapshots(watcher, account, activeGame);
-    const messageId = await notifier.sendOrEditWatcherMessage(
-      watcher,
-      activeNotificationGroup.messageId,
-      await renderer.activeGame(
-        watcher,
-        account,
-        activeGame,
-        "started",
-        await activeGameTargetDetails(
-          context,
-          watcher,
-          account,
-          activeGame,
-          activeNotificationGroup.targetDiscordIds,
-        ),
-      ),
-    );
-    await updateActiveNotificationGroupMessage(
-      activeNotificationGroup,
-      watcher,
-      currentGameId,
-      messageId,
-      notifiedAt,
-    );
-    await setWatcherState(watcher, {
-      lastState: "IN_GAME",
-      currentGameId,
-      currentMatchId: null,
-      currentNotificationMessageId: messageId,
-      gameStartedAt: new Date(activeGame.gameStartTime),
-      lastCheckedAt: new Date(),
-      lastInGameNotifiedAt: notifiedAt,
-    });
-    return;
-  }
-
-  if (shouldNotifyActiveNotificationGroup(activeNotificationGroup, watcher)) {
-    const notifiedAt = new Date();
-    const messageId = await notifier.sendOrEditWatcherMessage(
-      watcher,
-      activeNotificationGroup.messageId ?? watcher.currentNotificationMessageId,
-      await renderer.activeGame(
-        watcher,
-        account,
-        activeGame,
-        "progress",
-        await activeGameTargetDetails(
-          context,
-          watcher,
-          account,
-          activeGame,
-          activeNotificationGroup.targetDiscordIds,
-        ),
-      ),
-    );
-    await updateActiveNotificationGroupMessage(
-      activeNotificationGroup,
-      watcher,
-      currentGameId,
-      messageId,
-      notifiedAt,
-    );
-    await setWatcherState(watcher, {
-      lastState: "IN_GAME",
-      currentGameId,
-      currentNotificationMessageId: messageId,
-      lastCheckedAt: new Date(),
-      lastInGameNotifiedAt: notifiedAt,
-    });
-    return;
-  }
-
-  const didSyncSharedMessageId = await syncActiveNotificationWatcherState(
-    activeNotificationGroup,
-    watcher,
-    currentGameId,
-    activeNotificationGroup.messageId,
-  );
-  if (didSyncSharedMessageId) {
-    return;
-  }
-
-  await setWatcherState(watcher, {
-    lastState: "IN_GAME",
-    currentGameId,
-    lastCheckedAt: new Date(),
+    logger: botLogger,
+    config: matchTrackingServiceConfig(),
   });
 }
 
 async function processMatchWatchers(client: Client) {
-  const result = await apiClient.getEnabledMatchWatchers();
-  if (!result.success) {
-    botLogger.error("match_tracking.watchers_fetch_failed", {
-      error: result.error,
-    });
-    return;
-  }
-
-  warnIfRiotRequestBudgetRisk(result.watchers.length);
-
-  const context = createMatchWatcherProcessingContext();
-  const renderer = createDefaultMatchTrackingRenderer();
-  const notifier = createMatchTrackingNotifier({
-    client: {
-      channels: {
-        fetch: async (channelId) =>
-          await client.channels.fetch(channelId) as WatcherChannel | null,
-      },
-    },
-    logger: botLogger,
-  });
-  await seedMatchWatcherProcessingContext(context, result.watchers);
-  for (const watcher of result.watchers) {
-    try {
-      await processWatcher(notifier, renderer, watcher, context);
-    } catch (error) {
-      botLogger.error("match_tracking.watcher_failed", {
-        guildId: watcher.guildId,
-        targetDiscordId: watcher.targetDiscordId,
-      }, error);
-    }
-  }
+  await createDefaultMatchTrackingService(client).processMatchWatchers();
 }
 
 let workerId: number | undefined;
 let processingMatchWatchers = false;
 let lastBudgetWarningAt = 0;
 
-function warnIfRiotRequestBudgetRisk(
-  watcherCount: number,
-  pollIntervalMs = numberEnv(
-    "MATCH_WATCH_POLL_INTERVAL_MS",
-    DEFAULT_POLL_INTERVAL_MS,
-  ),
-) {
-  const longWindowLimit = numberEnv(
-    "RIOT_RATE_LIMIT_LONG_WINDOW_LIMIT",
-    DEFAULT_RIOT_LONG_WINDOW_LIMIT,
-  );
-  const longWindowMs = numberEnv(
-    "RIOT_RATE_LIMIT_LONG_WINDOW_MS",
-    DEFAULT_RIOT_LONG_WINDOW_MS,
-  );
+function warnIfRiotRequestBudgetRisk(watcherCount: number) {
+  const config = matchTrackingServiceConfig();
   const estimatedRequests = watcherCount *
-    Math.ceil(longWindowMs / pollIntervalMs);
+    Math.ceil(config.riotLongWindowMs / config.pollIntervalMs);
   const now = Date.now();
   if (
-    estimatedRequests >= longWindowLimit * 0.8 &&
-    now - lastBudgetWarningAt >= longWindowMs
+    estimatedRequests >= config.riotLongWindowLimit * 0.8 &&
+    now - lastBudgetWarningAt >= config.riotLongWindowMs
   ) {
     lastBudgetWarningAt = now;
     botLogger.warn("match_tracking.riot_request_budget_risk", {
       watcherCount,
-      pollIntervalMs,
-      rateLimitWindowMs: longWindowMs,
+      pollIntervalMs: config.pollIntervalMs,
+      rateLimitWindowMs: config.riotLongWindowMs,
       estimatedRequestsPerWindow: estimatedRequests,
-      limitPerWindow: longWindowLimit,
+      limitPerWindow: config.riotLongWindowLimit,
     });
   }
 }
@@ -1073,6 +165,28 @@ function stopMatchTrackingWorker() {
   if (workerId === undefined) return;
   clearInterval(workerId);
   workerId = undefined;
+}
+
+function hasResultFetchTimedOut(watcher: MatchWatcher) {
+  return hasResultFetchTimedOutWithConfig(
+    watcher,
+    numberEnv(
+      "MATCH_WATCH_RESULT_FETCH_TIMEOUT_MS",
+      DEFAULT_RESULT_FETCH_TIMEOUT_MS,
+    ),
+    new Date(),
+  );
+}
+
+function shouldNotifyInGame(watcher: MatchWatcher) {
+  return shouldNotifyInGameWithConfig(
+    watcher,
+    numberEnv(
+      "MATCH_WATCH_IN_GAME_NOTIFY_INTERVAL_MS",
+      DEFAULT_IN_GAME_NOTIFY_INTERVAL_MS,
+    ),
+    new Date(),
+  );
 }
 
 export const matchTracker = {

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -112,6 +112,9 @@ async function processMatchWatchers(client: Client) {
 let workerId: number | undefined;
 let processingMatchWatchers = false;
 let lastBudgetWarningAt = 0;
+let workerService:
+  | ReturnType<typeof createMatchTrackingService>
+  | undefined;
 
 function warnIfRiotRequestBudgetRisk(watcherCount: number) {
   const config = matchTrackingServiceConfig();
@@ -133,7 +136,9 @@ function warnIfRiotRequestBudgetRisk(watcherCount: number) {
   }
 }
 
-async function guardedProcessMatchWatchers(client: Client) {
+async function guardedProcessMatchWatchers(
+  service: ReturnType<typeof createMatchTrackingService>,
+) {
   if (processingMatchWatchers) {
     botLogger.warn("match_tracking.worker_tick_skipped", {
       reason: "previous_tick_still_running",
@@ -142,7 +147,7 @@ async function guardedProcessMatchWatchers(client: Client) {
   }
   processingMatchWatchers = true;
   try {
-    await processMatchWatchers(client);
+    await service.processMatchWatchers();
   } finally {
     processingMatchWatchers = false;
   }
@@ -155,16 +160,20 @@ function startMatchTrackingWorker(client: Client) {
     "MATCH_WATCH_POLL_INTERVAL_MS",
     DEFAULT_POLL_INTERVAL_MS,
   );
+  workerService = createDefaultMatchTrackingService(client);
   workerId = setInterval(() => {
-    guardedProcessMatchWatchers(client);
+    if (workerService) {
+      guardedProcessMatchWatchers(workerService);
+    }
   }, pollIntervalMs);
-  guardedProcessMatchWatchers(client);
+  guardedProcessMatchWatchers(workerService);
 }
 
 function stopMatchTrackingWorker() {
   if (workerId === undefined) return;
   clearInterval(workerId);
   workerId = undefined;
+  workerService = undefined;
 }
 
 function hasResultFetchTimedOut(watcher: MatchWatcher) {

--- a/bot/src/features/match_tracking_service.test.ts
+++ b/bot/src/features/match_tracking_service.test.ts
@@ -1,0 +1,115 @@
+import { assertEquals } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import type { MatchWatcher } from "@adteemo/api/contract";
+import { createMatchTrackingService } from "./match_tracking_service.ts";
+
+function watcher(overrides: Partial<MatchWatcher> = {}): MatchWatcher {
+  return {
+    guildId: "guild-1",
+    targetDiscordId: "target-1",
+    requesterId: "requester-1",
+    channelId: "channel-1",
+    enabled: true,
+    lastState: "IDLE",
+    currentGameId: null,
+    currentMatchId: null,
+    currentNotificationMessageId: null,
+    gameStartedAt: null,
+    lastCheckedAt: null,
+    lastInGameNotifiedAt: null,
+    pendingResultMatchId: null,
+    pendingResultNotificationMessageId: null,
+    pendingResultStartedAt: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+describe("match_tracking_service.ts", () => {
+  test("watcher単位処理で例外が発生したとき、後続のwatcher処理を継続する", async () => {
+    const accountCalls: string[] = [];
+    const errors: unknown[] = [];
+    const service = createMatchTrackingService({
+      apiClient: {
+        getEnabledMatchWatchers: () =>
+          Promise.resolve({
+            success: true as const,
+            watchers: [
+              watcher({ targetDiscordId: "target-1" }),
+              watcher({ targetDiscordId: "target-2" }),
+            ],
+          }),
+        getRiotAccount: (targetDiscordId) => {
+          accountCalls.push(targetDiscordId);
+          if (targetDiscordId === "target-1") {
+            throw new Error("temporary failure");
+          }
+          return Promise.resolve({
+            success: true as const,
+            account: {
+              discordId: targetDiscordId,
+              puuid: `puuid-${targetDiscordId}`,
+              gameName: "Teemo",
+              tagLine: "JP1",
+              platform: "jp1",
+              region: "asia",
+              createdAt: new Date("2026-01-01T00:00:00Z"),
+              updatedAt: null,
+            },
+          });
+        },
+        getActiveGameByPuuid: () => Promise.resolve(null),
+        getMatchById: () => Promise.resolve(null),
+        getLeagueEntriesByPuuid: () => Promise.resolve([]),
+        upsertPendingRankSnapshots: () =>
+          Promise.resolve({ success: true as const }),
+        finalizeRankSnapshots: () =>
+          Promise.resolve({
+            success: true as const,
+            snapshots: { before: [], after: [] },
+          }),
+        resolveOpggMatchDetail: () =>
+          Promise.resolve({ success: true as const, detail: null }),
+        updateMatchWatcherState: () =>
+          Promise.resolve({ success: true as const }),
+      },
+      notifier: {
+        sendOrEditWatcherMessage: () => Promise.resolve(null),
+      },
+      renderer: {
+        activeGame: () => {
+          throw new Error("renderer should not be called");
+        },
+        resultPending: () => {
+          throw new Error("renderer should not be called");
+        },
+        resultFetchTimeout: () => {
+          throw new Error("renderer should not be called");
+        },
+        matchResult: () => {
+          throw new Error("renderer should not be called");
+        },
+      },
+      clock: {
+        now: () => new Date("2026-01-01T00:00:00Z"),
+      },
+      logger: {
+        warn: () => {},
+        error: (_message, _metadata, error) => errors.push(error),
+      },
+      config: {
+        pollIntervalMs: 60_000,
+        inGameNotifyIntervalMs: 300_000,
+        resultFetchTimeoutMs: 10_000,
+        riotLongWindowLimit: 100,
+        riotLongWindowMs: 120_000,
+      },
+    });
+
+    await service.processMatchWatchers();
+
+    assertEquals(accountCalls, ["target-1", "target-2"]);
+    assertEquals(errors.length, 1);
+  });
+});

--- a/bot/src/features/match_tracking_service.ts
+++ b/bot/src/features/match_tracking_service.ts
@@ -1,0 +1,1085 @@
+import type { MatchWatcher, RiotAccount } from "@adteemo/api/contract";
+import type { ApiClient } from "../api_client.ts";
+import {
+  activeGameCacheKey,
+  type ActiveNotificationGroup,
+  activeNotificationGroupKey,
+  currentStateFromWatcher,
+  hasResultFetchTimedOut as hasResultFetchTimedOutWithConfig,
+  isAfterDate,
+  isResultFetchTimedOut as isResultFetchTimedOutWithConfig,
+  matchCacheKey,
+  matchIdForGame,
+  matchIdParts,
+  newerDate,
+  type PendingResult,
+  pendingResultFromWatcher,
+  rankedQueueTypeByQueueId,
+  rankSnapshotPayloadsFromEntries,
+  type RankSummary,
+  selectResultNotificationMessageId,
+  shouldNotifyActiveNotificationGroup
+    as shouldNotifyActiveNotificationGroupWithConfig,
+  shouldNotifyInGame as shouldNotifyInGameWithConfig,
+} from "./match_tracking_state.ts";
+import type { createMatchTrackingRenderer } from "./match_tracking_renderer.ts";
+
+type ActiveGame = NonNullable<
+  Awaited<ReturnType<ApiClient["getActiveGameByPuuid"]>>
+>;
+type ActiveGameResult = Awaited<
+  ReturnType<ApiClient["getActiveGameByPuuid"]>
+>;
+type RiotAccountResult = Awaited<ReturnType<ApiClient["getRiotAccount"]>>;
+type RiotMatch = NonNullable<
+  Awaited<ReturnType<ApiClient["getMatchById"]>>
+>;
+type WatcherState = Parameters<ApiClient["updateMatchWatcherState"]>[2];
+type MatchTrackingRenderer = ReturnType<typeof createMatchTrackingRenderer>;
+type MatchTrackingEmbed = ReturnType<MatchTrackingRenderer["resultPending"]>;
+type MatchTrackingNotifier = {
+  sendOrEditWatcherMessage: (
+    watcher: MatchWatcher,
+    messageId: string | null | undefined,
+    embed: MatchTrackingEmbed,
+  ) => Promise<string | null>;
+};
+type MatchWatcherProcessingContext = {
+  activeNotificationGroups: Map<string, ActiveNotificationGroup>;
+  riotAccountsByTargetDiscordId: Map<string, Promise<RiotAccountResult>>;
+  activeGamesByRiotAccount: Map<string, Promise<ActiveGameResult>>;
+  matchesByRegionAndMatchId: Map<string, Promise<RiotMatch | null>>;
+};
+type ActiveGameTargetDetail = {
+  targetDiscordId: string;
+  championId?: number;
+};
+export type MatchTrackingServiceConfig = {
+  pollIntervalMs: number;
+  inGameNotifyIntervalMs: number;
+  resultFetchTimeoutMs: number;
+  riotLongWindowLimit: number;
+  riotLongWindowMs: number;
+};
+export type MatchTrackingServiceLogger = {
+  warn: (message: string, metadata?: Record<string, unknown>) => void;
+  error: (
+    message: string,
+    metadata?: Record<string, unknown>,
+    error?: unknown,
+  ) => void;
+};
+export type MatchTrackingServiceClock = {
+  now: () => Date;
+};
+export type MatchTrackingServiceApiClient = Pick<
+  ApiClient,
+  | "getEnabledMatchWatchers"
+  | "getRiotAccount"
+  | "getActiveGameByPuuid"
+  | "getMatchById"
+  | "getLeagueEntriesByPuuid"
+  | "upsertPendingRankSnapshots"
+  | "finalizeRankSnapshots"
+  | "resolveOpggMatchDetail"
+  | "updateMatchWatcherState"
+>;
+export type MatchTrackingServiceDependencies = {
+  apiClient: MatchTrackingServiceApiClient;
+  notifier: MatchTrackingNotifier;
+  renderer: MatchTrackingRenderer;
+  clock: MatchTrackingServiceClock;
+  logger: MatchTrackingServiceLogger;
+  config: MatchTrackingServiceConfig;
+};
+
+function createMatchWatcherProcessingContext(): MatchWatcherProcessingContext {
+  return {
+    activeNotificationGroups: new Map(),
+    riotAccountsByTargetDiscordId: new Map(),
+    activeGamesByRiotAccount: new Map(),
+    matchesByRegionAndMatchId: new Map(),
+  };
+}
+
+async function seedMatchWatcherProcessingContext(
+  dependencies: MatchTrackingServiceDependencies,
+  context: MatchWatcherProcessingContext,
+  watchers: MatchWatcher[],
+) {
+  for (const watcher of watchers) {
+    rememberPendingResultNotificationMessage(
+      context.activeNotificationGroups,
+      watcher,
+    );
+
+    if (
+      watcher.lastState !== "IN_GAME" || !watcher.currentGameId
+    ) {
+      continue;
+    }
+
+    const accountResult = await getRiotAccountForWatcher(
+      dependencies,
+      context,
+      watcher.targetDiscordId,
+    );
+    if (!accountResult.success) continue;
+
+    const key = activeNotificationGroupKey(
+      watcher,
+      accountResult.account.platform,
+      watcher.currentGameId,
+    );
+    const existingGroup = context.activeNotificationGroups.get(key);
+    if (existingGroup) {
+      existingGroup.targetDiscordIds.add(watcher.targetDiscordId);
+      rememberActiveNotificationWatcher(existingGroup, watcher);
+      rememberActiveNotificationMessage(existingGroup, watcher);
+      continue;
+    }
+
+    const group: ActiveNotificationGroup = {
+      messageId: watcher.currentNotificationMessageId,
+      targetDiscordIds: new Set([watcher.targetDiscordId]),
+      activeWatchers: new Map([[watcher.targetDiscordId, watcher]]),
+      messageIdTargetDiscordIds: new Map(),
+      resultMessageIdsInUse: new Set(),
+    };
+    rememberActiveNotificationMessage(group, watcher);
+    context.activeNotificationGroups.set(key, group);
+  }
+}
+
+function rememberPendingResultNotificationMessage(
+  activeNotificationGroups: Map<string, ActiveNotificationGroup>,
+  watcher: MatchWatcher,
+) {
+  const pending = pendingResultFromWatcher(watcher);
+  if (!pending?.messageId) return;
+
+  const parts = matchIdParts(pending.matchId);
+  if (!parts) return;
+
+  const key = activeNotificationGroupKey(watcher, parts.platform, parts.gameId);
+  const existingGroup = activeNotificationGroups.get(key);
+  if (existingGroup) {
+    existingGroup.resultMessageIdsInUse.add(pending.messageId);
+    return;
+  }
+
+  activeNotificationGroups.set(key, {
+    messageId: null,
+    targetDiscordIds: new Set(),
+    activeWatchers: new Map(),
+    messageIdTargetDiscordIds: new Map(),
+    resultMessageIdsInUse: new Set([pending.messageId]),
+  });
+}
+
+function rememberActiveNotificationWatcher(
+  group: ActiveNotificationGroup,
+  watcher: MatchWatcher,
+) {
+  const existing = group.activeWatchers.get(watcher.targetDiscordId);
+  if (!existing) {
+    group.activeWatchers.set(watcher.targetDiscordId, watcher);
+    return;
+  }
+
+  const shouldKeepSyncedGroupMessageId = group.messageId !== null &&
+    existing.currentNotificationMessageId === group.messageId &&
+    watcher.currentNotificationMessageId !== group.messageId;
+  const currentNotificationMessageId = shouldKeepSyncedGroupMessageId
+    ? existing.currentNotificationMessageId
+    : watcher.currentNotificationMessageId ??
+      existing.currentNotificationMessageId;
+
+  group.activeWatchers.set(watcher.targetDiscordId, {
+    ...watcher,
+    currentGameId: watcher.currentGameId ?? existing.currentGameId,
+    currentNotificationMessageId,
+    lastInGameNotifiedAt: newerDate(
+      existing.lastInGameNotifiedAt,
+      watcher.lastInGameNotifiedAt,
+    ),
+  });
+}
+
+function rememberActiveNotificationMessage(
+  group: ActiveNotificationGroup,
+  watcher: MatchWatcher,
+  messageId = watcher.currentNotificationMessageId,
+) {
+  if (!messageId) return;
+  group.messageId ??= messageId;
+  const targetDiscordIds = group.messageIdTargetDiscordIds.get(messageId) ??
+    new Set<string>();
+  targetDiscordIds.add(watcher.targetDiscordId);
+  group.messageIdTargetDiscordIds.set(messageId, targetDiscordIds);
+}
+
+function resultNotificationMessageId(
+  group: ActiveNotificationGroup | undefined,
+  watcher: MatchWatcher,
+) {
+  if (!group) return watcher.currentNotificationMessageId ?? null;
+
+  const activeWatcher = group.activeWatchers.get(watcher.targetDiscordId);
+  const messageId = selectResultNotificationMessageId({
+    groupMessageId: group.messageId,
+    watcherMessageId: watcher.currentNotificationMessageId,
+    activeWatcherMessageId: activeWatcher?.currentNotificationMessageId,
+    usedMessageIds: group.resultMessageIdsInUse,
+  });
+  if (!messageId) return null;
+  group.resultMessageIdsInUse.add(messageId);
+  return messageId;
+}
+
+function getActiveNotificationGroup(
+  context: MatchWatcherProcessingContext,
+  watcher: MatchWatcher,
+  account: RiotAccount,
+  gameId: string | number,
+) {
+  const key = activeNotificationGroupKey(watcher, account.platform, gameId);
+  const existing = context.activeNotificationGroups.get(key);
+  if (existing) {
+    existing.targetDiscordIds.add(watcher.targetDiscordId);
+    if (
+      !existing.messageId && watcher.currentGameId === String(gameId) &&
+      watcher.currentNotificationMessageId
+    ) {
+      existing.messageId = watcher.currentNotificationMessageId;
+    }
+    if (watcher.currentGameId === String(gameId)) {
+      rememberActiveNotificationWatcher(existing, watcher);
+      rememberActiveNotificationMessage(existing, watcher);
+    }
+    return existing;
+  }
+
+  const group: ActiveNotificationGroup = {
+    messageId: watcher.currentGameId === String(gameId)
+      ? watcher.currentNotificationMessageId
+      : null,
+    targetDiscordIds: new Set([watcher.targetDiscordId]),
+    activeWatchers: new Map(),
+    messageIdTargetDiscordIds: new Map(),
+    resultMessageIdsInUse: new Set(),
+  };
+  if (watcher.currentGameId === String(gameId)) {
+    rememberActiveNotificationWatcher(group, watcher);
+    rememberActiveNotificationMessage(group, watcher);
+  }
+  context.activeNotificationGroups.set(key, group);
+  return group;
+}
+
+async function updateActiveNotificationGroupMessage(
+  dependencies: MatchTrackingServiceDependencies,
+  group: ActiveNotificationGroup,
+  currentWatcher: MatchWatcher,
+  gameId: string,
+  messageId: string | null,
+  notifiedAt?: Date,
+) {
+  group.messageId = messageId;
+  rememberActiveNotificationWatcher(group, {
+    ...currentWatcher,
+    lastState: "IN_GAME",
+    currentGameId: gameId,
+    currentNotificationMessageId: messageId,
+    lastInGameNotifiedAt: notifiedAt &&
+        isAfterDate(notifiedAt, currentWatcher.lastInGameNotifiedAt)
+      ? notifiedAt
+      : currentWatcher.lastInGameNotifiedAt,
+  });
+  rememberActiveNotificationMessage(group, currentWatcher, messageId);
+  if (!messageId) {
+    return;
+  }
+
+  for (const watcher of group.activeWatchers.values()) {
+    if (watcher.targetDiscordId === currentWatcher.targetDiscordId) continue;
+    await syncActiveNotificationWatcherState(
+      dependencies,
+      group,
+      watcher,
+      gameId,
+      messageId,
+      notifiedAt,
+    );
+  }
+}
+
+async function syncActiveNotificationWatcherState(
+  dependencies: MatchTrackingServiceDependencies,
+  group: ActiveNotificationGroup,
+  watcher: MatchWatcher,
+  gameId: string,
+  messageId: string | null,
+  notifiedAt?: Date,
+) {
+  if (!messageId) return false;
+
+  const shouldSyncMessageId = watcher.currentNotificationMessageId !==
+    messageId;
+  const shouldSyncNotifiedAt = notifiedAt &&
+    isAfterDate(notifiedAt, watcher.lastInGameNotifiedAt);
+  if (!shouldSyncMessageId && !shouldSyncNotifiedAt) return false;
+
+  await setWatcherState(dependencies, watcher, {
+    lastState: "IN_GAME",
+    currentGameId: gameId,
+    currentNotificationMessageId: messageId,
+    lastCheckedAt: dependencies.clock.now(),
+    ...(shouldSyncNotifiedAt ? { lastInGameNotifiedAt: notifiedAt } : {}),
+  });
+  rememberActiveNotificationWatcher(group, {
+    ...watcher,
+    lastState: "IN_GAME",
+    currentGameId: gameId,
+    currentNotificationMessageId: messageId,
+    lastInGameNotifiedAt: shouldSyncNotifiedAt
+      ? notifiedAt
+      : watcher.lastInGameNotifiedAt,
+  });
+  rememberActiveNotificationMessage(group, watcher, messageId);
+  return true;
+}
+
+function getRiotAccountForWatcher(
+  dependencies: MatchTrackingServiceDependencies,
+  context: MatchWatcherProcessingContext,
+  targetDiscordId: string,
+) {
+  const cached = context.riotAccountsByTargetDiscordId.get(targetDiscordId);
+  if (cached) return cached;
+
+  const result = dependencies.apiClient.getRiotAccount(targetDiscordId);
+  context.riotAccountsByTargetDiscordId.set(targetDiscordId, result);
+  return result;
+}
+
+function getActiveGameForAccount(
+  dependencies: MatchTrackingServiceDependencies,
+  context: MatchWatcherProcessingContext,
+  account: RiotAccount,
+) {
+  const cacheKey = activeGameCacheKey(account);
+  const cached = context.activeGamesByRiotAccount.get(cacheKey);
+  if (cached) return cached;
+
+  const result = dependencies.apiClient.getActiveGameByPuuid(
+    account.platform,
+    account.puuid,
+  );
+  context.activeGamesByRiotAccount.set(cacheKey, result);
+  return result;
+}
+
+function getMatchForPendingResult(
+  dependencies: MatchTrackingServiceDependencies,
+  context: MatchWatcherProcessingContext,
+  account: RiotAccount,
+  matchId: string,
+) {
+  const cacheKey = matchCacheKey(account, matchId);
+  const cached = context.matchesByRegionAndMatchId.get(cacheKey);
+  if (cached) return cached;
+
+  const result = dependencies.apiClient.getMatchById(account.region, matchId);
+  context.matchesByRegionAndMatchId.set(cacheKey, result);
+  return result;
+}
+
+async function capturePendingRankSnapshots(
+  dependencies: MatchTrackingServiceDependencies,
+  watcher: MatchWatcher,
+  account: RiotAccount,
+  activeGame: ActiveGame,
+) {
+  if (!rankedQueueTypeByQueueId(activeGame.gameQueueConfigId)) return;
+
+  try {
+    const entries = await dependencies.apiClient.getLeagueEntriesByPuuid(
+      account.platform,
+      account.puuid,
+    );
+    const result = await dependencies.apiClient.upsertPendingRankSnapshots({
+      platform: account.platform,
+      gameId: String(activeGame.gameId),
+      puuid: account.puuid,
+      snapshots: rankSnapshotPayloadsFromEntries(
+        entries,
+        dependencies.clock.now(),
+      ),
+    });
+    if (!result.success) {
+      dependencies.logger.warn(
+        "match_tracking.rank_snapshot_pending_save_failed",
+        {
+          guildId: watcher.guildId,
+          targetDiscordId: watcher.targetDiscordId,
+          error: result.error,
+        },
+      );
+    }
+  } catch (error) {
+    dependencies.logger.warn(
+      "match_tracking.rank_snapshot_before_fetch_failed",
+      {
+        guildId: watcher.guildId,
+        targetDiscordId: watcher.targetDiscordId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
+async function finalizeRankSnapshotsForResult(
+  dependencies: MatchTrackingServiceDependencies,
+  watcher: MatchWatcher,
+  account: RiotAccount,
+  match: RiotMatch,
+): Promise<RankSummary | null> {
+  const queueType = rankedQueueTypeByQueueId(match.info.queueId);
+  if (!queueType) return null;
+
+  try {
+    const entries = await dependencies.apiClient.getLeagueEntriesByPuuid(
+      account.platform,
+      account.puuid,
+    );
+    const result = await dependencies.apiClient.finalizeRankSnapshots(
+      match.metadata.matchId,
+      {
+        platform: account.platform,
+        gameId: String(match.info.gameId),
+        puuid: account.puuid,
+        snapshots: rankSnapshotPayloadsFromEntries(
+          entries,
+          dependencies.clock.now(),
+        ),
+      },
+    );
+    if (!result.success) {
+      dependencies.logger.warn("match_tracking.rank_snapshot_finalize_failed", {
+        guildId: watcher.guildId,
+        targetDiscordId: watcher.targetDiscordId,
+        matchId: match.metadata.matchId,
+        error: result.error,
+      });
+      return null;
+    }
+
+    return {
+      queueType,
+      before: result.snapshots.before.find((snapshot) =>
+        snapshot.queueType === queueType
+      ) ?? null,
+      after: result.snapshots.after.find((snapshot) =>
+        snapshot.queueType === queueType
+      ) ?? null,
+    };
+  } catch (error) {
+    dependencies.logger.warn(
+      "match_tracking.rank_snapshot_after_fetch_failed",
+      {
+        guildId: watcher.guildId,
+        targetDiscordId: watcher.targetDiscordId,
+        matchId: match.metadata.matchId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return null;
+  }
+}
+
+function shouldNotifyInGame(
+  watcher: MatchWatcher,
+  intervalMs: number,
+  now: Date,
+) {
+  return shouldNotifyInGameWithConfig(watcher, intervalMs, now);
+}
+
+function shouldNotifyActiveNotificationGroup(
+  dependencies: MatchTrackingServiceDependencies,
+  group: ActiveNotificationGroup,
+  watcher: MatchWatcher,
+) {
+  return shouldNotifyActiveNotificationGroupWithConfig(
+    group,
+    watcher,
+    dependencies.config.inGameNotifyIntervalMs,
+    dependencies.clock.now(),
+  );
+}
+
+function hasResultFetchTimedOut(
+  watcher: MatchWatcher,
+  timeoutMs: number,
+  now: Date,
+) {
+  return hasResultFetchTimedOutWithConfig(watcher, timeoutMs, now);
+}
+
+function isResultFetchTimedOut(
+  dependencies: MatchTrackingServiceDependencies,
+  startedAt: Date,
+) {
+  return isResultFetchTimedOutWithConfig(
+    startedAt,
+    dependencies.config.resultFetchTimeoutMs,
+    dependencies.clock.now(),
+  );
+}
+
+async function activeGameTargetDetails(
+  dependencies: MatchTrackingServiceDependencies,
+  context: MatchWatcherProcessingContext,
+  currentWatcher: MatchWatcher,
+  currentAccount: RiotAccount,
+  activeGame: ActiveGame,
+  targetDiscordIds: Iterable<string>,
+): Promise<ActiveGameTargetDetail[]> {
+  const details: ActiveGameTargetDetail[] = [];
+  for (const targetDiscordId of targetDiscordIds) {
+    const accountResult = targetDiscordId === currentWatcher.targetDiscordId
+      ? { success: true as const, account: currentAccount }
+      : await getRiotAccountForWatcher(
+        dependencies,
+        context,
+        targetDiscordId,
+      );
+    if (!accountResult.success) {
+      details.push({
+        targetDiscordId,
+      });
+      continue;
+    }
+
+    const participant = activeGame.participants.find((p) =>
+      p.puuid === accountResult.account.puuid
+    );
+    details.push({
+      targetDiscordId,
+      championId: participant?.championId,
+    });
+  }
+  return details;
+}
+
+async function resolveOpggMatchDetailForResult(
+  dependencies: MatchTrackingServiceDependencies,
+  watcher: MatchWatcher,
+  account: RiotAccount,
+  match: RiotMatch,
+) {
+  const participant = match.info.participants.find((candidate) =>
+    candidate.puuid === account.puuid
+  );
+  if (!participant) return null;
+
+  const result = await dependencies.apiClient.resolveOpggMatchDetail(
+    match.metadata.matchId,
+    {
+      targetDiscordId: watcher.targetDiscordId,
+      match: {
+        gameCreation: match.info.gameCreation,
+        gameDuration: match.info.gameDuration,
+        queueId: match.info.queueId,
+        participant: {
+          puuid: participant.puuid,
+          championId: participant.championId,
+          championName: participant.championName,
+        },
+      },
+    },
+  );
+  if (!result.success) {
+    dependencies.logger.warn("match_tracking.opgg_detail_resolve_failed", {
+      guildId: watcher.guildId,
+      targetDiscordId: watcher.targetDiscordId,
+      matchId: match.metadata.matchId,
+      error: result.error,
+    });
+    return null;
+  }
+  return result.detail;
+}
+
+async function setWatcherState(
+  dependencies: MatchTrackingServiceDependencies,
+  watcher: MatchWatcher,
+  state: WatcherState,
+) {
+  const result = await dependencies.apiClient.updateMatchWatcherState(
+    watcher.guildId,
+    watcher.targetDiscordId,
+    state,
+  );
+  if (!result.success) {
+    dependencies.logger.error("match_tracking.state_update_failed", {
+      guildId: watcher.guildId,
+      targetDiscordId: watcher.targetDiscordId,
+      error: result.error,
+    });
+  }
+}
+
+async function tryFetchAndNotifyResult(
+  dependencies: MatchTrackingServiceDependencies,
+  watcher: MatchWatcher,
+  account: RiotAccount,
+  context: MatchWatcherProcessingContext,
+  pending: PendingResult,
+  currentState: WatcherState = currentStateFromWatcher(watcher),
+) {
+  if (
+    pending.startedAt && isResultFetchTimedOut(dependencies, pending.startedAt)
+  ) {
+    dependencies.logger.warn("match_tracking.fetch_result_timeout", {
+      guildId: watcher.guildId,
+      targetDiscordId: watcher.targetDiscordId,
+      matchId: pending.matchId,
+    });
+    const messageId = await dependencies.notifier.sendOrEditWatcherMessage(
+      watcher,
+      pending.messageId,
+      dependencies.renderer.resultFetchTimeout(watcher, pending.matchId),
+    );
+    await setWatcherState(dependencies, watcher, {
+      ...currentState,
+      pendingResultMatchId: null,
+      pendingResultNotificationMessageId: null,
+      pendingResultStartedAt: null,
+      currentMatchId: null,
+      lastCheckedAt: dependencies.clock.now(),
+    });
+    return { status: "cleared" as const, messageId };
+  }
+
+  const match = await getMatchForPendingResult(
+    dependencies,
+    context,
+    account,
+    pending.matchId,
+  );
+  if (!match) {
+    await setWatcherState(dependencies, watcher, {
+      ...currentState,
+      pendingResultMatchId: pending.matchId,
+      pendingResultNotificationMessageId: pending.messageId,
+      pendingResultStartedAt: pending.startedAt,
+      currentMatchId: null,
+      lastCheckedAt: dependencies.clock.now(),
+    });
+    return { status: "pending" as const, messageId: pending.messageId };
+  }
+
+  const rankSummary = await finalizeRankSnapshotsForResult(
+    dependencies,
+    watcher,
+    account,
+    match,
+  );
+  const opggDetail = await resolveOpggMatchDetailForResult(
+    dependencies,
+    watcher,
+    account,
+    match,
+  );
+  const messageId = await dependencies.notifier.sendOrEditWatcherMessage(
+    watcher,
+    pending.messageId,
+    await dependencies.renderer.matchResult(
+      watcher,
+      account,
+      match,
+      rankSummary,
+      opggDetail,
+    ),
+  );
+  await setWatcherState(dependencies, watcher, {
+    ...currentState,
+    currentMatchId: null,
+    pendingResultMatchId: null,
+    pendingResultNotificationMessageId: null,
+    pendingResultStartedAt: null,
+    lastCheckedAt: dependencies.clock.now(),
+  });
+  return { status: "cleared" as const, messageId };
+}
+
+async function processWatcher(
+  dependencies: MatchTrackingServiceDependencies,
+  watcher: MatchWatcher,
+  context: MatchWatcherProcessingContext,
+) {
+  const accountResult = await getRiotAccountForWatcher(
+    dependencies,
+    context,
+    watcher.targetDiscordId,
+  );
+  if (!accountResult.success) {
+    dependencies.logger.warn("match_tracking.riot_account_not_found", {
+      guildId: watcher.guildId,
+      targetDiscordId: watcher.targetDiscordId,
+      error: accountResult.error,
+    });
+    return;
+  }
+  const account = accountResult.account;
+
+  const pending = pendingResultFromWatcher(watcher);
+  let pendingStatus: "none" | "pending" | "cleared" = "none";
+  if (pending) {
+    const result = await tryFetchAndNotifyResult(
+      dependencies,
+      watcher,
+      account,
+      context,
+      pending,
+    );
+    pendingStatus = result.status;
+    if (watcher.lastState === "FETCHING_RESULT" && watcher.currentMatchId) {
+      return;
+    }
+  }
+
+  const activeGame = await getActiveGameForAccount(
+    dependencies,
+    context,
+    account,
+  );
+  if (!activeGame) {
+    if (watcher.lastState === "IN_GAME" && watcher.currentGameId) {
+      const activeNotificationGroup = getActiveNotificationGroup(
+        context,
+        watcher,
+        account,
+        watcher.currentGameId,
+      );
+      const matchId = matchIdForGame(account, watcher.currentGameId);
+      const messageId = await dependencies.notifier.sendOrEditWatcherMessage(
+        watcher,
+        resultNotificationMessageId(activeNotificationGroup, watcher),
+        dependencies.renderer.resultPending(watcher, matchId),
+      );
+      await tryFetchAndNotifyResult(
+        dependencies,
+        watcher,
+        account,
+        context,
+        {
+          matchId,
+          messageId,
+          startedAt: watcher.gameStartedAt,
+        },
+        {
+          lastState: "IDLE",
+          currentGameId: null,
+          currentMatchId: null,
+          currentNotificationMessageId: null,
+          gameStartedAt: null,
+          lastInGameNotifiedAt: null,
+        },
+      );
+      return;
+    }
+
+    if (watcher.lastState === "IDLE" && watcher.currentGameId === null) {
+      return;
+    }
+
+    await setWatcherState(dependencies, watcher, {
+      lastState: "IDLE",
+      currentGameId: null,
+      currentNotificationMessageId: null,
+      lastCheckedAt: dependencies.clock.now(),
+    });
+    return;
+  }
+
+  const currentGameId = String(activeGame.gameId);
+  const activeNotificationGroup = getActiveNotificationGroup(
+    context,
+    watcher,
+    account,
+    currentGameId,
+  );
+  if (
+    watcher.lastState === "IN_GAME" &&
+    watcher.currentGameId &&
+    watcher.currentGameId !== currentGameId
+  ) {
+    if (pendingStatus === "pending") {
+      dependencies.logger.warn("match_tracking.pending_result_replaced", {
+        guildId: watcher.guildId,
+        targetDiscordId: watcher.targetDiscordId,
+        pendingMatchId: pending?.matchId,
+      });
+    }
+    const previousMatchId = matchIdForGame(account, watcher.currentGameId);
+    const previousActiveNotificationGroup = getActiveNotificationGroup(
+      context,
+      watcher,
+      account,
+      watcher.currentGameId,
+    );
+    const notifiedAt = dependencies.clock.now();
+    const previousMessageId = await dependencies.notifier
+      .sendOrEditWatcherMessage(
+        watcher,
+        resultNotificationMessageId(previousActiveNotificationGroup, watcher),
+        dependencies.renderer.resultPending(watcher, previousMatchId),
+      );
+    await capturePendingRankSnapshots(
+      dependencies,
+      watcher,
+      account,
+      activeGame,
+    );
+    const newMessageId = await dependencies.notifier.sendOrEditWatcherMessage(
+      watcher,
+      activeNotificationGroup.messageId,
+      await dependencies.renderer.activeGame(
+        watcher,
+        account,
+        activeGame,
+        "started",
+        await activeGameTargetDetails(
+          dependencies,
+          context,
+          watcher,
+          account,
+          activeGame,
+          activeNotificationGroup.targetDiscordIds,
+        ),
+      ),
+    );
+    await updateActiveNotificationGroupMessage(
+      dependencies,
+      activeNotificationGroup,
+      watcher,
+      currentGameId,
+      newMessageId,
+      notifiedAt,
+    );
+    const currentState = {
+      lastState: "IN_GAME" as const,
+      currentGameId,
+      currentMatchId: null,
+      currentNotificationMessageId: newMessageId,
+      gameStartedAt: new Date(activeGame.gameStartTime),
+      lastInGameNotifiedAt: notifiedAt,
+    };
+    await setWatcherState(dependencies, watcher, {
+      ...currentState,
+      pendingResultMatchId: previousMatchId,
+      pendingResultNotificationMessageId: previousMessageId,
+      pendingResultStartedAt: watcher.gameStartedAt,
+      lastCheckedAt: dependencies.clock.now(),
+    });
+    await tryFetchAndNotifyResult(
+      dependencies,
+      watcher,
+      account,
+      context,
+      {
+        matchId: previousMatchId,
+        messageId: previousMessageId,
+        startedAt: watcher.gameStartedAt,
+      },
+      currentState,
+    );
+    return;
+  }
+
+  const started = watcher.lastState !== "IN_GAME" ||
+    watcher.currentGameId !== currentGameId;
+  if (started) {
+    const notifiedAt = dependencies.clock.now();
+    await capturePendingRankSnapshots(
+      dependencies,
+      watcher,
+      account,
+      activeGame,
+    );
+    const messageId = await dependencies.notifier.sendOrEditWatcherMessage(
+      watcher,
+      activeNotificationGroup.messageId,
+      await dependencies.renderer.activeGame(
+        watcher,
+        account,
+        activeGame,
+        "started",
+        await activeGameTargetDetails(
+          dependencies,
+          context,
+          watcher,
+          account,
+          activeGame,
+          activeNotificationGroup.targetDiscordIds,
+        ),
+      ),
+    );
+    await updateActiveNotificationGroupMessage(
+      dependencies,
+      activeNotificationGroup,
+      watcher,
+      currentGameId,
+      messageId,
+      notifiedAt,
+    );
+    await setWatcherState(dependencies, watcher, {
+      lastState: "IN_GAME",
+      currentGameId,
+      currentMatchId: null,
+      currentNotificationMessageId: messageId,
+      gameStartedAt: new Date(activeGame.gameStartTime),
+      lastCheckedAt: dependencies.clock.now(),
+      lastInGameNotifiedAt: notifiedAt,
+    });
+    return;
+  }
+
+  if (
+    shouldNotifyActiveNotificationGroup(
+      dependencies,
+      activeNotificationGroup,
+      watcher,
+    )
+  ) {
+    const notifiedAt = dependencies.clock.now();
+    const messageId = await dependencies.notifier.sendOrEditWatcherMessage(
+      watcher,
+      activeNotificationGroup.messageId ?? watcher.currentNotificationMessageId,
+      await dependencies.renderer.activeGame(
+        watcher,
+        account,
+        activeGame,
+        "progress",
+        await activeGameTargetDetails(
+          dependencies,
+          context,
+          watcher,
+          account,
+          activeGame,
+          activeNotificationGroup.targetDiscordIds,
+        ),
+      ),
+    );
+    await updateActiveNotificationGroupMessage(
+      dependencies,
+      activeNotificationGroup,
+      watcher,
+      currentGameId,
+      messageId,
+      notifiedAt,
+    );
+    await setWatcherState(dependencies, watcher, {
+      lastState: "IN_GAME",
+      currentGameId,
+      currentNotificationMessageId: messageId,
+      lastCheckedAt: dependencies.clock.now(),
+      lastInGameNotifiedAt: notifiedAt,
+    });
+    return;
+  }
+
+  const didSyncSharedMessageId = await syncActiveNotificationWatcherState(
+    dependencies,
+    activeNotificationGroup,
+    watcher,
+    currentGameId,
+    activeNotificationGroup.messageId,
+  );
+  if (didSyncSharedMessageId) {
+    return;
+  }
+
+  await setWatcherState(dependencies, watcher, {
+    lastState: "IN_GAME",
+    currentGameId,
+    lastCheckedAt: dependencies.clock.now(),
+  });
+}
+
+export function createMatchTrackingService(
+  dependencies: MatchTrackingServiceDependencies,
+) {
+  let lastBudgetWarningAt = 0;
+
+  function warnIfRiotRequestBudgetRisk(watcherCount: number) {
+    const estimatedRequests = watcherCount *
+      Math.ceil(
+        dependencies.config.riotLongWindowMs /
+          dependencies.config.pollIntervalMs,
+      );
+    const now = dependencies.clock.now().getTime();
+    if (
+      estimatedRequests >= dependencies.config.riotLongWindowLimit * 0.8 &&
+      now - lastBudgetWarningAt >= dependencies.config.riotLongWindowMs
+    ) {
+      lastBudgetWarningAt = now;
+      dependencies.logger.warn("match_tracking.riot_request_budget_risk", {
+        watcherCount,
+        pollIntervalMs: dependencies.config.pollIntervalMs,
+        rateLimitWindowMs: dependencies.config.riotLongWindowMs,
+        estimatedRequestsPerWindow: estimatedRequests,
+        limitPerWindow: dependencies.config.riotLongWindowLimit,
+      });
+    }
+  }
+
+  async function processMatchWatchers() {
+    const result = await dependencies.apiClient.getEnabledMatchWatchers();
+    if (!result.success) {
+      dependencies.logger.error("match_tracking.watchers_fetch_failed", {
+        error: result.error,
+      });
+      return;
+    }
+
+    warnIfRiotRequestBudgetRisk(result.watchers.length);
+
+    const context = createMatchWatcherProcessingContext();
+    await seedMatchWatcherProcessingContext(
+      dependencies,
+      context,
+      result.watchers,
+    );
+    for (const watcher of result.watchers) {
+      try {
+        await processWatcher(dependencies, watcher, context);
+      } catch (error) {
+        dependencies.logger.error("match_tracking.watcher_failed", {
+          guildId: watcher.guildId,
+          targetDiscordId: watcher.targetDiscordId,
+        }, error);
+      }
+    }
+  }
+
+  return {
+    processMatchWatchers,
+    hasResultFetchTimedOut: (watcher: MatchWatcher) =>
+      hasResultFetchTimedOut(
+        watcher,
+        dependencies.config.resultFetchTimeoutMs,
+        dependencies.clock.now(),
+      ),
+    shouldNotifyInGame: (watcher: MatchWatcher) =>
+      shouldNotifyInGame(
+        watcher,
+        dependencies.config.inGameNotifyIntervalMs,
+        dependencies.clock.now(),
+      ),
+    warnIfRiotRequestBudgetRisk,
+  };
+}


### PR DESCRIPTION
## 概要

- `createMatchTrackingService(deps)` を導入し、watcher単位処理、tick内キャッシュ、rank/result補完をserviceへ集約
- `match_tracking.ts` を環境変数読み取り、Discord notifier/renderer assembly、worker管理だけのFacadeへ整理
- service単体テストを追加し、watcher単位処理で例外が発生しても後続watcher処理を継続することを固定

## 影響

- HTTP API契約の変更なし
- 既存の1 tick内 account / active game / match 取得共有と、guild/channel/platform/game単位の通知統合を維持
- serviceはmodule-level `apiClient`、Discord `Client`、環境変数を直接参照しない構成

## 検証

- `env BOT_MESSAGE_LANG=ja_JP deno test -A bot/src/features/match_tracking_service.test.ts bot/src/features/match_tracking.test.ts`
- `deno test -A bot/src/component_boundary.test.ts bot/check-runtime-boundary.test.ts`
- `deno task quality`

Closes #82