### PR TITLE
[codex] match tracking workerをinstance化する

### DIFF
--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -16,6 +16,7 @@ import {
   createMatchTrackingService,
   type MatchTrackingServiceConfig,
 } from "./match_tracking_service.ts";
+import { createRiotRequestBudgetMonitor } from "./match_tracking_budget.ts";
 
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 const DEFAULT_IN_GAME_NOTIFY_INTERVAL_MS = 300_000;
@@ -109,71 +110,108 @@ async function processMatchWatchers(client: Client) {
   await createDefaultMatchTrackingService(client).processMatchWatchers();
 }
 
-let workerId: number | undefined;
-let processingMatchWatchers = false;
-let lastBudgetWarningAt = 0;
-let workerService:
-  | ReturnType<typeof createMatchTrackingService>
+export type MatchTrackingWorkerService = {
+  processMatchWatchers: () => Promise<void>;
+};
+
+export type MatchTrackingWorkerScheduler = {
+  setInterval: (callback: () => void, intervalMs: number) => number;
+  clearInterval: (intervalId: number) => void;
+};
+
+export type MatchTrackingWorkerDependencies = {
+  createService: () => MatchTrackingWorkerService;
+  scheduler: MatchTrackingWorkerScheduler;
+  config: {
+    pollIntervalMs: number;
+  };
+  logger: {
+    warn: (message: string, metadata: Record<string, unknown>) => void;
+  };
+};
+
+export function createMatchTrackingWorker(
+  dependencies: MatchTrackingWorkerDependencies,
+) {
+  let workerId: number | undefined;
+  let processingMatchWatchers = false;
+
+  async function guardedProcessMatchWatchers(
+    service: MatchTrackingWorkerService,
+  ) {
+    if (processingMatchWatchers) {
+      dependencies.logger.warn("match_tracking.worker_tick_skipped", {
+        reason: "previous_tick_still_running",
+      });
+      return;
+    }
+    processingMatchWatchers = true;
+    try {
+      await service.processMatchWatchers();
+    } finally {
+      processingMatchWatchers = false;
+    }
+  }
+
+  function start() {
+    if (workerId !== undefined) return;
+
+    const service = dependencies.createService();
+    workerId = dependencies.scheduler.setInterval(() => {
+      void guardedProcessMatchWatchers(service);
+    }, dependencies.config.pollIntervalMs);
+    void guardedProcessMatchWatchers(service);
+  }
+
+  function stop() {
+    if (workerId === undefined) return;
+    dependencies.scheduler.clearInterval(workerId);
+    workerId = undefined;
+  }
+
+  return {
+    start,
+    stop,
+  };
+}
+
+function createDefaultMatchTrackingWorker(client: Client) {
+  return createMatchTrackingWorker({
+    createService: () => createDefaultMatchTrackingService(client),
+    scheduler: {
+      setInterval: (callback, intervalMs) => setInterval(callback, intervalMs),
+      clearInterval: (intervalId) => clearInterval(intervalId),
+    },
+    config: {
+      pollIntervalMs: numberEnv(
+        "MATCH_WATCH_POLL_INTERVAL_MS",
+        DEFAULT_POLL_INTERVAL_MS,
+      ),
+    },
+    logger: botLogger,
+  });
+}
+
+let defaultWorker:
+  | ReturnType<typeof createDefaultMatchTrackingWorker>
   | undefined;
 
