### PR TITLE
[codex] 試合結果取得をBackendユースケースへ移す

### DIFF
--- a/api/src/contract/app.ts
+++ b/api/src/contract/app.ts
@@ -7,6 +7,7 @@ import {
   createParticipantSchema,
   finalizeRankSnapshotsSchema,
   inspectMatchWatcherActiveGameSchema,
+  inspectMatchWatcherResultSchema,
   linkByRiotIdSchema,
   loginUrlQuerySchema,
   platformAndPuuidSchema,
@@ -22,6 +23,7 @@ import type {
   Event,
   LeagueEntry,
   MatchRankSnapshot,
+  MatchTrackingRankSummary,
   MatchWatcher,
   OpggMatchDetail,
   RiotAccount,
@@ -128,6 +130,20 @@ const matchWatchersContractRoutes = new Hono()
       return c.json({
         account: {} as RiotAccount,
         activeGame: null as ActiveGame | null,
+      }, 200);
+    },
+  )
+  .post(
+    "/:guildId/:targetDiscordId/tracking/result",
+    zValidator("json", inspectMatchWatcherResultSchema),
+    (c) => {
+      if (hasContractError()) return c.json(errorResponse, 404);
+      if (hasContractError()) return c.json(errorResponse, 502);
+      return c.json({
+        account: {} as RiotAccount,
+        match: null as RiotMatch | null,
+        rankSummary: null as MatchTrackingRankSummary | null,
+        opggDetail: null as OpggMatchDetail | null,
       }, 200);
     },
   )

--- a/api/src/contract/models.ts
+++ b/api/src/contract/models.ts
@@ -78,6 +78,12 @@ export type MatchRankSnapshot = {
   fetchedAt: Date;
 };
 
