### PR TITLE
[codex] match tracking active game検査をBackendへ移す

### DIFF
--- a/api/src/contract/app.ts
+++ b/api/src/contract/app.ts
@@ -6,6 +6,7 @@ import {
   createMatchWatcherSchema,
   createParticipantSchema,
   finalizeRankSnapshotsSchema,
+  inspectMatchWatcherActiveGameSchema,
   linkByRiotIdSchema,
   loginUrlQuerySchema,
   platformAndPuuidSchema,
@@ -117,6 +118,18 @@ const matchWatchersContractRoutes = new Hono()
     "/:guildId/:targetDiscordId/state",
     zValidator("json", updateMatchWatcherStateSchema),
     (c) => c.body(null, 204),
+  )
+  .post(
+    "/:guildId/:targetDiscordId/tracking/active-game",
+    zValidator("json", inspectMatchWatcherActiveGameSchema),
+    (c) => {
+      if (hasContractError()) return c.json(errorResponse, 404);
+      if (hasContractError()) return c.json(errorResponse, 502);
+      return c.json({
+        account: {} as RiotAccount,
+        activeGame: null as ActiveGame | null,
+      }, 200);
+    },
   )
   .delete("/:guildId/:targetDiscordId", (c) => c.body(null, 204));
 

--- a/api/src/contract/schemas.ts
+++ b/api/src/contract/schemas.ts
@@ -99,6 +99,11 @@ export const updateMatchWatcherStateSchema = z.object({
   lastInGameNotifiedAt: z.coerce.date().nullable().optional(),
 });
 
+export const inspectMatchWatcherActiveGameSchema = z.object({
+  lastState: z.enum(matchWatcherStates),
+  currentGameId: z.string().nullable(),
+});
+
 export const platformAndPuuidSchema = z.object({
   platform: z.enum(riotPlatforms),
   puuid: z.string().min(1),

--- a/api/src/routes/match_watchers.test.ts
+++ b/api/src/routes/match_watchers.test.ts
@@ -158,6 +158,102 @@ describe("routes/match_watchers.ts", () => {
     });
   });
 