-function warnIfRiotRequestBudgetRisk(watcherCount: number) {
-  const config = matchTrackingServiceConfig();
-  const estimatedRequests = watcherCount *
-    Math.ceil(config.riotLongWindowMs / config.pollIntervalMs);
-  const now = Date.now();
-  if (
-    estimatedRequests >= config.riotLongWindowLimit * 0.8 &&
-    now - lastBudgetWarningAt >= config.riotLongWindowMs
-  ) {
-    lastBudgetWarningAt = now;
-    botLogger.warn("match_tracking.riot_request_budget_risk", {
-      watcherCount,
-      pollIntervalMs: config.pollIntervalMs,
-      rateLimitWindowMs: config.riotLongWindowMs,
-      estimatedRequestsPerWindow: estimatedRequests,
-      limitPerWindow: config.riotLongWindowLimit,
-    });
-  }
-}
-
-async function guardedProcessMatchWatchers(
-  service: ReturnType<typeof createMatchTrackingService>,
-) {
-  if (processingMatchWatchers) {
-    botLogger.warn("match_tracking.worker_tick_skipped", {
-      reason: "previous_tick_still_running",
-    });
-    return;
-  }
-  processingMatchWatchers = true;
-  try {
-    await service.processMatchWatchers();
-  } finally {
-    processingMatchWatchers = false;
-  }
-}
+const defaultBudgetMonitor = createRiotRequestBudgetMonitor({
+  config: matchTrackingServiceConfig,
+  clock: {
+    now: () => new Date(),
+  },
+  logger: botLogger,
+});
 
 function startMatchTrackingWorker(client: Client) {
-  if (workerId !== undefined) return;
-
-  const pollIntervalMs = numberEnv(
-    "MATCH_WATCH_POLL_INTERVAL_MS",
-    DEFAULT_POLL_INTERVAL_MS,
-  );
-  workerService = createDefaultMatchTrackingService(client);
-  workerId = setInterval(() => {
-    if (workerService) {
-      guardedProcessMatchWatchers(workerService);
-    }
-  }, pollIntervalMs);
-  guardedProcessMatchWatchers(workerService);
+  defaultWorker ??= createDefaultMatchTrackingWorker(client);
+  defaultWorker.start();
 }
 
 function stopMatchTrackingWorker() {
-  if (workerId === undefined) return;
-  clearInterval(workerId);
-  workerId = undefined;
-  workerService = undefined;
+  defaultWorker?.stop();
+  defaultWorker = undefined;
 }
 
 function hasResultFetchTimedOut(watcher: MatchWatcher) {
@@ -200,9 +238,11 @@ function shouldNotifyInGame(watcher: MatchWatcher) {
 
 export const matchTracker = {
   processMatchWatchers,
+  createMatchTrackingWorker,
+  createDefaultMatchTrackingWorker,
   startMatchTrackingWorker,
   stopMatchTrackingWorker,
   hasResultFetchTimedOut,
   shouldNotifyInGame,
-  warnIfRiotRequestBudgetRisk,
+  warnIfRiotRequestBudgetRisk: defaultBudgetMonitor.warnIfRiotRequestBudgetRisk,
 };

--- a/bot/src/features/match_tracking.ts
+++ b/bot/src/features/match_tracking.ts
@@ -127,6 +127,11 @@ export type MatchTrackingWorkerDependencies = {
   };
   logger: {
     warn: (message: string, metadata: Record<string, unknown>) => void;
+    error: (
+      message: string,
+      metadata: Record<string, unknown>,
+      error?: unknown,
+    ) => void;
   };
 };
 
@@ -148,6 +153,8 @@ export function createMatchTrackingWorker(
     processingMatchWatchers = true;
     try {
       await service.processMatchWatchers();
+    } catch (error) {
+      dependencies.logger.error("match_tracking.worker_tick_failed", {}, error);
     } finally {
       processingMatchWatchers = false;
     }

--- a/bot/src/features/match_tracking_budget.test.ts
+++ b/bot/src/features/match_tracking_budget.test.ts
@@ -1,0 +1,83 @@
+import { assertEquals } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import { createRiotRequestBudgetMonitor } from "./match_tracking_budget.ts";
+
+describe("match_tracking_budget.ts", () => {
+  test("watcher数の見積もりがlong window上限の8割以上になったとき、固定時刻で警告する", () => {
+    const warnings: Record<string, unknown>[] = [];
+    const monitor = createRiotRequestBudgetMonitor({
+      config: () => ({
+        pollIntervalMs: 60_000,
+        riotLongWindowLimit: 100,
+        riotLongWindowMs: 120_000,
+      }),
+      clock: {
+        now: () => new Date("2026-01-01T00:00:00Z"),
+      },
+      logger: {
+        warn: (_message, metadata) => warnings.push(metadata),
+      },
+    });
+
+    monitor.warnIfRiotRequestBudgetRisk(40);
+
+    assertEquals(warnings, [{
+      watcherCount: 40,
+      pollIntervalMs: 60_000,
+      rateLimitWindowMs: 120_000,
+      estimatedRequestsPerWindow: 80,
+      limitPerWindow: 100,
+    }]);
+  });
+
+  test("long window内で警告済みのとき、同じinstanceでは再警告しない", () => {
+    let now = new Date("2026-01-01T00:00:00Z");
+    const warnings: string[] = [];
+    const monitor = createRiotRequestBudgetMonitor({
+      config: () => ({
+        pollIntervalMs: 60_000,
+        riotLongWindowLimit: 100,
+        riotLongWindowMs: 120_000,
+      }),
+      clock: {
+        now: () => now,
+      },
+      logger: {
+        warn: (message) => warnings.push(message),
+      },
+    });
+
+    monitor.warnIfRiotRequestBudgetRisk(40);
+    now = new Date("2026-01-01T00:01:00Z");
+    monitor.warnIfRiotRequestBudgetRisk(40);
+
+    assertEquals(warnings, ["match_tracking.riot_request_budget_risk"]);
+  });
+
+  test("long window経過後に警告条件が続くとき、同じinstanceで再警告する", () => {
+    let now = new Date("2026-01-01T00:00:00Z");
+    const warnings: string[] = [];
+    const monitor = createRiotRequestBudgetMonitor({
+      config: () => ({
+        pollIntervalMs: 60_000,
+        riotLongWindowLimit: 100,
+        riotLongWindowMs: 120_000,
+      }),
+      clock: {
+        now: () => now,
+      },
+      logger: {
+        warn: (message) => warnings.push(message),
+      },
+    });
+
+    monitor.warnIfRiotRequestBudgetRisk(40);
+    now = new Date("2026-01-01T00:02:00Z");
+    monitor.warnIfRiotRequestBudgetRisk(40);
+
+    assertEquals(warnings, [
+      "match_tracking.riot_request_budget_risk",
+      "match_tracking.riot_request_budget_risk",
+    ]);
+  });
+});

--- a/bot/src/features/match_tracking_budget.ts
+++ b/bot/src/features/match_tracking_budget.ts
@@ -1,0 +1,46 @@
+export type RiotRequestBudgetMonitorConfig = {
+  pollIntervalMs: number;
+  riotLongWindowLimit: number;
+  riotLongWindowMs: number;
+};
+
+export type RiotRequestBudgetMonitorDependencies = {
+  config: () => RiotRequestBudgetMonitorConfig;
+  clock: {
+    now: () => Date;
+  };
+  logger: {
+    warn: (message: string, metadata: Record<string, unknown>) => void;
+  };
+};
+
+export function createRiotRequestBudgetMonitor(
+  dependencies: RiotRequestBudgetMonitorDependencies,
+) {
+  let lastBudgetWarningAt: number | undefined;
+
+  function warnIfRiotRequestBudgetRisk(watcherCount: number) {
+    const config = dependencies.config();
+    const estimatedRequests = watcherCount *
+      Math.ceil(config.riotLongWindowMs / config.pollIntervalMs);
+    const now = dependencies.clock.now().getTime();
+    if (
+      estimatedRequests >= config.riotLongWindowLimit * 0.8 &&
+      (lastBudgetWarningAt === undefined ||
+        now - lastBudgetWarningAt >= config.riotLongWindowMs)
+    ) {
+      lastBudgetWarningAt = now;
+      dependencies.logger.warn("match_tracking.riot_request_budget_risk", {
+        watcherCount,
+        pollIntervalMs: config.pollIntervalMs,
+        rateLimitWindowMs: config.riotLongWindowMs,
+        estimatedRequestsPerWindow: estimatedRequests,
+        limitPerWindow: config.riotLongWindowLimit,
+      });
+    }
+  }
+
+  return {
+    warnIfRiotRequestBudgetRisk,
+  };
+}

--- a/bot/src/features/match_tracking_service.ts
+++ b/bot/src/features/match_tracking_service.ts
@@ -22,6 +22,7 @@ import {
     as shouldNotifyActiveNotificationGroupWithConfig,
   shouldNotifyInGame as shouldNotifyInGameWithConfig,
 } from "./match_tracking_state.ts";
+import { createRiotRequestBudgetMonitor } from "./match_tracking_budget.ts";
 import type { createMatchTrackingRenderer } from "./match_tracking_renderer.ts";
 
 type ActiveGame = NonNullable<
@@ -1013,29 +1014,11 @@ async function processWatcher(
 export function createMatchTrackingService(
   dependencies: MatchTrackingServiceDependencies,
 ) {
-  let lastBudgetWarningAt = 0;
-
-  function warnIfRiotRequestBudgetRisk(watcherCount: number) {
-    const estimatedRequests = watcherCount *
-      Math.ceil(
-        dependencies.config.riotLongWindowMs /
-          dependencies.config.pollIntervalMs,
-      );
-    const now = dependencies.clock.now().getTime();
-    if (
-      estimatedRequests >= dependencies.config.riotLongWindowLimit * 0.8 &&
-      now - lastBudgetWarningAt >= dependencies.config.riotLongWindowMs
-    ) {
-      lastBudgetWarningAt = now;
-      dependencies.logger.warn("match_tracking.riot_request_budget_risk", {
-        watcherCount,
-        pollIntervalMs: dependencies.config.pollIntervalMs,
-        rateLimitWindowMs: dependencies.config.riotLongWindowMs,
-        estimatedRequestsPerWindow: estimatedRequests,
-        limitPerWindow: dependencies.config.riotLongWindowLimit,
-      });
-    }
-  }
+  const budgetMonitor = createRiotRequestBudgetMonitor({
+    config: () => dependencies.config,
+    clock: dependencies.clock,
+    logger: dependencies.logger,
+  });
 
   async function processMatchWatchers() {
     const result = await dependencies.apiClient.getEnabledMatchWatchers();
@@ -1046,7 +1029,7 @@ export function createMatchTrackingService(
       return;
     }
 
-    warnIfRiotRequestBudgetRisk(result.watchers.length);
+    budgetMonitor.warnIfRiotRequestBudgetRisk(result.watchers.length);
 
     const context = createMatchWatcherProcessingContext();
     await seedMatchWatcherProcessingContext(
@@ -1080,6 +1063,6 @@ export function createMatchTrackingService(
         dependencies.config.inGameNotifyIntervalMs,
         dependencies.clock.now(),
       ),
-    warnIfRiotRequestBudgetRisk,
+    warnIfRiotRequestBudgetRisk: budgetMonitor.warnIfRiotRequestBudgetRisk,
   };
 }

--- a/bot/src/features/match_tracking_worker.test.ts
+++ b/bot/src/features/match_tracking_worker.test.ts
@@ -58,6 +58,7 @@ describe("match_tracking worker", () => {
       },
       logger: {
         warn: () => {},
+        error: () => {},
       },
     });
 
@@ -90,6 +91,7 @@ describe("match_tracking worker", () => {
       },
       logger: {
         warn: () => {},
+        error: () => {},
       },
     });
 
@@ -120,6 +122,7 @@ describe("match_tracking worker", () => {
       },
       logger: {
         warn: (message) => warnings.push(message),
+        error: () => {},
       },
     });
 
@@ -134,6 +137,50 @@ describe("match_tracking worker", () => {
     assertEquals(warnings, ["match_tracking.worker_tick_skipped"]);
   });
 
+  test("tick処理が例外で失敗したとき、errorログを出して次tickを継続できる", async () => {
+    const manualScheduler = createManualScheduler();
+    const calls: string[] = [];
+    const errors: {
+      message: string;
+      metadata: Record<string, unknown>;
+      error: unknown;
+    }[] = [];
+    const failure = new Error("temporary failure");
+    const worker = createMatchTrackingWorker({
+      createService: () => ({
+        processMatchWatchers: () => {
+          calls.push("process");
+          if (calls.length === 1) {
+            return Promise.reject(failure);
+          }
+          return Promise.resolve();
+        },
+      }),
+      scheduler: manualScheduler.scheduler,
+      config: {
+        pollIntervalMs: 60_000,
+      },
+      logger: {
+        warn: () => {},
+        error: (message, metadata, error) => {
+          errors.push({ message, metadata, error });
+        },
+      },
+    });
+
+    worker.start();
+    await flushMicrotasks();
+    manualScheduler.tick();
+    await flushMicrotasks();
+
+    assertEquals(calls, ["process", "process"]);
+    assertEquals(errors, [{
+      message: "match_tracking.worker_tick_failed",
+      metadata: {},
+      error: failure,
+    }]);
+  });
+
   test("stopしたとき、登録済みintervalを解除する", () => {
     const manualScheduler = createManualScheduler();
     const worker = createMatchTrackingWorker({
@@ -146,6 +193,7 @@ describe("match_tracking worker", () => {
       },
       logger: {
         warn: () => {},
+        error: () => {},
       },
     });
 

--- a/bot/src/features/match_tracking_worker.test.ts
+++ b/bot/src/features/match_tracking_worker.test.ts
@@ -1,0 +1,157 @@
+import { assertEquals } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import { createMatchTrackingWorker } from "./match_tracking.ts";
+
+function createManualScheduler() {
+  const callbacks = new Map<number, () => void>();
+  const intervals: number[] = [];
+  const cleared: number[] = [];
+  let nextId = 1;
+
+  return {
+    intervals,
+    cleared,
+    scheduler: {
+      setInterval: (callback: () => void, intervalMs: number) => {
+        const id = nextId++;
+        callbacks.set(id, callback);
+        intervals.push(intervalMs);
+        return id;
+      },
+      clearInterval: (id: number) => {
+        cleared.push(id);
+        callbacks.delete(id);
+      },
+    },
+    tick: (id = 1) => callbacks.get(id)?.(),
+  };
+}
+
+function deferred() {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(count = 10) {
+  for (let index = 0; index < count; index++) {
+    await Promise.resolve();
+  }
+}
+
+describe("match_tracking worker", () => {
+  test("startしたとき、初回tickを即時実行しpoll間隔で次tickを登録する", async () => {
+    const manualScheduler = createManualScheduler();
+    const calls: string[] = [];
+    const worker = createMatchTrackingWorker({
+      createService: () => ({
+        processMatchWatchers: () => {
+          calls.push("process");
+          return Promise.resolve();
+        },
+      }),
+      scheduler: manualScheduler.scheduler,
+      config: {
+        pollIntervalMs: 12_345,
+      },
+      logger: {
+        warn: () => {},
+      },
+    });
+
+    worker.start();
+    await flushMicrotasks();
+    manualScheduler.tick();
+    await flushMicrotasks();
+
+    assertEquals(manualScheduler.intervals, [12_345]);
+    assertEquals(calls, ["process", "process"]);
+  });
+
+  test("startを重複して呼んだとき、新しいintervalと初回tickを追加しない", async () => {
+    const manualScheduler = createManualScheduler();
+    let serviceCount = 0;
+    const calls: string[] = [];
+    const worker = createMatchTrackingWorker({
+      createService: () => {
+        serviceCount += 1;
+        return {
+          processMatchWatchers: () => {
+            calls.push("process");
+            return Promise.resolve();
+          },
+        };
+      },
+      scheduler: manualScheduler.scheduler,
+      config: {
+        pollIntervalMs: 60_000,
+      },
+      logger: {
+        warn: () => {},
+      },
+    });
+
+    worker.start();
+    worker.start();
+    await flushMicrotasks();
+
+    assertEquals(serviceCount, 1);
+    assertEquals(manualScheduler.intervals, [60_000]);
+    assertEquals(calls, ["process"]);
+  });
+
+  test("前tickが処理中のとき、次tickをskipして警告する", async () => {
+    const manualScheduler = createManualScheduler();
+    const firstTick = deferred();
+    const calls: string[] = [];
+    const warnings: string[] = [];
+    const worker = createMatchTrackingWorker({
+      createService: () => ({
+        processMatchWatchers: () => {
+          calls.push("process");
+          return firstTick.promise;
+        },
+      }),
+      scheduler: manualScheduler.scheduler,
+      config: {
+        pollIntervalMs: 60_000,
+      },
+      logger: {
+        warn: (message) => warnings.push(message),
+      },
+    });
+
+    worker.start();
+    await flushMicrotasks();
+    manualScheduler.tick();
+    await flushMicrotasks();
+    firstTick.resolve();
+    await flushMicrotasks();
+
+    assertEquals(calls, ["process"]);
+    assertEquals(warnings, ["match_tracking.worker_tick_skipped"]);
+  });
+
+  test("stopしたとき、登録済みintervalを解除する", () => {
+    const manualScheduler = createManualScheduler();
+    const worker = createMatchTrackingWorker({
+      createService: () => ({
+        processMatchWatchers: () => Promise.resolve(),
+      }),
+      scheduler: manualScheduler.scheduler,
+      config: {
+        pollIntervalMs: 60_000,
+      },
+      logger: {
+        warn: () => {},
+      },
+    });
+
+    worker.start();
+    worker.stop();
+
+    assertEquals(manualScheduler.cleared, [1]);
+  });
+});

--- a/bot/src/main.ts
+++ b/bot/src/main.ts
@@ -38,8 +38,7 @@ client.once(Events.ClientReady, (c) => {
     userTag: c.user.tag,
     userId: c.user.id,
   });
-  const matchTrackingWorker = matchTracker.createDefaultMatchTrackingWorker(c);
-  matchTrackingWorker.start();
+  matchTracker.startMatchTrackingWorker(c);
 });
 
 export async function handleInteractionCreate(interaction: Interaction) {

--- a/bot/src/main.ts
+++ b/bot/src/main.ts
@@ -38,7 +38,8 @@ client.once(Events.ClientReady, (c) => {
     userTag: c.user.tag,
     userId: c.user.id,
   });
-  matchTracker.startMatchTrackingWorker(c);
+  const matchTrackingWorker = matchTracker.createDefaultMatchTrackingWorker(c);
+  matchTrackingWorker.start();
 });
 
 export async function handleInteractionCreate(interaction: Interaction) {


### PR DESCRIPTION
## 概要

Closes #83

- match tracking workerのtimer、reentrancy guard、start/stopを`createMatchTrackingWorker`のinstance状態へ移動
- Riot request budget警告を`createRiotRequestBudgetMonitor`として分離し、警告条件とlong window抑制を固定時刻で検証
- `main.ts`は互換wrapperの`startMatchTrackingWorker`経由で起動し、`stopMatchTrackingWorker`から稼働中workerを停止できるライフサイクルを維持
- worker tickの非同期例外を捕捉してerrorログを出し、次tickを継続できるように変更

## 検証

- `deno task quality`

## 備考

- 既存の`matchTracker.startMatchTrackingWorker` / `stopMatchTrackingWorker` / `warnIfRiotRequestBudgetRisk`は互換ラッパーとして残しています。