+export type MatchTrackingRankSummary = {
+  queueType: RankedQueueType;
+  before: MatchRankSnapshot | null;
+  after: MatchRankSnapshot | null;
+};
+
 export type ExternalMatchDetail = {
   matchId: string;
   provider: ExternalMatchProvider;

--- a/api/src/contract/schemas.ts
+++ b/api/src/contract/schemas.ts
@@ -104,6 +104,10 @@ export const inspectMatchWatcherActiveGameSchema = z.object({
   currentGameId: z.string().nullable(),
 });
 
+export const inspectMatchWatcherResultSchema = z.object({
+  matchId: z.string().min(1),
+});
+
 export const platformAndPuuidSchema = z.object({
   platform: z.enum(riotPlatforms),
   puuid: z.string().min(1),

--- a/api/src/routes/match_watchers.test.ts
+++ b/api/src/routes/match_watchers.test.ts
@@ -254,6 +254,149 @@ describe("routes/match_watchers.ts", () => {
     assertSpyCall(accountStub, 0, { args: [watcher.targetDiscordId] });
   });
 
+  test("監視処理用Result検査を行うと、試合結果とrank summaryとOP.GG詳細を返す", async () => {
+    const account = {
+      discordId: watcher.targetDiscordId,
+      puuid: "puuid-1",
+      gameName: "Teemo",
+      tagLine: "JP1",
+      platform: "jp1" as const,
+      region: "asia" as const,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: null,
+    };
+    const match = {
+      metadata: {
+        matchId: "JP1_12345",
+        participants: ["puuid-1"],
+      },
+      info: {
+        gameId: 12345,
+        gameCreation: 1_700_000_000_000,
+        gameDuration: 1800,
+        gameMode: "CLASSIC",
+        gameType: "MATCHED_GAME",
+        mapId: 11,
+        queueId: 420,
+        participants: [{
+          puuid: "puuid-1",
+          championId: 17,
+          championName: "Teemo",
+          teamId: 100,
+          win: true,
+          kills: 10,
+          deaths: 2,
+          assists: 8,
+          totalMinionsKilled: 180,
+          neutralMinionsKilled: 12,
+          goldEarned: 12345,
+        }],
+      },
+    };
+    const beforeSnapshot = {
+      id: 1,
+      matchId: "JP1_12345",
+      puuid: "puuid-1",
+      platform: "jp1" as const,
+      queueType: "RANKED_SOLO_5x5" as const,
+      phase: "before" as const,
+      tier: "EMERALD",
+      rank: "IV",
+      leaguePoints: 19,
+      wins: 11,
+      losses: 8,
+      fetchedAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const afterSnapshot = {
+      ...beforeSnapshot,
+      id: 2,
+      phase: "after" as const,
+      leaguePoints: 37,
+      fetchedAt: new Date("2026-01-01T00:05:00.000Z"),
+    };
+    const opggDetail = {
+      provider: "opgg" as const,
+      providerRegion: "jp",
+      providerMatchId: "12345",
+      detailUrl: "https://op.gg/lol/summoners/jp/Teemo-JP1/matches/12345",
+      providerCreatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      averageTier: "Emerald",
+      participant: {
+        puuid: "puuid-1",
+        participantId: 1,
+        laneScore: 7,
+      },
+    };
+    using accountStub = stub(
+      dbActions,
+      "getRiotAccountByDiscordId",
+      () => Promise.resolve(account),
+    );
+    using matchStub = stub(
+      deps.riotApi,
+      "getMatchById",
+      () => Promise.resolve(match),
+    );
+    using entriesStub = stub(
+      deps.riotApi,
+      "getLeagueEntriesByPuuid",
+      () => Promise.resolve([]),
+    );
+    using finalizeStub = stub(
+      dbActions,
+      "finalizeMatchRankSnapshots",
+      () =>
+        Promise.resolve({
+          before: [beforeSnapshot],
+          after: [afterSnapshot],
+        }),
+    );
+    using opggStub = stub(
+      deps.opggMatchDetailService,
+      "resolveAndSave",
+      () => Promise.resolve(opggDetail),
+    );
+
+    const res = await client["match-watchers"][":guildId"][
+      ":targetDiscordId"
+    ].tracking.result.$post({
+      param: {
+        guildId: watcher.guildId,
+        targetDiscordId: watcher.targetDiscordId,
+      },
+      json: { matchId: "JP1_12345" },
+    });
+
+    assertEquals(res.status, 200);
+    assertEquals(await res.json(), {
+      account: {
+        ...account,
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      match,
+      rankSummary: {
+        queueType: "RANKED_SOLO_5x5",
+        before: {
+          ...beforeSnapshot,
+          fetchedAt: "2026-01-01T00:00:00.000Z",
+        },
+        after: {
+          ...afterSnapshot,
+          fetchedAt: "2026-01-01T00:05:00.000Z",
+        },
+      },
+      opggDetail: {
+        ...opggDetail,
+        providerCreatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    assertSpyCall(accountStub, 0, { args: [watcher.targetDiscordId] });
+    assertSpyCall(matchStub, 0, { args: ["asia", "JP1_12345"] });
+    assertSpyCall(entriesStub, 0, { args: ["jp1", "puuid-1"] });
+    assertEquals(finalizeStub.calls.length, 1);
+    assertEquals(opggStub.calls.length, 1);
+  });
+
   test("監視を解除すると、204 No Contentを返す", async () => {
     using disableStub = stub(
       dbActions,

--- a/api/src/routes/match_watchers.ts
+++ b/api/src/routes/match_watchers.ts
@@ -3,6 +3,7 @@ import { zValidator } from "@hono/zod-validator";
 import {
   createMatchWatcherSchema,
   inspectMatchWatcherActiveGameSchema,
+  inspectMatchWatcherResultSchema,
   updateMatchWatcherStateSchema,
 } from "../contract/schemas.ts";
 import { MatchWatcherLimitError, RecordNotFoundError } from "../errors.ts";
@@ -16,6 +17,7 @@ type MatchWatchersDbActions = Pick<
   | "getEnabledMatchWatchersByGuild"
   | "getRiotAccountByDiscordId"
   | "upsertPendingRankSnapshots"
+  | "finalizeMatchRankSnapshots"
   | "updateMatchWatcherState"
   | "disableMatchWatcher"
 >;
@@ -25,8 +27,11 @@ export function matchWatchersRoutes(
     dbActions: MatchWatchersDbActions;
     riotApi: Pick<
       AppDependencies["riotApi"],
-      "getActiveGameByPuuid" | "getLeagueEntriesByPuuid"
+      | "getActiveGameByPuuid"
+      | "getLeagueEntriesByPuuid"
+      | "getMatchById"
     >;
+    opggMatchDetailService: AppDependencies["opggMatchDetailService"];
     logger: AppDependencies["logger"];
   },
 ) {
@@ -90,6 +95,37 @@ export function matchWatchersRoutes(
           return c.json({
             account: result.account,
             activeGame: result.activeGame,
+          }, 200);
+        } catch (error) {
+          return c.json({
+            error: error instanceof Error
+              ? error.message
+              : "Riot API request failed",
+          }, 502);
+        }
+      },
+    )
+    .post(
+      "/:guildId/:targetDiscordId/tracking/result",
+      zValidator("json", inspectMatchWatcherResultSchema),
+      async (c) => {
+        const { guildId, targetDiscordId } = c.req.param();
+        const payload = c.req.valid("json");
+
+        try {
+          const result = await matchTrackingInspection.inspectResult({
+            guildId,
+            targetDiscordId,
+            matchId: payload.matchId,
+          });
+          if (result.status === "riot_account_not_found") {
+            return c.json({ error: result.error }, 404);
+          }
+          return c.json({
+            account: result.account,
+            match: result.match,
+            rankSummary: result.rankSummary,
+            opggDetail: result.opggDetail,
           }, 200);
         } catch (error) {
           return c.json({

--- a/api/src/services/match_tracking.test.ts
+++ b/api/src/services/match_tracking.test.ts
@@ -1,6 +1,12 @@
 import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
-import type { ActiveGame, LeagueEntry, RiotAccount } from "../contract/mod.ts";
+import type {
+  ActiveGame,
+  LeagueEntry,
+  MatchRankSnapshot,
+  RiotAccount,
+  RiotMatch,
+} from "../contract/mod.ts";
 import { createMatchTrackingInspectionService } from "./match_tracking.ts";
 
 const account: RiotAccount = {
@@ -34,6 +40,55 @@ const entries: LeagueEntry[] = [{
   wins: 11,
   losses: 8,
 }];
+const match: RiotMatch = {
+  metadata: {
+    matchId: "JP1_12345",
+    participants: ["puuid-1"],
+  },
+  info: {
+    gameId: 12345,
+    gameCreation: 1_700_000_000_000,
+    gameDuration: 1800,
+    gameMode: "CLASSIC",
+    gameType: "MATCHED_GAME",
+    mapId: 11,
+    queueId: 420,
+    participants: [{
+      puuid: "puuid-1",
+      championId: 17,
+      championName: "Teemo",
+      teamId: 100,
+      win: true,
+      kills: 10,
+      deaths: 2,
+      assists: 8,
+      totalMinionsKilled: 180,
+      neutralMinionsKilled: 12,
+      goldEarned: 12345,
+    }],
+  },
+};
+const beforeSnapshot: MatchRankSnapshot = {
+  id: 1,
+  matchId: "JP1_12345",
+  puuid: "puuid-1",
+  platform: "jp1",
+  queueType: "RANKED_SOLO_5x5",
+  phase: "before",
+  tier: "EMERALD",
+  rank: "IV",
+  leaguePoints: 19,
+  wins: 11,
+  losses: 8,
+  fetchedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+const afterSnapshot: MatchRankSnapshot = {
+  ...beforeSnapshot,
+  id: 2,
+  phase: "after",
+  leaguePoints: 37,
+  fetchedAt: new Date("2026-01-01T00:05:00.000Z"),
+};
 
 describe("services/match_tracking.ts", () => {
   test("新しいランク対象試合を検知すると、Riot取得後にpending rank snapshotを保存してactiveGameを返す", async () => {
@@ -50,6 +105,8 @@ describe("services/match_tracking.ts", () => {
           savedPayloads.push(payload);
           return Promise.resolve();
         },
+        finalizeMatchRankSnapshots: () =>
+          Promise.resolve({ before: [], after: [] }),
       },
       riotApi: {
         getActiveGameByPuuid: (platform, puuid) => {
@@ -60,6 +117,10 @@ describe("services/match_tracking.ts", () => {
           calls.push(`leagueEntries:${platform}:${puuid}`);
           return Promise.resolve(entries);
         },
+        getMatchById: () => Promise.resolve(null),
+      },
+      opggMatchDetailService: {
+        resolveAndSave: () => Promise.resolve(null),
       },
       logger: { warn: () => {} },
       clock: { now: () => new Date("2026-01-01T00:00:00.000Z") },
@@ -112,6 +173,8 @@ describe("services/match_tracking.ts", () => {
           calls.push("saveSnapshots");
           return Promise.resolve();
         },
+        finalizeMatchRankSnapshots: () =>
+          Promise.resolve({ before: [], after: [] }),
       },
       riotApi: {
         getActiveGameByPuuid: () => Promise.resolve(activeGame),
@@ -119,6 +182,10 @@ describe("services/match_tracking.ts", () => {
           calls.push("leagueEntries");
           return Promise.resolve(entries);
         },
+        getMatchById: () => Promise.resolve(null),
+      },
+      opggMatchDetailService: {
+        resolveAndSave: () => Promise.resolve(null),
       },
       logger: { warn: () => {} },
     });
@@ -132,5 +199,127 @@ describe("services/match_tracking.ts", () => {
 
     assertEquals(result, { status: "ok", account, activeGame });
     assertEquals(calls, []);
+  });
+
+  test("結果取得待ちの試合がMatch-v5に未反映のとき、rankとOP.GGを解決せずmatch nullを返す", async () => {
+    const calls: string[] = [];
+    const service = createMatchTrackingInspectionService({
+      dbActions: {
+        getRiotAccountByDiscordId: () => Promise.resolve(account),
+        upsertPendingRankSnapshots: () => Promise.resolve(),
+        finalizeMatchRankSnapshots: () => {
+          calls.push("finalizeSnapshots");
+          return Promise.resolve({ before: [], after: [] });
+        },
+      },
+      riotApi: {
+        getActiveGameByPuuid: () => Promise.resolve(null),
+        getLeagueEntriesByPuuid: () => {
+          calls.push("leagueEntries");
+          return Promise.resolve(entries);
+        },
+        getMatchById: (region, matchId) => {
+          calls.push(`match:${region}:${matchId}`);
+          return Promise.resolve(null);
+        },
+      },
+      opggMatchDetailService: {
+        resolveAndSave: () => {
+          calls.push("opgg");
+          return Promise.resolve(null);
+        },
+      },
+      logger: { warn: () => {} },
+    });
+
+    const result = await service.inspectResult({
+      guildId: "guild-1",
+      targetDiscordId: "target-1",
+      matchId: "JP1_12345",
+    });
+
+    assertEquals(result, {
+      status: "ok",
+      account,
+      match: null,
+      rankSummary: null,
+      opggDetail: null,
+    });
+    assertEquals(calls, ["match:asia:JP1_12345"]);
+  });
+
+  test("結果取得待ちの試合がMatch-v5で取得できると、rank snapshotを確定しOP.GG詳細を解決して返す", async () => {
+    const calls: string[] = [];
+    const opggDetail = {
+      provider: "opgg" as const,
+      providerRegion: "jp",
+      providerMatchId: "12345",
+      detailUrl: "https://op.gg/lol/summoners/jp/Teemo-JP1/matches/12345",
+      providerCreatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      averageTier: "Emerald",
+      participant: {
+        puuid: "puuid-1",
+        participantId: 1,
+        laneScore: 7,
+      },
+    };
+    const service = createMatchTrackingInspectionService({
+      dbActions: {
+        getRiotAccountByDiscordId: () => Promise.resolve(account),
+        upsertPendingRankSnapshots: () => Promise.resolve(),
+        finalizeMatchRankSnapshots: (payload) => {
+          calls.push(`finalize:${payload.matchId}:${payload.puuid}`);
+          return Promise.resolve({
+            before: [beforeSnapshot],
+            after: [afterSnapshot],
+          });
+        },
+      },
+      riotApi: {
+        getActiveGameByPuuid: () => Promise.resolve(null),
+        getLeagueEntriesByPuuid: (platform, puuid) => {
+          calls.push(`leagueEntries:${platform}:${puuid}`);
+          return Promise.resolve(entries);
+        },
+        getMatchById: (region, matchId) => {
+          calls.push(`match:${region}:${matchId}`);
+          return Promise.resolve(match);
+        },
+      },
+      opggMatchDetailService: {
+        resolveAndSave: (payload) => {
+          calls.push(
+            `opgg:${payload.matchId}:${payload.match.participant.puuid}`,
+          );
+          return Promise.resolve(opggDetail);
+        },
+      },
+      logger: { warn: () => {} },
+      clock: { now: () => new Date("2026-01-01T00:05:00.000Z") },
+    });
+
+    const result = await service.inspectResult({
+      guildId: "guild-1",
+      targetDiscordId: "target-1",
+      matchId: "JP1_12345",
+    });
+
+    assertEquals(result, {
+      status: "ok",
+      account,
+      match,
+      rankSummary: {
+        queueType: "RANKED_SOLO_5x5",
+        before: beforeSnapshot,
+        after: afterSnapshot,
+      },
+      opggDetail,
+    });
+    assertEquals(calls, [
+      "match:asia:JP1_12345",
+      "leagueEntries:jp1:puuid-1",
+      "finalize:JP1_12345:puuid-1",
+      "opgg:JP1_12345:puuid-1",
+    ]);
   });
 });

--- a/api/src/services/match_tracking.ts
+++ b/api/src/services/match_tracking.ts
@@ -1,9 +1,12 @@
 import type {
   ActiveGame,
   LeagueEntry,
+  MatchTrackingRankSummary,
   MatchWatcherState,
+  OpggMatchDetail,
   RankSnapshotPayload,
   RiotAccount,
+  RiotMatch,
 } from "../contract/mod.ts";
 import type { AppDependencies } from "../dependencies.ts";
 
@@ -21,11 +24,15 @@ const RANKED_QUEUE_BY_QUEUE_ID = new Map<
 
 type MatchTrackingInspectionDbActions = Pick<
   AppDependencies["dbActions"],
-  "getRiotAccountByDiscordId" | "upsertPendingRankSnapshots"
+  | "getRiotAccountByDiscordId"
+  | "upsertPendingRankSnapshots"
+  | "finalizeMatchRankSnapshots"
 >;
 type MatchTrackingInspectionRiotApi = Pick<
   AppDependencies["riotApi"],
-  "getActiveGameByPuuid" | "getLeagueEntriesByPuuid"
+  | "getActiveGameByPuuid"
+  | "getLeagueEntriesByPuuid"
+  | "getMatchById"
 >;
 type MatchTrackingInspectionLogger = Pick<
   AppDependencies["logger"],
@@ -46,6 +53,23 @@ export type InspectMatchWatcherActiveGameResult =
     status: "ok";
     account: RiotAccount;
     activeGame: ActiveGame | null;
+  }
+  | {
+    status: "riot_account_not_found";
+    error: string;
+  };
+export type InspectMatchWatcherResultInput = {
+  guildId: string;
+  targetDiscordId: string;
+  matchId: string;
+};
+export type InspectMatchWatcherResult =
+  | {
+    status: "ok";
+    account: RiotAccount;
+    match: RiotMatch | null;
+    rankSummary: MatchTrackingRankSummary | null;
+    opggDetail: OpggMatchDetail | null;
   }
   | {
     status: "riot_account_not_found";
@@ -93,6 +117,7 @@ export function createMatchTrackingInspectionService(
   dependencies: {
     dbActions: MatchTrackingInspectionDbActions;
     riotApi: MatchTrackingInspectionRiotApi;
+    opggMatchDetailService: AppDependencies["opggMatchDetailService"];
     logger: MatchTrackingInspectionLogger;
     clock?: MatchTrackingInspectionClock;
   },
@@ -158,7 +183,137 @@ export function createMatchTrackingInspectionService(
     };
   }
 
+  async function finalizeRankSnapshotsForResult(
+    input: InspectMatchWatcherResultInput,
+    account: RiotAccount,
+    match: RiotMatch,
+  ): Promise<MatchTrackingRankSummary | null> {
+    const queueType = rankedQueueTypeByQueueId(match.info.queueId);
+    if (!queueType) return null;
+
+    try {
+      const entries = await dependencies.riotApi.getLeagueEntriesByPuuid(
+        account.platform,
+        account.puuid,
+      );
+      const snapshots = await dependencies.dbActions.finalizeMatchRankSnapshots(
+        {
+          matchId: match.metadata.matchId,
+          platform: account.platform,
+          gameId: String(match.info.gameId),
+          puuid: account.puuid,
+          snapshots: rankSnapshotPayloadsFromEntries(entries, clock.now()),
+        },
+      );
+
+      return {
+        queueType,
+        before: snapshots.before.find((snapshot) =>
+          snapshot.queueType === queueType
+        ) ?? null,
+        after: snapshots.after.find((snapshot) =>
+          snapshot.queueType === queueType
+        ) ?? null,
+      };
+    } catch (error) {
+      dependencies.logger.warn(
+        "match_tracking.rank_snapshot_finalize_failed",
+        {
+          guildId: input.guildId,
+          targetDiscordId: input.targetDiscordId,
+          matchId: match.metadata.matchId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      return null;
+    }
+  }
+
+  async function resolveOpggMatchDetailForResult(
+    input: InspectMatchWatcherResultInput,
+    account: RiotAccount,
+    match: RiotMatch,
+  ) {
+    const participant = match.info.participants.find((candidate) =>
+      candidate.puuid === account.puuid
+    );
+    if (!participant) return null;
+
+    try {
+      return await dependencies.opggMatchDetailService.resolveAndSave({
+        matchId: match.metadata.matchId,
+        targetDiscordId: input.targetDiscordId,
+        match: {
+          gameCreation: match.info.gameCreation,
+          gameDuration: match.info.gameDuration,
+          queueId: match.info.queueId,
+          participant: {
+            puuid: participant.puuid,
+            championId: participant.championId,
+            championName: participant.championName,
+          },
+        },
+      });
+    } catch (error) {
+      dependencies.logger.warn("match_tracking.opgg_detail_resolve_failed", {
+        guildId: input.guildId,
+        targetDiscordId: input.targetDiscordId,
+        matchId: match.metadata.matchId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  async function inspectResult(
+    input: InspectMatchWatcherResultInput,
+  ): Promise<InspectMatchWatcherResult> {
+    const account = await dependencies.dbActions.getRiotAccountByDiscordId(
+      input.targetDiscordId,
+    );
+    if (!account) {
+      return {
+        status: "riot_account_not_found",
+        error: "Riot account not found",
+      };
+    }
+
+    const match = await dependencies.riotApi.getMatchById(
+      account.region,
+      input.matchId,
+    );
+    if (!match) {
+      return {
+        status: "ok",
+        account,
+        match: null,
+        rankSummary: null,
+        opggDetail: null,
+      };
+    }
+
+    const rankSummary = await finalizeRankSnapshotsForResult(
+      input,
+      account,
+      match,
+    );
+    const opggDetail = await resolveOpggMatchDetailForResult(
+      input,
+      account,
+      match,
+    );
+
+    return {
+      status: "ok",
+      account,
+      match,
+      rankSummary,
+      opggDetail,
+    };
+  }
+
   return {
     inspectActiveGame,
+    inspectResult,
   };
 }

--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -331,6 +331,98 @@ describe("apiClient", () => {
       assertEquals("status" in result ? result.status : undefined, 404);
       assertEquals(rpc.calls[0].path, "/match-watchers");
     });
+
+    test("監視処理用Result検査を行うと、rank snapshotとOP.GG詳細の日付をDateへ変換する", async () => {
+      const account = {
+        discordId: "target-1",
+        puuid: "puuid-1",
+        gameName: "Teemo",
+        tagLine: "JP1",
+        platform: "jp1",
+        region: "asia",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: null,
+      };
+      const match = {
+        metadata: { matchId: "JP1_12345", participants: ["puuid-1"] },
+        info: {
+          gameId: 12345,
+          gameCreation: 1_700_000_000_000,
+          gameDuration: 1800,
+          gameMode: "CLASSIC",
+          gameType: "MATCHED_GAME",
+          mapId: 11,
+          queueId: 420,
+          participants: [],
+        },
+      };
+      const rankSnapshot = {
+        id: 1,
+        matchId: "JP1_12345",
+        puuid: "puuid-1",
+        platform: "jp1",
+        queueType: "RANKED_SOLO_5x5",
+        phase: "before",
+        tier: "EMERALD",
+        rank: "IV",
+        leaguePoints: 19,
+        wins: 11,
+        losses: 8,
+        fetchedAt: "2026-01-01T00:05:00.000Z",
+      };
+      const opggDetail = {
+        provider: "opgg",
+        providerRegion: "jp",
+        providerMatchId: "12345",
+        detailUrl: "https://op.gg/lol/summoners/jp/Teemo-JP1/matches/12345",
+        providerCreatedAt: "2026-01-01T00:06:00.000Z",
+        averageTier: "Emerald",
+        participant: null,
+      };
+      const rpc = createRpcClientStub([
+        response({
+          account,
+          match,
+          rankSummary: {
+            queueType: "RANKED_SOLO_5x5",
+            before: rankSnapshot,
+            after: null,
+          },
+          opggDetail,
+        }),
+      ]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.inspectMatchWatcherResult(
+        "guild-1",
+        "target-1",
+        { matchId: "JP1_12345" },
+      );
+
+      assertEquals(result.success, true);
+      if (!result.success) return;
+      assertEquals(
+        result.account.createdAt,
+        new Date("2026-01-01T00:00:00.000Z"),
+      );
+      assertEquals(
+        result.rankSummary?.before?.fetchedAt,
+        new Date("2026-01-01T00:05:00.000Z"),
+      );
+      assertEquals(
+        result.opggDetail?.providerCreatedAt,
+        new Date("2026-01-01T00:06:00.000Z"),
+      );
+      assertEquals(result.match?.metadata.matchId, "JP1_12345");
+      assertEquals(rpc.calls[0], {
+        method: "$post",
+        path: "/match-watchers/:guildId/:targetDiscordId/tracking/result",
+        args: [{
+          param: { guildId: "guild-1", targetDiscordId: "target-1" },
+          json: { matchId: "JP1_12345" },
+        }],
+      });
+    });
   });
 
   describe("Riot API facade", () => {

--- a/bot/src/api_client.ts
+++ b/bot/src/api_client.ts
@@ -142,6 +142,9 @@ export const apiClient: ApiClient = {
   inspectMatchWatcherActiveGame(...args) {
     return getConfiguredApiClient().inspectMatchWatcherActiveGame(...args);
   },
+  inspectMatchWatcherResult(...args) {
+    return getConfiguredApiClient().inspectMatchWatcherResult(...args);
+  },
   getLoginUrl(...args) {
     return getConfiguredApiClient().getLoginUrl(...args);
   },

--- a/bot/src/api_clients/match_watchers.ts
+++ b/bot/src/api_clients/match_watchers.ts
@@ -1,8 +1,12 @@
 import type {
   ActiveGame,
+  MatchRankSnapshot,
+  MatchTrackingRankSummary,
   MatchWatcher,
   MatchWatcherState,
+  OpggMatchDetail,
   RiotAccount,
+  RiotMatch,
 } from "@adteemo/api/contract";
 import {
   type ApiRpcClient,
@@ -62,6 +66,58 @@ function parseRiotAccount(
 export type InspectMatchWatcherActiveGameResult =
   | { success: true; account: RiotAccount; activeGame: ActiveGame | null }
   | { success: false; error: string };
+export type InspectMatchWatcherResultResult =
+  | {
+    success: true;
+    account: RiotAccount;
+    match: RiotMatch | null;
+    rankSummary: MatchTrackingRankSummary | null;
+    opggDetail: OpggMatchDetail | null;
+  }
+  | { success: false; error: string };
+
+function parseMatchRankSnapshot(
+  snapshot: Omit<MatchRankSnapshot, "fetchedAt"> & {
+    fetchedAt: string | Date;
+  },
+): MatchRankSnapshot {
+  return {
+    ...snapshot,
+    fetchedAt: new Date(snapshot.fetchedAt),
+  };
+}
+
+function parseMatchTrackingRankSummary(
+  rankSummary:
+    | (Omit<MatchTrackingRankSummary, "before" | "after"> & {
+      before: Parameters<typeof parseMatchRankSnapshot>[0] | null;
+      after: Parameters<typeof parseMatchRankSnapshot>[0] | null;
+    })
+    | null,
+): MatchTrackingRankSummary | null {
+  if (!rankSummary) return null;
+  return {
+    ...rankSummary,
+    before: rankSummary.before
+      ? parseMatchRankSnapshot(rankSummary.before)
+      : null,
+    after: rankSummary.after ? parseMatchRankSnapshot(rankSummary.after) : null,
+  };
+}
+
+function parseOpggMatchDetail(
+  detail:
+    | (Omit<OpggMatchDetail, "providerCreatedAt"> & {
+      providerCreatedAt: string | Date;
+    })
+    | null,
+): OpggMatchDetail | null {
+  if (!detail) return null;
+  return {
+    ...detail,
+    providerCreatedAt: new Date(detail.providerCreatedAt),
+  };
+}
 
 export function createMatchWatchersApiClient(
   { rpcClient }: { rpcClient: ApiRpcClient },
@@ -193,12 +249,49 @@ export function createMatchWatchersApiClient(
     );
   }
 
+  async function inspectMatchWatcherResult(
+    guildId: string,
+    targetDiscordId: string,
+    payload: { matchId: string },
+  ): Promise<InspectMatchWatcherResultResult> {
+    return await resultFromRequest(
+      () =>
+        rpcClient["match-watchers"][":guildId"][":targetDiscordId"].tracking
+          .result.$post({
+            param: { guildId, targetDiscordId },
+            json: payload,
+          }),
+      async (res) => {
+        const body = await res.json() as {
+          account: Parameters<typeof parseRiotAccount>[0];
+          match: RiotMatch | null;
+          rankSummary: Parameters<typeof parseMatchTrackingRankSummary>[0];
+          opggDetail: Parameters<typeof parseOpggMatchDetail>[0];
+        };
+        return {
+          account: parseRiotAccount(body.account),
+          match: body.match,
+          rankSummary: parseMatchTrackingRankSummary(body.rankSummary),
+          opggDetail: parseOpggMatchDetail(body.opggDetail),
+        };
+      },
+      async (res) => {
+        if (res.status === 404 || res.status === 502) {
+          return { success: false, error: await readErrorMessage(res) };
+        }
+
+        throw unexpectedResponseError(res);
+      },
+    );
+  }
+
   return {
     watchMatch,
     unwatchMatch,
     getEnabledMatchWatchers,
     getEnabledMatchWatchersByGuild,
     inspectMatchWatcherActiveGame,
+    inspectMatchWatcherResult,
     updateMatchWatcherState,
   };
 }

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -264,6 +264,7 @@ describe("match_tracking.ts", () => {
   let staticDataStub: { restore(): void } | undefined;
   let opggDetailStub: { restore(): void } | undefined;
   let activeGameInspectionStub: { restore(): void } | undefined;
+  let resultInspectionStub: { restore(): void } | undefined;
   let rankSnapshotStubs: { restore(): void }[] = [];
 
   function restoreStaticDataStub() {
@@ -279,6 +280,11 @@ describe("match_tracking.ts", () => {
   function restoreActiveGameInspectionStub() {
     activeGameInspectionStub?.restore();
     activeGameInspectionStub = undefined;
+  }
+
+  function restoreResultInspectionStub() {
+    resultInspectionStub?.restore();
+    resultInspectionStub = undefined;
   }
 
   function restoreRankSnapshotStubs() {
@@ -351,7 +357,7 @@ describe("match_tracking.ts", () => {
               leaguePoints: entries[0]?.leaguePoints ?? null,
               wins: entries[0]?.wins ?? null,
               losses: entries[0]?.losses ?? null,
-              fetchedAt: new Date(),
+              fetchedAt: new Date("2026-01-01T00:00:00.000Z"),
             }, {
               queueType: "RANKED_FLEX_SR",
               tier: null,
@@ -359,7 +365,7 @@ describe("match_tracking.ts", () => {
               leaguePoints: null,
               wins: null,
               losses: null,
-              fetchedAt: new Date(),
+              fetchedAt: new Date("2026-01-01T00:00:00.000Z"),
             }],
           });
         }
@@ -371,12 +377,125 @@ describe("match_tracking.ts", () => {
         };
       },
     );
+    resultInspectionStub = stub(
+      apiClient,
+      "inspectMatchWatcherResult",
+      async (_guildId, targetDiscordId, payload) => {
+        const accountResult = await apiClient.getRiotAccount(targetDiscordId);
+        if (!accountResult.success) return accountResult;
+
+        const match = await apiClient.getMatchById(
+          accountResult.account.region,
+          payload.matchId,
+        );
+        if (!match) {
+          return {
+            success: true as const,
+            account: accountResult.account,
+            match: null,
+            rankSummary: null,
+            opggDetail: null,
+          };
+        }
+
+        const queueType = match.info.queueId === 420
+          ? "RANKED_SOLO_5x5" as const
+          : match.info.queueId === 440
+          ? "RANKED_FLEX_SR" as const
+          : null;
+        let rankSummary = null;
+        if (queueType) {
+          const entries = await apiClient.getLeagueEntriesByPuuid(
+            accountResult.account.platform,
+            accountResult.account.puuid,
+          );
+          const snapshots = await apiClient.finalizeRankSnapshots(
+            match.metadata.matchId,
+            {
+              platform: accountResult.account.platform,
+              gameId: String(match.info.gameId),
+              puuid: accountResult.account.puuid,
+              snapshots: [{
+                queueType: "RANKED_SOLO_5x5",
+                tier: entries[0]?.tier ?? null,
+                rank: entries[0]?.rank ?? null,
+                leaguePoints: entries[0]?.leaguePoints ?? null,
+                wins: entries[0]?.wins ?? null,
+                losses: entries[0]?.losses ?? null,
+                fetchedAt: new Date("2026-01-01T00:05:00.000Z"),
+              }, {
+                queueType: "RANKED_FLEX_SR",
+                tier: null,
+                rank: null,
+                leaguePoints: null,
+                wins: null,
+                losses: null,
+                fetchedAt: new Date("2026-01-01T00:05:00.000Z"),
+              }],
+            },
+          );
+          if (snapshots.success) {
+            rankSummary = {
+              queueType,
+              before: snapshots.snapshots.before.find((snapshot) =>
+                  snapshot.queueType === queueType
+                )
+                ? {
+                  id: 0,
+                  ...snapshots.snapshots.before.find((snapshot) =>
+                    snapshot.queueType === queueType
+                  )!,
+                }
+                : null,
+              after: snapshots.snapshots.after.find((snapshot) =>
+                  snapshot.queueType === queueType
+                )
+                ? {
+                  id: 0,
+                  ...snapshots.snapshots.after.find((snapshot) =>
+                    snapshot.queueType === queueType
+                  )!,
+                }
+                : null,
+            };
+          }
+        }
+
+        const participant = match.info.participants.find((candidate) =>
+          candidate.puuid === accountResult.account.puuid
+        );
+        const opggDetail = participant
+          ? await apiClient.resolveOpggMatchDetail(match.metadata.matchId, {
+            targetDiscordId,
+            match: {
+              gameCreation: match.info.gameCreation,
+              gameDuration: match.info.gameDuration,
+              queueId: match.info.queueId,
+              participant: {
+                puuid: participant.puuid,
+                championId: participant.championId,
+                championName: participant.championName,
+              },
+            },
+          })
+          : { success: true as const, detail: null };
+
+        return {
+          success: true as const,
+          account: accountResult.account,
+          match,
+          rankSummary,
+          opggDetail: opggDetail.success ? opggDetail.detail : null,
+        };
+      },
+    );
   });
 
   afterEach(() => {
     restoreStaticDataStub();
     restoreOpggDetailStub();
     restoreActiveGameInspectionStub();
+    restoreResultInspectionStub();
     restoreRankSnapshotStubs();
   });
 

--- a/bot/src/features/match_tracking_service.test.ts
+++ b/bot/src/features/match_tracking_service.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
+import { EmbedBuilder } from "discord.js";
 import type { MatchWatcher } from "@adteemo/api/contract";
 import { createMatchTrackingService } from "./match_tracking_service.ts";
 
@@ -27,6 +28,150 @@ function watcher(overrides: Partial<MatchWatcher> = {}): MatchWatcher {
 }
 
 describe("match_tracking_service.ts", () => {
+  test("結果取得待ちのwatcherを処理するとき、BackendのResult検査を使って通知と状態更新を行う", async () => {
+    const resultInspectionCalls: unknown[] = [];
+    const activeGameInspectionCalls: unknown[] = [];
+    const renderedMatches: unknown[] = [];
+    const notifications: unknown[] = [];
+    const stateUpdates: unknown[] = [];
+    const targetWatcher = watcher({
+      lastState: "FETCHING_RESULT",
+      currentMatchId: "JP1_12345",
+      currentNotificationMessageId: "message-existing",
+      gameStartedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    const account = {
+      discordId: "target-1",
+      puuid: "puuid-1",
+      gameName: "Teemo",
+      tagLine: "JP1",
+      platform: "jp1" as const,
+      region: "asia" as const,
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: null,
+    };
+    const match = {
+      metadata: {
+        matchId: "JP1_12345",
+        participants: ["puuid-1"],
+      },
+      info: {
+        gameId: 12345,
+        gameCreation: 1_700_000_000_000,
+        gameDuration: 1800,
+        gameMode: "CLASSIC",
+        gameType: "MATCHED_GAME",
+        mapId: 11,
+        queueId: 420,
+        participants: [{
+          puuid: "puuid-1",
+          championId: 17,
+          championName: "Teemo",
+          teamId: 100,
+          win: true,
+          kills: 10,
+          deaths: 2,
+          assists: 8,
+          totalMinionsKilled: 180,
+          neutralMinionsKilled: 12,
+          goldEarned: 12345,
+        }],
+      },
+    };
+    const service = createMatchTrackingService({
+      apiClient: {
+        getEnabledMatchWatchers: () =>
+          Promise.resolve({
+            success: true as const,
+            watchers: [targetWatcher],
+          }),
+        getRiotAccount: () => {
+          throw new Error("getRiotAccount should not be called");
+        },
+        inspectMatchWatcherActiveGame: (...args) => {
+          activeGameInspectionCalls.push(args);
+          throw new Error("inspectMatchWatcherActiveGame should not be called");
+        },
+        inspectMatchWatcherResult: (...args) => {
+          resultInspectionCalls.push(args);
+          return Promise.resolve({
+            success: true as const,
+            account,
+            match,
+            rankSummary: null,
+            opggDetail: null,
+          });
+        },
+        updateMatchWatcherState: (...args) => {
+          stateUpdates.push(args);
+          return Promise.resolve({ success: true as const });
+        },
+      },
+      notifier: {
+        sendOrEditWatcherMessage: (...args) => {
+          notifications.push(args);
+          return Promise.resolve("message-result");
+        },
+      },
+      renderer: {
+        activeGame: () => {
+          throw new Error("renderer.activeGame should not be called");
+        },
+        resultPending: () => {
+          throw new Error("renderer.resultPending should not be called");
+        },
+        resultFetchTimeout: () => {
+          throw new Error("renderer.resultFetchTimeout should not be called");
+        },
+        matchResult: (...args) => {
+          renderedMatches.push(args);
+          return Promise.resolve(new EmbedBuilder());
+        },
+      },
+      clock: {
+        now: () => new Date("2026-01-01T00:05:00Z"),
+      },
+      logger: {
+        warn: () => {},
+        error: () => {},
+      },
+      config: {
+        pollIntervalMs: 60_000,
+        inGameNotifyIntervalMs: 300_000,
+        resultFetchTimeoutMs: 10 * 60_000,
+        riotLongWindowLimit: 100,
+        riotLongWindowMs: 120_000,
+      },
+    });
+
+    await service.processMatchWatchers();
+
+    assertEquals(resultInspectionCalls, [[
+      "guild-1",
+      "target-1",
+      { matchId: "JP1_12345" },
+    ]]);
+    assertEquals(activeGameInspectionCalls, []);
+    assertEquals(renderedMatches.length, 1);
+    assertEquals(notifications.length, 1);
+    assertEquals(stateUpdates, [[
+      "guild-1",
+      "target-1",
+      {
+        lastState: "IDLE",
+        currentGameId: null,
+        currentMatchId: null,
+        currentNotificationMessageId: null,
+        pendingResultMatchId: null,
+        pendingResultNotificationMessageId: null,
+        pendingResultStartedAt: null,
+        gameStartedAt: null,
+        lastInGameNotifiedAt: null,
+        lastCheckedAt: new Date("2026-01-01T00:05:00Z"),
+      },
+    ]]);
+  });
+
   test("watcher単位処理で例外が発生したとき、後続のwatcher処理を継続する", async () => {
     const inspectionCalls: string[] = [];
     const errors: unknown[] = [];
@@ -63,15 +208,9 @@ describe("match_tracking_service.ts", () => {
             activeGame: null,
           });
         },
-        getMatchById: () => Promise.resolve(null),
-        getLeagueEntriesByPuuid: () => Promise.resolve([]),
-        finalizeRankSnapshots: () =>
-          Promise.resolve({
-            success: true as const,
-            snapshots: { before: [], after: [] },
-          }),
-        resolveOpggMatchDetail: () =>
-          Promise.resolve({ success: true as const, detail: null }),
+        inspectMatchWatcherResult: () => {
+          throw new Error("inspectMatchWatcherResult should not be called");
+        },
         updateMatchWatcherState: () =>
           Promise.resolve({ success: true as const }),
       },

--- a/bot/src/features/match_tracking_service.ts
+++ b/bot/src/features/match_tracking_service.ts
@@ -7,15 +7,11 @@ import {
   hasResultFetchTimedOut as hasResultFetchTimedOutWithConfig,
   isAfterDate,
   isResultFetchTimedOut as isResultFetchTimedOutWithConfig,
-  matchCacheKey,
   matchIdForGame,
   matchIdParts,
   newerDate,
   type PendingResult,
   pendingResultFromWatcher,
-  rankedQueueTypeByQueueId,
-  rankSnapshotPayloadsFromEntries,
-  type RankSummary,
   selectResultNotificationMessageId,
   shouldNotifyActiveNotificationGroup
     as shouldNotifyActiveNotificationGroupWithConfig,
@@ -31,8 +27,8 @@ type RiotAccountResult = Awaited<ReturnType<ApiClient["getRiotAccount"]>>;
 type ActiveGameInspectionResult = Awaited<
   ReturnType<ApiClient["inspectMatchWatcherActiveGame"]>
 >;
-type RiotMatch = NonNullable<
-  Awaited<ReturnType<ApiClient["getMatchById"]>>
+type ResultInspectionResult = Awaited<
+  ReturnType<ApiClient["inspectMatchWatcherResult"]>
 >;
 type WatcherState = Parameters<ApiClient["updateMatchWatcherState"]>[2];
 type MatchTrackingRenderer = ReturnType<typeof createMatchTrackingRenderer>;
@@ -51,7 +47,10 @@ type MatchWatcherProcessingContext = {
     string,
     Promise<ActiveGameInspectionResult>
   >;
-  matchesByRegionAndMatchId: Map<string, Promise<RiotMatch | null>>;
+  resultInspectionsByTargetAndMatchId: Map<
+    string,
+    Promise<ResultInspectionResult>
+  >;
 };
 type ActiveGameTargetDetail = {
   targetDiscordId: string;
@@ -79,11 +78,8 @@ export type MatchTrackingServiceApiClient = Pick<
   ApiClient,
   | "getEnabledMatchWatchers"
   | "getRiotAccount"
-  | "getMatchById"
-  | "getLeagueEntriesByPuuid"
-  | "finalizeRankSnapshots"
-  | "resolveOpggMatchDetail"
   | "inspectMatchWatcherActiveGame"
+  | "inspectMatchWatcherResult"
   | "updateMatchWatcherState"
 >;
 export type MatchTrackingServiceDependencies = {
@@ -100,7 +96,7 @@ function createMatchWatcherProcessingContext(): MatchWatcherProcessingContext {
     activeNotificationGroups: new Map(),
     riotAccountsByTargetDiscordId: new Map(),
     activeGameInspectionsByTargetAndState: new Map(),
-    matchesByRegionAndMatchId: new Map(),
+    resultInspectionsByTargetAndMatchId: new Map(),
   };
 }
 
@@ -405,86 +401,28 @@ async function inspectActiveGameForWatcher(
   return result;
 }
 
-function getMatchForPendingResult(
+async function inspectResultForWatcher(
   dependencies: MatchTrackingServiceDependencies,
   context: MatchWatcherProcessingContext,
-  account: RiotAccount,
+  watcher: MatchWatcher,
   matchId: string,
 ) {
-  const cacheKey = matchCacheKey(account, matchId);
-  const cached = context.matchesByRegionAndMatchId.get(cacheKey);
-  if (cached) return cached;
-
-  const result = dependencies.apiClient.getMatchById(account.region, matchId);
-  context.matchesByRegionAndMatchId.set(cacheKey, result);
-  return result;
-}
-
-async function finalizeRankSnapshotsForResult(
-  dependencies: MatchTrackingServiceDependencies,
-  watcher: MatchWatcher,
-  account: RiotAccount,
-  match: RiotMatch,
-): Promise<RankSummary | null> {
-  const queueType = rankedQueueTypeByQueueId(match.info.queueId);
-  if (!queueType) return null;
-
-  try {
-    const entries = await dependencies.apiClient.getLeagueEntriesByPuuid(
-      account.platform,
-      account.puuid,
+  const cacheKey = `${watcher.targetDiscordId}:${matchId}`;
+  let promise = context.resultInspectionsByTargetAndMatchId.get(cacheKey);
+  if (!promise) {
+    promise = dependencies.apiClient.inspectMatchWatcherResult(
+      watcher.guildId,
+      watcher.targetDiscordId,
+      { matchId },
     );
-    const result = await dependencies.apiClient.finalizeRankSnapshots(
-      match.metadata.matchId,
-      {
-        platform: account.platform,
-        gameId: String(match.info.gameId),
-        puuid: account.puuid,
-        snapshots: rankSnapshotPayloadsFromEntries(
-          entries,
-          dependencies.clock.now(),
-        ),
-      },
-    );
-    if (!result.success) {
-      dependencies.logger.warn("match_tracking.rank_snapshot_finalize_failed", {
-        guildId: watcher.guildId,
-        targetDiscordId: watcher.targetDiscordId,
-        matchId: match.metadata.matchId,
-        error: result.error,
-      });
-      return null;
-    }
-
-    return {
-      queueType,
-      before: result.snapshots.before.find((snapshot) =>
-        snapshot.queueType === queueType
-      ) ?? null,
-      after: result.snapshots.after.find((snapshot) =>
-        snapshot.queueType === queueType
-      ) ?? null,
-    };
-  } catch (error) {
-    dependencies.logger.warn(
-      "match_tracking.rank_snapshot_after_fetch_failed",
-      {
-        guildId: watcher.guildId,
-        targetDiscordId: watcher.targetDiscordId,
-        matchId: match.metadata.matchId,
-        error: error instanceof Error ? error.message : String(error),
-      },
-    );
-    return null;
+    context.resultInspectionsByTargetAndMatchId.set(cacheKey, promise);
   }
-}
 
-function shouldNotifyInGame(
-  watcher: MatchWatcher,
-  intervalMs: number,
-  now: Date,
-) {
-  return shouldNotifyInGameWithConfig(watcher, intervalMs, now);
+  const result = await promise;
+  if (result.success) {
+    rememberRiotAccountForWatcher(context, result.account);
+  }
+  return result;
 }
 
 function shouldNotifyActiveNotificationGroup(
@@ -498,6 +436,14 @@ function shouldNotifyActiveNotificationGroup(
     dependencies.config.inGameNotifyIntervalMs,
     dependencies.clock.now(),
   );
+}
+
+function shouldNotifyInGame(
+  watcher: MatchWatcher,
+  intervalMs: number,
+  now: Date,
+) {
+  return shouldNotifyInGameWithConfig(watcher, intervalMs, now);
 }
 
 function hasResultFetchTimedOut(
@@ -554,45 +500,6 @@ async function activeGameTargetDetails(
   return details;
 }
 
-async function resolveOpggMatchDetailForResult(
-  dependencies: MatchTrackingServiceDependencies,
-  watcher: MatchWatcher,
-  account: RiotAccount,
-  match: RiotMatch,
-) {
-  const participant = match.info.participants.find((candidate) =>
-    candidate.puuid === account.puuid
-  );
-  if (!participant) return null;
-
-  const result = await dependencies.apiClient.resolveOpggMatchDetail(
-    match.metadata.matchId,
-    {
-      targetDiscordId: watcher.targetDiscordId,
-      match: {
-        gameCreation: match.info.gameCreation,
-        gameDuration: match.info.gameDuration,
-        queueId: match.info.queueId,
-        participant: {
-          puuid: participant.puuid,
-          championId: participant.championId,
-          championName: participant.championName,
-        },
-      },
-    },
-  );
-  if (!result.success) {
-    dependencies.logger.warn("match_tracking.opgg_detail_resolve_failed", {
-      guildId: watcher.guildId,
-      targetDiscordId: watcher.targetDiscordId,
-      matchId: match.metadata.matchId,
-      error: result.error,
-    });
-    return null;
-  }
-  return result.detail;
-}
-
 async function setWatcherState(
   dependencies: MatchTrackingServiceDependencies,
   watcher: MatchWatcher,
@@ -615,7 +522,6 @@ async function setWatcherState(
 async function tryFetchAndNotifyResult(
   dependencies: MatchTrackingServiceDependencies,
   watcher: MatchWatcher,
-  account: RiotAccount,
   context: MatchWatcherProcessingContext,
   pending: PendingResult,
   currentState: WatcherState = currentStateFromWatcher(watcher),
@@ -644,12 +550,21 @@ async function tryFetchAndNotifyResult(
     return { status: "cleared" as const, messageId };
   }
 
-  const match = await getMatchForPendingResult(
+  const result = await inspectResultForWatcher(
     dependencies,
     context,
-    account,
+    watcher,
     pending.matchId,
   );
+  if (!result.success) {
+    dependencies.logger.warn("match_tracking.riot_account_not_found", {
+      guildId: watcher.guildId,
+      targetDiscordId: watcher.targetDiscordId,
+      error: result.error,
+    });
+    return { status: "pending" as const, messageId: pending.messageId };
+  }
+  const { account, match, rankSummary, opggDetail } = result;
   if (!match) {
     await setWatcherState(dependencies, watcher, {
       ...currentState,
@@ -662,18 +577,6 @@ async function tryFetchAndNotifyResult(
     return { status: "pending" as const, messageId: pending.messageId };
   }
 
-  const rankSummary = await finalizeRankSnapshotsForResult(
-    dependencies,
-    watcher,
-    account,
-    match,
-  );
-  const opggDetail = await resolveOpggMatchDetailForResult(
-    dependencies,
-    watcher,
-    account,
-    match,
-  );
   const messageId = await dependencies.notifier.sendOrEditWatcherMessage(
     watcher,
     pending.messageId,
@@ -704,23 +607,9 @@ async function processWatcher(
   const pending = pendingResultFromWatcher(watcher);
   let pendingStatus: "none" | "pending" | "cleared" = "none";
   if (pending) {
-    const accountResult = await getRiotAccountForWatcher(
-      dependencies,
-      context,
-      watcher.targetDiscordId,
-    );
-    if (!accountResult.success) {
-      dependencies.logger.warn("match_tracking.riot_account_not_found", {
-        guildId: watcher.guildId,
-        targetDiscordId: watcher.targetDiscordId,
-        error: accountResult.error,
-      });
-      return;
-    }
     const result = await tryFetchAndNotifyResult(
       dependencies,
       watcher,
-      accountResult.account,
       context,
       pending,
     );
@@ -765,7 +654,6 @@ async function processWatcher(
       await tryFetchAndNotifyResult(
         dependencies,
         watcher,
-        account,
         context,
         {
           matchId,
@@ -874,7 +762,6 @@ async function processWatcher(
     await tryFetchAndNotifyResult(
       dependencies,
       watcher,
-      account,
       context,
       {
         matchId: previousMatchId,


### PR DESCRIPTION
## 概要

- match watcher向けに `POST /match-watchers/:guildId/:targetDiscordId/tracking/result` を追加
- Match-v5取得、rank snapshot確定、OP.GG詳細解決をBackendのmatch tracking inspection serviceへ移動
- Bot側は新しいResult検査APIを呼び、Discord通知とwatcher状態更新に集中するよう整理
- API contract、Backend route/service、Bot API client、Bot serviceの各境界にテストを追加

## 背景

#106 の続きとして、試合結果取得まわりの責務をBotからBackendへ寄せました。これによりBotがRiot API、rank snapshot確定、OP.GG解決を個別に組み立てずに済み、監視処理の境界が明確になります。

## 検証

- `deno task quality`
- 関連テストで、未反映Match-v5時にrank/OP.GGを解決しないこと、Match取得後にrank/OP.GGをBackendで解決することを確認
- Bot serviceの単体テストで、`FETCHING_RESULT` がBackend Result検査を使って通知と状態更新を行うことを確認

## 残課題

- #106 の究極形である通知intent化、watcher state更新方針のBackend集約は、このPRでは未対応です。今回のPRは #107 後に残っていた Match-v5結果取得、rank snapshot finalize、OP.GG詳細解決のBackend移管を対象にしています。

Refs #106