+  test("監視処理用Active Game検査を行うと、連携アカウントと進行中試合を返す", async () => {
+    const account = {
+      discordId: watcher.targetDiscordId,
+      puuid: "puuid-1",
+      gameName: "Teemo",
+      tagLine: "JP1",
+      platform: "jp1" as const,
+      region: "asia" as const,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: null,
+    };
+    const activeGame = {
+      gameId: 12345,
+      gameType: "MATCHED_GAME",
+      gameStartTime: 1_700_000_000_000,
+      mapId: 11,
+      gameMode: "CLASSIC",
+      gameQueueConfigId: 420,
+      participants: [{
+        puuid: "puuid-1",
+        championId: 17,
+        teamId: 100,
+      }],
+    };
+    using accountStub = stub(
+      dbActions,
+      "getRiotAccountByDiscordId",
+      () => Promise.resolve(account),
+    );
+    using activeGameStub = stub(
+      deps.riotApi,
+      "getActiveGameByPuuid",
+      () => Promise.resolve(activeGame),
+    );
+    using entriesStub = stub(
+      deps.riotApi,
+      "getLeagueEntriesByPuuid",
+      () => Promise.resolve([]),
+    );
+    using snapshotsStub = stub(
+      dbActions,
+      "upsertPendingRankSnapshots",
+      () => Promise.resolve(),
+    );
+
+    const res = await client["match-watchers"][":guildId"][
+      ":targetDiscordId"
+    ].tracking["active-game"].$post({
+      param: {
+        guildId: watcher.guildId,
+        targetDiscordId: watcher.targetDiscordId,
+      },
+      json: {
+        lastState: "IDLE",
+        currentGameId: null,
+      },
+    });
+
+    assertEquals(res.status, 200);
+    assertEquals(await res.json(), {
+      account: {
+        ...account,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      activeGame,
+    });
+    assertSpyCall(accountStub, 0, { args: [watcher.targetDiscordId] });
+    assertSpyCall(activeGameStub, 0, { args: ["jp1", "puuid-1"] });
+    assertSpyCall(entriesStub, 0, { args: ["jp1", "puuid-1"] });
+    assertEquals(snapshotsStub.calls.length, 1);
+  });
+
+  test("監視処理用Active Game検査で未連携メンバーを指定すると、404を返す", async () => {
+    using accountStub = stub(
+      dbActions,
+      "getRiotAccountByDiscordId",
+      () => Promise.resolve(undefined),
+    );
+
+    const res = await client["match-watchers"][":guildId"][
+      ":targetDiscordId"
+    ].tracking["active-game"].$post({
+      param: {
+        guildId: watcher.guildId,
+        targetDiscordId: watcher.targetDiscordId,
+      },
+      json: {
+        lastState: "IDLE",
+        currentGameId: null,
+      },
+    });
+
+    assertEquals(res.status, 404);
+    assertSpyCall(accountStub, 0, { args: [watcher.targetDiscordId] });
+  });
+
   test("監視を解除すると、204 No Contentを返す", async () => {
     using disableStub = stub(
       dbActions,

--- a/api/src/routes/match_watchers.ts
+++ b/api/src/routes/match_watchers.ts
@@ -2,24 +2,36 @@ import { Hono } from "@hono/hono";
 import { zValidator } from "@hono/zod-validator";
 import {
   createMatchWatcherSchema,
+  inspectMatchWatcherActiveGameSchema,
   updateMatchWatcherStateSchema,
 } from "../contract/schemas.ts";
 import { MatchWatcherLimitError, RecordNotFoundError } from "../errors.ts";
 import type { AppDependencies } from "../dependencies.ts";
+import { createMatchTrackingInspectionService } from "../services/match_tracking.ts";
 
 type MatchWatchersDbActions = Pick<
   AppDependencies["dbActions"],
   | "upsertMatchWatcher"
   | "getEnabledMatchWatchers"
   | "getEnabledMatchWatchersByGuild"
+  | "getRiotAccountByDiscordId"
+  | "upsertPendingRankSnapshots"
   | "updateMatchWatcherState"
   | "disableMatchWatcher"
 >;
 
 export function matchWatchersRoutes(
-  deps: { dbActions: MatchWatchersDbActions },
+  deps: {
+    dbActions: MatchWatchersDbActions;
+    riotApi: Pick<
+      AppDependencies["riotApi"],
+      "getActiveGameByPuuid" | "getLeagueEntriesByPuuid"
+    >;
+    logger: AppDependencies["logger"];
+  },
 ) {
   const { dbActions } = deps;
+  const matchTrackingInspection = createMatchTrackingInspectionService(deps);
   return new Hono()
     .post("/", zValidator("json", createMatchWatcherSchema), async (c) => {
       const watcher = c.req.valid("json");
@@ -57,6 +69,35 @@ export function matchWatchersRoutes(
           state,
         );
         return c.body(null, 204);
+      },
+    )
+    .post(
+      "/:guildId/:targetDiscordId/tracking/active-game",
+      zValidator("json", inspectMatchWatcherActiveGameSchema),
+      async (c) => {
+        const { guildId, targetDiscordId } = c.req.param();
+        const state = c.req.valid("json");
+
+        try {
+          const result = await matchTrackingInspection.inspectActiveGame({
+            guildId,
+            targetDiscordId,
+            ...state,
+          });
+          if (result.status === "riot_account_not_found") {
+            return c.json({ error: result.error }, 404);
+          }
+          return c.json({
+            account: result.account,
+            activeGame: result.activeGame,
+          }, 200);
+        } catch (error) {
+          return c.json({
+            error: error instanceof Error
+              ? error.message
+              : "Riot API request failed",
+          }, 502);
+        }
       },
     )
     .delete("/:guildId/:targetDiscordId", async (c) => {

--- a/api/src/services/match_tracking.test.ts
+++ b/api/src/services/match_tracking.test.ts
@@ -1,0 +1,136 @@
+import { assertEquals } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import type { ActiveGame, LeagueEntry, RiotAccount } from "../contract/mod.ts";
+import { createMatchTrackingInspectionService } from "./match_tracking.ts";
+
+const account: RiotAccount = {
+  discordId: "target-1",
+  puuid: "puuid-1",
+  gameName: "Teemo",
+  tagLine: "JP1",
+  platform: "jp1",
+  region: "asia",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: null,
+};
+const activeGame: ActiveGame = {
+  gameId: 12345,
+  gameType: "MATCHED_GAME",
+  gameStartTime: 1_700_000_000_000,
+  mapId: 11,
+  gameMode: "CLASSIC",
+  gameQueueConfigId: 420,
+  participants: [{
+    puuid: "puuid-1",
+    championId: 17,
+    teamId: 100,
+  }],
+};
+const entries: LeagueEntry[] = [{
+  queueType: "RANKED_SOLO_5x5",
+  tier: "EMERALD",
+  rank: "IV",
+  leaguePoints: 19,
+  wins: 11,
+  losses: 8,
+}];
+
+describe("services/match_tracking.ts", () => {
+  test("新しいランク対象試合を検知すると、Riot取得後にpending rank snapshotを保存してactiveGameを返す", async () => {
+    const calls: string[] = [];
+    const savedPayloads: unknown[] = [];
+    const service = createMatchTrackingInspectionService({
+      dbActions: {
+        getRiotAccountByDiscordId: (discordId) => {
+          calls.push(`account:${discordId}`);
+          return Promise.resolve(account);
+        },
+        upsertPendingRankSnapshots: (payload) => {
+          calls.push("saveSnapshots");
+          savedPayloads.push(payload);
+          return Promise.resolve();
+        },
+      },
+      riotApi: {
+        getActiveGameByPuuid: (platform, puuid) => {
+          calls.push(`activeGame:${platform}:${puuid}`);
+          return Promise.resolve(activeGame);
+        },
+        getLeagueEntriesByPuuid: (platform, puuid) => {
+          calls.push(`leagueEntries:${platform}:${puuid}`);
+          return Promise.resolve(entries);
+        },
+      },
+      logger: { warn: () => {} },
+      clock: { now: () => new Date("2026-01-01T00:00:00.000Z") },
+    });
+
+    const result = await service.inspectActiveGame({
+      guildId: "guild-1",
+      targetDiscordId: "target-1",
+      lastState: "IDLE",
+      currentGameId: null,
+    });
+
+    assertEquals(result, { status: "ok", account, activeGame });
+    assertEquals(calls, [
+      "account:target-1",
+      "activeGame:jp1:puuid-1",
+      "leagueEntries:jp1:puuid-1",
+      "saveSnapshots",
+    ]);
+    assertEquals(savedPayloads, [{
+      platform: "jp1",
+      gameId: "12345",
+      puuid: "puuid-1",
+      snapshots: [{
+        queueType: "RANKED_SOLO_5x5",
+        tier: "EMERALD",
+        rank: "IV",
+        leaguePoints: 19,
+        wins: 11,
+        losses: 8,
+        fetchedAt: new Date("2026-01-01T00:00:00.000Z"),
+      }, {
+        queueType: "RANKED_FLEX_SR",
+        tier: null,
+        rank: null,
+        leaguePoints: null,
+        wins: null,
+        losses: null,
+        fetchedAt: new Date("2026-01-01T00:00:00.000Z"),
+      }],
+    }]);
+  });
+
+  test("同じ進行中試合を再確認すると、pending rank snapshotを保存せずactiveGameを返す", async () => {
+    const calls: string[] = [];
+    const service = createMatchTrackingInspectionService({
+      dbActions: {
+        getRiotAccountByDiscordId: () => Promise.resolve(account),
+        upsertPendingRankSnapshots: () => {
+          calls.push("saveSnapshots");
+          return Promise.resolve();
+        },
+      },
+      riotApi: {
+        getActiveGameByPuuid: () => Promise.resolve(activeGame),
+        getLeagueEntriesByPuuid: () => {
+          calls.push("leagueEntries");
+          return Promise.resolve(entries);
+        },
+      },
+      logger: { warn: () => {} },
+    });
+
+    const result = await service.inspectActiveGame({
+      guildId: "guild-1",
+      targetDiscordId: "target-1",
+      lastState: "IN_GAME",
+      currentGameId: "12345",
+    });
+
+    assertEquals(result, { status: "ok", account, activeGame });
+    assertEquals(calls, []);
+  });
+});

--- a/api/src/services/match_tracking.ts
+++ b/api/src/services/match_tracking.ts
@@ -1,0 +1,164 @@
+import type {
+  ActiveGame,
+  LeagueEntry,
+  MatchWatcherState,
+  RankSnapshotPayload,
+  RiotAccount,
+} from "../contract/mod.ts";
+import type { AppDependencies } from "../dependencies.ts";
+
+const RANKED_QUEUE_TYPES: RankSnapshotPayload["queueType"][] = [
+  "RANKED_SOLO_5x5",
+  "RANKED_FLEX_SR",
+];
+const RANKED_QUEUE_BY_QUEUE_ID = new Map<
+  number,
+  RankSnapshotPayload["queueType"]
+>([
+  [420, "RANKED_SOLO_5x5"],
+  [440, "RANKED_FLEX_SR"],
+]);
+
+type MatchTrackingInspectionDbActions = Pick<
+  AppDependencies["dbActions"],
+  "getRiotAccountByDiscordId" | "upsertPendingRankSnapshots"
+>;
+type MatchTrackingInspectionRiotApi = Pick<
+  AppDependencies["riotApi"],
+  "getActiveGameByPuuid" | "getLeagueEntriesByPuuid"
+>;
+type MatchTrackingInspectionLogger = Pick<
+  AppDependencies["logger"],
+  "warn"
+>;
+type MatchTrackingInspectionClock = {
+  now: () => Date;
+};
+
+export type InspectMatchWatcherActiveGameInput = {
+  guildId: string;
+  targetDiscordId: string;
+  lastState: MatchWatcherState;
+  currentGameId: string | null;
+};
+export type InspectMatchWatcherActiveGameResult =
+  | {
+    status: "ok";
+    account: RiotAccount;
+    activeGame: ActiveGame | null;
+  }
+  | {
+    status: "riot_account_not_found";
+    error: string;
+  };
+
+function rankedQueueTypeByQueueId(queueId: number | undefined) {
+  return queueId === undefined
+    ? undefined
+    : RANKED_QUEUE_BY_QUEUE_ID.get(queueId);
+}
+
+function rankSnapshotPayloadsFromEntries(
+  entries: LeagueEntry[],
+  fetchedAt: Date,
+): RankSnapshotPayload[] {
+  return RANKED_QUEUE_TYPES.map((queueType) => {
+    const entry = entries.find((candidate) =>
+      candidate.queueType === queueType
+    );
+    return {
+      queueType,
+      tier: entry?.tier ?? null,
+      rank: entry?.rank ?? null,
+      leaguePoints: entry?.leaguePoints ?? null,
+      wins: entry?.wins ?? null,
+      losses: entry?.losses ?? null,
+      fetchedAt,
+    };
+  });
+}
+
+function shouldCapturePendingRankSnapshots(
+  input: Pick<
+    InspectMatchWatcherActiveGameInput,
+    "lastState" | "currentGameId"
+  >,
+  activeGame: ActiveGame,
+) {
+  const currentGameId = String(activeGame.gameId);
+  return input.lastState !== "IN_GAME" || input.currentGameId !== currentGameId;
+}
+
+export function createMatchTrackingInspectionService(
+  dependencies: {
+    dbActions: MatchTrackingInspectionDbActions;
+    riotApi: MatchTrackingInspectionRiotApi;
+    logger: MatchTrackingInspectionLogger;
+    clock?: MatchTrackingInspectionClock;
+  },
+) {
+  const clock = dependencies.clock ?? { now: () => new Date() };
+
+  async function capturePendingRankSnapshots(
+    input: InspectMatchWatcherActiveGameInput,
+    account: RiotAccount,
+    activeGame: ActiveGame,
+  ) {
+    if (!rankedQueueTypeByQueueId(activeGame.gameQueueConfigId)) return;
+    if (!shouldCapturePendingRankSnapshots(input, activeGame)) return;
+
+    try {
+      const entries = await dependencies.riotApi.getLeagueEntriesByPuuid(
+        account.platform,
+        account.puuid,
+      );
+      await dependencies.dbActions.upsertPendingRankSnapshots({
+        platform: account.platform,
+        gameId: String(activeGame.gameId),
+        puuid: account.puuid,
+        snapshots: rankSnapshotPayloadsFromEntries(entries, clock.now()),
+      });
+    } catch (error) {
+      dependencies.logger.warn(
+        "match_tracking.rank_snapshot_pending_save_failed",
+        {
+          guildId: input.guildId,
+          targetDiscordId: input.targetDiscordId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+
+  async function inspectActiveGame(
+    input: InspectMatchWatcherActiveGameInput,
+  ): Promise<InspectMatchWatcherActiveGameResult> {
+    const account = await dependencies.dbActions.getRiotAccountByDiscordId(
+      input.targetDiscordId,
+    );
+    if (!account) {
+      return {
+        status: "riot_account_not_found",
+        error: "Riot account not found",
+      };
+    }
+
+    const activeGame = await dependencies.riotApi.getActiveGameByPuuid(
+      account.platform,
+      account.puuid,
+    );
+    if (activeGame) {
+      await capturePendingRankSnapshots(input, account, activeGame);
+    }
+
+    return {
+      status: "ok",
+      account,
+      activeGame,
+    };
+  }
+
+  return {
+    inspectActiveGame,
+  };
+}

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -139,6 +139,9 @@ export const apiClient: ApiClient = {
   resolveOpggMatchDetail(...args) {
     return getConfiguredApiClient().resolveOpggMatchDetail(...args);
   },
+  inspectMatchWatcherActiveGame(...args) {
+    return getConfiguredApiClient().inspectMatchWatcherActiveGame(...args);
+  },
   getLoginUrl(...args) {
     return getConfiguredApiClient().getLoginUrl(...args);
   },

--- a/bot/src/api_clients/match_watchers.ts
+++ b/bot/src/api_clients/match_watchers.ts
@@ -1,4 +1,9 @@
-import type { MatchWatcher, MatchWatcherState } from "@adteemo/api/contract";
+import type {
+  ActiveGame,
+  MatchWatcher,
+  MatchWatcherState,
+  RiotAccount,
+} from "@adteemo/api/contract";
 import {
   type ApiRpcClient,
   dateOrNull,
@@ -38,6 +43,25 @@ function parseMatchWatcher(
     pendingResultStartedAt: dateOrNull(watcher.pendingResultStartedAt),
   };
 }
+
+function parseRiotAccount(
+  account:
+    & {
+      createdAt: string | Date;
+      updatedAt: string | Date | null;
+    }
+    & Omit<RiotAccount, "createdAt" | "updatedAt">,
+): RiotAccount {
+  return {
+    ...account,
+    createdAt: new Date(account.createdAt),
+    updatedAt: dateOrNull(account.updatedAt),
+  };
+}
+
+export type InspectMatchWatcherActiveGameResult =
+  | { success: true; account: RiotAccount; activeGame: ActiveGame | null }
+  | { success: false; error: string };
 
 export function createMatchWatchersApiClient(
   { rpcClient }: { rpcClient: ApiRpcClient },
@@ -133,11 +157,48 @@ export function createMatchWatchersApiClient(
     );
   }
 
+  async function inspectMatchWatcherActiveGame(
+    guildId: string,
+    targetDiscordId: string,
+    state: {
+      lastState: MatchWatcherState;
+      currentGameId: string | null;
+    },
+  ): Promise<InspectMatchWatcherActiveGameResult> {
+    return await resultFromRequest(
+      () =>
+        rpcClient["match-watchers"][":guildId"][":targetDiscordId"].tracking[
+          "active-game"
+        ].$post({
+          param: { guildId, targetDiscordId },
+          json: state,
+        }),
+      async (res) => {
+        const body = await res.json() as {
+          account: Parameters<typeof parseRiotAccount>[0];
+          activeGame: ActiveGame | null;
+        };
+        return {
+          account: parseRiotAccount(body.account),
+          activeGame: body.activeGame,
+        };
+      },
+      async (res) => {
+        if (res.status === 404 || res.status === 502) {
+          return { success: false, error: await readErrorMessage(res) };
+        }
+
+        throw unexpectedResponseError(res);
+      },
+    );
+  }
+
   return {
     watchMatch,
     unwatchMatch,
     getEnabledMatchWatchers,
     getEnabledMatchWatchersByGuild,
+    inspectMatchWatcherActiveGame,
     updateMatchWatcherState,
   };
 }

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -3235,6 +3235,60 @@ describe("match_tracking.ts", () => {
     assertEquals(updateStub.calls.at(-1)?.args[2].currentGameId, "67890");
   });
 
+  test("pending resultがある状態でActive Game検査が失敗しても、結果取得を先に試行する", async () => {
+    const calls: string[] = [];
+    const { client } = clientWithSend();
+    using _loggerStub = stub(botLogger, "error", () => {});
+    using _getWatchersStub = stub(
+      apiClient,
+      "getEnabledMatchWatchers",
+      () =>
+        Promise.resolve({
+          success: true as const,
+          watchers: [watcher({
+            pendingResultMatchId: "JP1_12345",
+            pendingResultNotificationMessageId: "message-old",
+            pendingResultStartedAt: new Date(Date.now() - 120_000),
+          })],
+        }),
+    );
+    using _getAccountStub = stub(
+      apiClient,
+      "getRiotAccount",
+      () => Promise.resolve({ success: true as const, account: account() }),
+    );
+    using getMatchStub = stub(
+      apiClient,
+      "getMatchById",
+      () => {
+        calls.push("match");
+        return Promise.resolve(null);
+      },
+    );
+    using _activeGameStub = stub(
+      apiClient,
+      "getActiveGameByPuuid",
+      () => {
+        calls.push("activeGame");
+        throw new Error("Spectator API failed");
+      },
+    );
+    using updateStub = stub(
+      apiClient,
+      "updateMatchWatcherState",
+      () => Promise.resolve({ success: true as const }),
+    );
+
+    await matchTracker.processMatchWatchers(client);
+
+    assertEquals(calls, ["match", "activeGame"]);
+    assertSpyCall(getMatchStub, 0, { args: ["asia", "JP1_12345"] });
+    assertEquals(
+      updateStub.calls[0].args[2].pendingResultMatchId,
+      "JP1_12345",
+    );
+  });
+
   test("IDLEかつ試合中ではない監視対象では、DB状態更新をスキップする", async () => {
     const { client, sendSpy } = clientWithSend();
     using _getWatchersStub = stub(

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -263,6 +263,7 @@ async function resultEmbedFields(resultMatch: RiotMatch) {
 describe("match_tracking.ts", () => {
   let staticDataStub: { restore(): void } | undefined;
   let opggDetailStub: { restore(): void } | undefined;
+  let activeGameInspectionStub: { restore(): void } | undefined;
   let rankSnapshotStubs: { restore(): void }[] = [];
 
   function restoreStaticDataStub() {
@@ -273,6 +274,11 @@ describe("match_tracking.ts", () => {
   function restoreOpggDetailStub() {
     opggDetailStub?.restore();
     opggDetailStub = undefined;
+  }
+
+  function restoreActiveGameInspectionStub() {
+    activeGameInspectionStub?.restore();
+    activeGameInspectionStub = undefined;
   }
 
   function restoreRankSnapshotStubs() {
@@ -314,11 +320,63 @@ describe("match_tracking.ts", () => {
           }),
       ),
     ];
+    activeGameInspectionStub = stub(
+      apiClient,
+      "inspectMatchWatcherActiveGame",
+      async (_guildId, targetDiscordId, state) => {
+        const accountResult = await apiClient.getRiotAccount(targetDiscordId);
+        if (!accountResult.success) return accountResult;
+
+        const activeGame = await apiClient.getActiveGameByPuuid(
+          accountResult.account.platform,
+          accountResult.account.puuid,
+        );
+        if (
+          activeGame && activeGame.gameQueueConfigId === 420 &&
+          (state.lastState !== "IN_GAME" ||
+            state.currentGameId !== String(activeGame.gameId))
+        ) {
+          const entries = await apiClient.getLeagueEntriesByPuuid(
+            accountResult.account.platform,
+            accountResult.account.puuid,
+          );
+          await apiClient.upsertPendingRankSnapshots({
+            platform: accountResult.account.platform,
+            gameId: String(activeGame.gameId),
+            puuid: accountResult.account.puuid,
+            snapshots: [{
+              queueType: "RANKED_SOLO_5x5",
+              tier: entries[0]?.tier ?? null,
+              rank: entries[0]?.rank ?? null,
+              leaguePoints: entries[0]?.leaguePoints ?? null,
+              wins: entries[0]?.wins ?? null,
+              losses: entries[0]?.losses ?? null,
+              fetchedAt: new Date(),
+            }, {
+              queueType: "RANKED_FLEX_SR",
+              tier: null,
+              rank: null,
+              leaguePoints: null,
+              wins: null,
+              losses: null,
+              fetchedAt: new Date(),
+            }],
+          });
+        }
+
+        return {
+          success: true as const,
+          account: accountResult.account,
+          activeGame,
+        };
+      },
+    );
   });
 
   afterEach(() => {
     restoreStaticDataStub();
     restoreOpggDetailStub();
+    restoreActiveGameInspectionStub();
     restoreRankSnapshotStubs();
   });
 

--- a/bot/src/features/match_tracking_service.test.ts
+++ b/bot/src/features/match_tracking_service.test.ts
@@ -28,7 +28,7 @@ function watcher(overrides: Partial<MatchWatcher> = {}): MatchWatcher {
 
 describe("match_tracking_service.ts", () => {
   test("watcher単位処理で例外が発生したとき、後続のwatcher処理を継続する", async () => {
-    const accountCalls: string[] = [];
+    const inspectionCalls: string[] = [];
     const errors: unknown[] = [];
     const service = createMatchTrackingService({
       apiClient: {
@@ -40,8 +40,11 @@ describe("match_tracking_service.ts", () => {
               watcher({ targetDiscordId: "target-2" }),
             ],
           }),
-        getRiotAccount: (targetDiscordId) => {
-          accountCalls.push(targetDiscordId);
+        getRiotAccount: () => {
+          throw new Error("getRiotAccount should not be called");
+        },
+        inspectMatchWatcherActiveGame: (_guildId, targetDiscordId) => {
+          inspectionCalls.push(targetDiscordId);
           if (targetDiscordId === "target-1") {
             throw new Error("temporary failure");
           }
@@ -57,13 +60,11 @@ describe("match_tracking_service.ts", () => {
               createdAt: new Date("2026-01-01T00:00:00Z"),
               updatedAt: null,
             },
+            activeGame: null,
           });
         },
-        getActiveGameByPuuid: () => Promise.resolve(null),
         getMatchById: () => Promise.resolve(null),
         getLeagueEntriesByPuuid: () => Promise.resolve([]),
-        upsertPendingRankSnapshots: () =>
-          Promise.resolve({ success: true as const }),
         finalizeRankSnapshots: () =>
           Promise.resolve({
             success: true as const,
@@ -109,7 +110,7 @@ describe("match_tracking_service.ts", () => {
 
     await service.processMatchWatchers();
 
-    assertEquals(accountCalls, ["target-1", "target-2"]);
+    assertEquals(inspectionCalls, ["target-1", "target-2"]);
     assertEquals(errors.length, 1);
   });
 });

--- a/bot/src/features/match_tracking_service.ts
+++ b/bot/src/features/match_tracking_service.ts
@@ -1,7 +1,6 @@
 import type { MatchWatcher, RiotAccount } from "@adteemo/api/contract";
 import type { ApiClient } from "../api_client.ts";
 import {
-  activeGameCacheKey,
   type ActiveNotificationGroup,
   activeNotificationGroupKey,
   currentStateFromWatcher,
@@ -28,10 +27,10 @@ import type { createMatchTrackingRenderer } from "./match_tracking_renderer.ts";
 type ActiveGame = NonNullable<
   Awaited<ReturnType<ApiClient["getActiveGameByPuuid"]>>
 >;
-type ActiveGameResult = Awaited<
-  ReturnType<ApiClient["getActiveGameByPuuid"]>
->;
 type RiotAccountResult = Awaited<ReturnType<ApiClient["getRiotAccount"]>>;
+type ActiveGameInspectionResult = Awaited<
+  ReturnType<ApiClient["inspectMatchWatcherActiveGame"]>
+>;
 type RiotMatch = NonNullable<
   Awaited<ReturnType<ApiClient["getMatchById"]>>
 >;
@@ -48,7 +47,10 @@ type MatchTrackingNotifier = {
 type MatchWatcherProcessingContext = {
   activeNotificationGroups: Map<string, ActiveNotificationGroup>;
   riotAccountsByTargetDiscordId: Map<string, Promise<RiotAccountResult>>;
-  activeGamesByRiotAccount: Map<string, Promise<ActiveGameResult>>;
+  activeGameInspectionsByTargetAndState: Map<
+    string,
+    Promise<ActiveGameInspectionResult>
+  >;
   matchesByRegionAndMatchId: Map<string, Promise<RiotMatch | null>>;
 };
 type ActiveGameTargetDetail = {
@@ -77,12 +79,11 @@ export type MatchTrackingServiceApiClient = Pick<
   ApiClient,
   | "getEnabledMatchWatchers"
   | "getRiotAccount"
-  | "getActiveGameByPuuid"
   | "getMatchById"
   | "getLeagueEntriesByPuuid"
-  | "upsertPendingRankSnapshots"
   | "finalizeRankSnapshots"
   | "resolveOpggMatchDetail"
+  | "inspectMatchWatcherActiveGame"
   | "updateMatchWatcherState"
 >;
 export type MatchTrackingServiceDependencies = {
@@ -98,7 +99,7 @@ function createMatchWatcherProcessingContext(): MatchWatcherProcessingContext {
   return {
     activeNotificationGroups: new Map(),
     riotAccountsByTargetDiscordId: new Map(),
-    activeGamesByRiotAccount: new Map(),
+    activeGameInspectionsByTargetAndState: new Map(),
     matchesByRegionAndMatchId: new Map(),
   };
 }
@@ -364,20 +365,45 @@ function getRiotAccountForWatcher(
   return result;
 }
 
-function getActiveGameForAccount(
-  dependencies: MatchTrackingServiceDependencies,
+function rememberRiotAccountForWatcher(
   context: MatchWatcherProcessingContext,
   account: RiotAccount,
 ) {
-  const cacheKey = activeGameCacheKey(account);
-  const cached = context.activeGamesByRiotAccount.get(cacheKey);
-  if (cached) return cached;
-
-  const result = dependencies.apiClient.getActiveGameByPuuid(
-    account.platform,
-    account.puuid,
+  context.riotAccountsByTargetDiscordId.set(
+    account.discordId,
+    Promise.resolve({ success: true as const, account }),
   );
-  context.activeGamesByRiotAccount.set(cacheKey, result);
+}
+
+async function inspectActiveGameForWatcher(
+  dependencies: MatchTrackingServiceDependencies,
+  context: MatchWatcherProcessingContext,
+  watcher: MatchWatcher,
+) {
+  const cacheKey = [
+    watcher.targetDiscordId,
+    watcher.lastState,
+    watcher.currentGameId ?? "",
+  ].join(":");
+  const cached = context.activeGameInspectionsByTargetAndState.get(cacheKey);
+  const result = await (cached ??
+    dependencies.apiClient.inspectMatchWatcherActiveGame(
+      watcher.guildId,
+      watcher.targetDiscordId,
+      {
+        lastState: watcher.lastState,
+        currentGameId: watcher.currentGameId,
+      },
+    ));
+  if (!cached) {
+    context.activeGameInspectionsByTargetAndState.set(
+      cacheKey,
+      Promise.resolve(result),
+    );
+  }
+  if (result.success) {
+    rememberRiotAccountForWatcher(context, result.account);
+  }
   return result;
 }
 
@@ -394,50 +420,6 @@ function getMatchForPendingResult(
   const result = dependencies.apiClient.getMatchById(account.region, matchId);
   context.matchesByRegionAndMatchId.set(cacheKey, result);
   return result;
-}
-
-async function capturePendingRankSnapshots(
-  dependencies: MatchTrackingServiceDependencies,
-  watcher: MatchWatcher,
-  account: RiotAccount,
-  activeGame: ActiveGame,
-) {
-  if (!rankedQueueTypeByQueueId(activeGame.gameQueueConfigId)) return;
-
-  try {
-    const entries = await dependencies.apiClient.getLeagueEntriesByPuuid(
-      account.platform,
-      account.puuid,
-    );
-    const result = await dependencies.apiClient.upsertPendingRankSnapshots({
-      platform: account.platform,
-      gameId: String(activeGame.gameId),
-      puuid: account.puuid,
-      snapshots: rankSnapshotPayloadsFromEntries(
-        entries,
-        dependencies.clock.now(),
-      ),
-    });
-    if (!result.success) {
-      dependencies.logger.warn(
-        "match_tracking.rank_snapshot_pending_save_failed",
-        {
-          guildId: watcher.guildId,
-          targetDiscordId: watcher.targetDiscordId,
-          error: result.error,
-        },
-      );
-    }
-  } catch (error) {
-    dependencies.logger.warn(
-      "match_tracking.rank_snapshot_before_fetch_failed",
-      {
-        guildId: watcher.guildId,
-        targetDiscordId: watcher.targetDiscordId,
-        error: error instanceof Error ? error.message : String(error),
-      },
-    );
-  }
 }
 
 async function finalizeRankSnapshotsForResult(
@@ -721,22 +703,48 @@ async function processWatcher(
   watcher: MatchWatcher,
   context: MatchWatcherProcessingContext,
 ) {
-  const accountResult = await getRiotAccountForWatcher(
+  const pending = pendingResultFromWatcher(watcher);
+  if (
+    pending && watcher.lastState === "FETCHING_RESULT" && watcher.currentMatchId
+  ) {
+    const accountResult = await getRiotAccountForWatcher(
+      dependencies,
+      context,
+      watcher.targetDiscordId,
+    );
+    if (!accountResult.success) {
+      dependencies.logger.warn("match_tracking.riot_account_not_found", {
+        guildId: watcher.guildId,
+        targetDiscordId: watcher.targetDiscordId,
+        error: accountResult.error,
+      });
+      return;
+    }
+    await tryFetchAndNotifyResult(
+      dependencies,
+      watcher,
+      accountResult.account,
+      context,
+      pending,
+    );
+    return;
+  }
+
+  const activeGameResult = await inspectActiveGameForWatcher(
     dependencies,
     context,
-    watcher.targetDiscordId,
+    watcher,
   );
-  if (!accountResult.success) {
+  if (!activeGameResult.success) {
     dependencies.logger.warn("match_tracking.riot_account_not_found", {
       guildId: watcher.guildId,
       targetDiscordId: watcher.targetDiscordId,
-      error: accountResult.error,
+      error: activeGameResult.error,
     });
     return;
   }
-  const account = accountResult.account;
+  const account = activeGameResult.account;
 
-  const pending = pendingResultFromWatcher(watcher);
   let pendingStatus: "none" | "pending" | "cleared" = "none";
   if (pending) {
     const result = await tryFetchAndNotifyResult(
@@ -752,11 +760,7 @@ async function processWatcher(
     }
   }
 
-  const activeGame = await getActiveGameForAccount(
-    dependencies,
-    context,
-    account,
-  );
+  const activeGame = activeGameResult.activeGame;
   if (!activeGame) {
     if (watcher.lastState === "IN_GAME" && watcher.currentGameId) {
       const activeNotificationGroup = getActiveNotificationGroup(
@@ -839,12 +843,6 @@ async function processWatcher(
         resultNotificationMessageId(previousActiveNotificationGroup, watcher),
         dependencies.renderer.resultPending(watcher, previousMatchId),
       );
-    await capturePendingRankSnapshots(
-      dependencies,
-      watcher,
-      account,
-      activeGame,
-    );
     const newMessageId = await dependencies.notifier.sendOrEditWatcherMessage(
       watcher,
       activeNotificationGroup.messageId,
@@ -905,12 +903,6 @@ async function processWatcher(
     watcher.currentGameId !== currentGameId;
   if (started) {
     const notifiedAt = dependencies.clock.now();
-    await capturePendingRankSnapshots(
-      dependencies,
-      watcher,
-      account,
-      activeGame,
-    );
     const messageId = await dependencies.notifier.sendOrEditWatcherMessage(
       watcher,
       activeNotificationGroup.messageId,

--- a/bot/src/features/match_tracking_service.ts
+++ b/bot/src/features/match_tracking_service.ts
@@ -385,22 +385,20 @@ async function inspectActiveGameForWatcher(
     watcher.lastState,
     watcher.currentGameId ?? "",
   ].join(":");
-  const cached = context.activeGameInspectionsByTargetAndState.get(cacheKey);
-  const result = await (cached ??
-    dependencies.apiClient.inspectMatchWatcherActiveGame(
+  let promise = context.activeGameInspectionsByTargetAndState.get(cacheKey);
+  if (!promise) {
+    promise = dependencies.apiClient.inspectMatchWatcherActiveGame(
       watcher.guildId,
       watcher.targetDiscordId,
       {
         lastState: watcher.lastState,
         currentGameId: watcher.currentGameId,
       },
-    ));
-  if (!cached) {
-    context.activeGameInspectionsByTargetAndState.set(
-      cacheKey,
-      Promise.resolve(result),
     );
+    context.activeGameInspectionsByTargetAndState.set(cacheKey, promise);
   }
+
+  const result = await promise;
   if (result.success) {
     rememberRiotAccountForWatcher(context, result.account);
   }
@@ -704,9 +702,8 @@ async function processWatcher(
   context: MatchWatcherProcessingContext,
 ) {
   const pending = pendingResultFromWatcher(watcher);
-  if (
-    pending && watcher.lastState === "FETCHING_RESULT" && watcher.currentMatchId
-  ) {
+  let pendingStatus: "none" | "pending" | "cleared" = "none";
+  if (pending) {
     const accountResult = await getRiotAccountForWatcher(
       dependencies,
       context,
@@ -720,14 +717,19 @@ async function processWatcher(
       });
       return;
     }
-    await tryFetchAndNotifyResult(
+    const result = await tryFetchAndNotifyResult(
       dependencies,
       watcher,
       accountResult.account,
       context,
       pending,
     );
-    return;
+    pendingStatus = result.status;
+    if (
+      watcher.lastState === "FETCHING_RESULT" && watcher.currentMatchId
+    ) {
+      return;
+    }
   }
 
   const activeGameResult = await inspectActiveGameForWatcher(
@@ -744,21 +746,6 @@ async function processWatcher(
     return;
   }
   const account = activeGameResult.account;
-
-  let pendingStatus: "none" | "pending" | "cleared" = "none";
-  if (pending) {
-    const result = await tryFetchAndNotifyResult(
-      dependencies,
-      watcher,
-      account,
-      context,
-      pending,
-    );
-    pendingStatus = result.status;
-    if (watcher.lastState === "FETCHING_RESULT" && watcher.currentMatchId) {
-      return;
-    }
-  }
 
   const activeGame = activeGameResult.activeGame;
   if (!activeGame) {


### PR DESCRIPTION
## 概要

Refs #106

- Backendにmatch tracking用のActive Game検査use caseを追加し、Riotアカウント取得、Active Game取得、rank pending snapshot保存をまとめました
- `/match-watchers/:guildId/:targetDiscordId/tracking/active-game` を追加し、BotはこのAPI経由でaccount/activeGameを受け取るようにしました
- Bot側はDiscord通知、messageId同期、結果通知処理を維持しつつ、同一tick内のinspection結果cacheで既存の取得共有挙動を保ちました

## 確認

- `deno task quality`

## 補足

- #106全体のうち、Active Game検知とrank pending snapshot保存をBackend use caseへ寄せる段階移行です
- Match-v5結果取得、rank snapshot finalize、OP.GG詳細解決の完全移管は後続で扱える余地を残しています