### PR TITLE
[codex] match tracking通知intentをBackend応答へ追加

### DIFF
--- a/api/src/contract/app.ts
+++ b/api/src/contract/app.ts
@@ -23,7 +23,9 @@ import type {
   Event,
   LeagueEntry,
   MatchRankSnapshot,
+  MatchTrackingNotificationIntent,
   MatchTrackingRankSummary,
+  MatchTrackingStateTransition,
   MatchWatcher,
   OpggMatchDetail,
   RiotAccount,
@@ -130,6 +132,8 @@ const matchWatchersContractRoutes = new Hono()
       return c.json({
         account: {} as RiotAccount,
         activeGame: null as ActiveGame | null,
+        notificationIntent: null as MatchTrackingNotificationIntent | null,
+        stateTransition: null as MatchTrackingStateTransition | null,
       }, 200);
     },
   )
@@ -144,6 +148,8 @@ const matchWatchersContractRoutes = new Hono()
         match: null as RiotMatch | null,
         rankSummary: null as MatchTrackingRankSummary | null,
         opggDetail: null as OpggMatchDetail | null,
+        notificationIntent: null as MatchTrackingNotificationIntent | null,
+        stateTransition: null as MatchTrackingStateTransition | null,
       }, 200);
     },
   )

--- a/api/src/contract/models.ts
+++ b/api/src/contract/models.ts
@@ -50,7 +50,7 @@ export type MatchWatcher = {
 };
 
 export type MatchWatcherStatePatch = {
-  lastState: MatchWatcherState;
+  lastState?: MatchWatcherState;
   currentGameId?: string | null;
   currentMatchId?: string | null;
   currentNotificationMessageId?: string | null;

--- a/api/src/contract/models.ts
+++ b/api/src/contract/models.ts
@@ -49,6 +49,19 @@ export type MatchWatcher = {
   updatedAt: Date | null;
 };
 
+export type MatchWatcherStatePatch = {
+  lastState: MatchWatcherState;
+  currentGameId?: string | null;
+  currentMatchId?: string | null;
+  currentNotificationMessageId?: string | null;
+  pendingResultMatchId?: string | null;
+  pendingResultNotificationMessageId?: string | null;
+  pendingResultStartedAt?: Date | null;
+  gameStartedAt?: Date | null;
+  lastCheckedAt?: Date | null;
+  lastInGameNotifiedAt?: Date | null;
+};
+
 export type PendingMatchRankSnapshot = {
   platform: RiotPlatform;
   gameId: string;
@@ -187,4 +200,32 @@ export type LeagueEntry = {
   leaguePoints: number;
   wins: number;
   losses: number;
+};
+
+export type MatchTrackingNotificationIntent =
+  | {
+    kind: "started" | "progress";
+    activeGame: ActiveGame;
+  }
+  | {
+    kind: "resultPending";
+    matchId: string;
+  }
+  | {
+    kind: "result";
+    match: RiotMatch;
+    rankSummary: MatchTrackingRankSummary | null;
+    opggDetail: OpggMatchDetail | null;
+  }
+  | {
+    kind: "timeout";
+    matchId: string;
+  };
+
+export type MatchTrackingStateTransition = {
+  state: MatchWatcherStatePatch;
+  messageIdField:
+    | "currentNotificationMessageId"
+    | "pendingResultNotificationMessageId"
+    | null;
 };

--- a/api/src/contract/schemas.ts
+++ b/api/src/contract/schemas.ts
@@ -102,10 +102,18 @@ export const updateMatchWatcherStateSchema = z.object({
 export const inspectMatchWatcherActiveGameSchema = z.object({
   lastState: z.enum(matchWatcherStates),
   currentGameId: z.string().nullable(),
+  currentNotificationMessageId: z.string().nullable().optional(),
+  gameStartedAt: z.coerce.date().nullable().optional(),
+  lastInGameNotifiedAt: z.coerce.date().nullable().optional(),
+  notificationLastInGameNotifiedAt: z.coerce.date().nullable().optional(),
+  inGameNotifyIntervalMs: z.number().int().nonnegative().optional(),
 });
 
 export const inspectMatchWatcherResultSchema = z.object({
   matchId: z.string().min(1),
+  messageId: z.string().nullable().optional(),
+  startedAt: z.coerce.date().nullable().optional(),
+  resultFetchTimeoutMs: z.number().int().nonnegative().optional(),
 });
 
 export const platformAndPuuidSchema = z.object({

--- a/api/src/routes/match_watchers.test.ts
+++ b/api/src/routes/match_watchers.test.ts
@@ -85,7 +85,7 @@ describe("routes/match_watchers.ts", () => {
     const res = await client["match-watchers"].enabled.$get();
 
     assert(res.status === 200);
-    const body = await res.json();
+    const body = await res.json() as { watchers: unknown[] };
     assertEquals(body.watchers.length, 1);
     assertSpyCall(getStub, 0, { args: [] });
   });
@@ -119,7 +119,9 @@ describe("routes/match_watchers.ts", () => {
     });
 
     assert(res.status === 200);
-    const body = await res.json();
+    const body = await res.json() as {
+      watchers: Array<{ guildId: string }>;
+    };
     assertEquals(
       body.watchers.map((item: { guildId: string }) => item.guildId),
       [watcher.guildId],
@@ -217,13 +219,27 @@ describe("routes/match_watchers.ts", () => {
     });
 
     assertEquals(res.status, 200);
-    assertEquals(await res.json(), {
-      account: {
-        ...account,
-        createdAt: "2026-01-01T00:00:00.000Z",
-      },
-      activeGame,
+    const body = await res.json() as {
+      account: unknown;
+      activeGame: unknown;
+      notificationIntent: unknown;
+      stateTransition: {
+        messageIdField: unknown;
+        state: { lastState: unknown; currentGameId: unknown };
+      };
+    };
+    assertEquals(body.account, {
+      ...account,
+      createdAt: "2026-01-01T00:00:00.000Z",
     });
+    assertEquals(body.activeGame, activeGame);
+    assertEquals(body.notificationIntent, { kind: "started", activeGame });
+    assertEquals(
+      body.stateTransition.messageIdField,
+      "currentNotificationMessageId",
+    );
+    assertEquals(body.stateTransition.state.lastState, "IN_GAME");
+    assertEquals(body.stateTransition.state.currentGameId, "12345");
     assertSpyCall(accountStub, 0, { args: [watcher.targetDiscordId] });
     assertSpyCall(activeGameStub, 0, { args: ["jp1", "puuid-1"] });
     assertSpyCall(entriesStub, 0, { args: ["jp1", "puuid-1"] });
@@ -368,11 +384,39 @@ describe("routes/match_watchers.ts", () => {
     });
 
     assertEquals(res.status, 200);
-    assertEquals(await res.json(), {
-      account: {
-        ...account,
-        createdAt: "2026-01-01T00:00:00.000Z",
+    const body = await res.json() as {
+      account: unknown;
+      match: unknown;
+      rankSummary: unknown;
+      opggDetail: unknown;
+      notificationIntent: unknown;
+      stateTransition: {
+        messageIdField: unknown;
+        state: { pendingResultMatchId: unknown };
+      };
+    };
+    assertEquals(body.account, {
+      ...account,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    assertEquals(body.match, match);
+    assertEquals(body.rankSummary, {
+      queueType: "RANKED_SOLO_5x5",
+      before: {
+        ...beforeSnapshot,
+        fetchedAt: "2026-01-01T00:00:00.000Z",
       },
+      after: {
+        ...afterSnapshot,
+        fetchedAt: "2026-01-01T00:05:00.000Z",
+      },
+    });
+    assertEquals(body.opggDetail, {
+      ...opggDetail,
+      providerCreatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    assertEquals(body.notificationIntent, {
+      kind: "result",
       match,
       rankSummary: {
         queueType: "RANKED_SOLO_5x5",
@@ -390,6 +434,8 @@ describe("routes/match_watchers.ts", () => {
         providerCreatedAt: "2026-01-01T00:00:00.000Z",
       },
     });
+    assertEquals(body.stateTransition.messageIdField, null);
+    assertEquals(body.stateTransition.state.pendingResultMatchId, null);
     assertSpyCall(accountStub, 0, { args: [watcher.targetDiscordId] });
     assertSpyCall(matchStub, 0, { args: ["asia", "JP1_12345"] });
     assertSpyCall(entriesStub, 0, { args: ["jp1", "puuid-1"] });

--- a/api/src/routes/match_watchers.ts
+++ b/api/src/routes/match_watchers.ts
@@ -95,6 +95,8 @@ export function matchWatchersRoutes(
           return c.json({
             account: result.account,
             activeGame: result.activeGame,
+            notificationIntent: result.notificationIntent,
+            stateTransition: result.stateTransition,
           }, 200);
         } catch (error) {
           return c.json({
@@ -117,6 +119,9 @@ export function matchWatchersRoutes(
             guildId,
             targetDiscordId,
             matchId: payload.matchId,
+            messageId: payload.messageId,
+            startedAt: payload.startedAt,
+            resultFetchTimeoutMs: payload.resultFetchTimeoutMs,
           });
           if (result.status === "riot_account_not_found") {
             return c.json({ error: result.error }, 404);
@@ -126,6 +131,8 @@ export function matchWatchersRoutes(
             match: result.match,
             rankSummary: result.rankSummary,
             opggDetail: result.opggDetail,
+            notificationIntent: result.notificationIntent,
+            stateTransition: result.stateTransition,
           }, 200);
         } catch (error) {
           return c.json({

--- a/api/src/services/match_tracking.test.ts
+++ b/api/src/services/match_tracking.test.ts
@@ -144,6 +144,7 @@ describe("services/match_tracking.ts", () => {
           currentGameId: "12345",
           currentMatchId: null,
           gameStartedAt: new Date("2023-11-14T22:13:20.000Z"),
+          lastInGameNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
           lastCheckedAt: new Date("2026-01-01T00:00:00.000Z"),
         },
         messageIdField: "currentNotificationMessageId",
@@ -223,6 +224,52 @@ describe("services/match_tracking.ts", () => {
     assertEquals(calls, []);
   });
 
+  test("同じ進行中試合で通知間隔を過ぎると、progress intentと通知時刻更新用transitionを返す", async () => {
+    const service = createMatchTrackingInspectionService({
+      dbActions: {
+        getRiotAccountByDiscordId: () => Promise.resolve(account),
+        upsertPendingRankSnapshots: () => Promise.resolve(),
+        finalizeMatchRankSnapshots: () =>
+          Promise.resolve({ before: [], after: [] }),
+      },
+      riotApi: {
+        getActiveGameByPuuid: () => Promise.resolve(activeGame),
+        getLeagueEntriesByPuuid: () => Promise.resolve(entries),
+        getMatchById: () => Promise.resolve(null),
+      },
+      opggMatchDetailService: {
+        resolveAndSave: () => Promise.resolve(null),
+      },
+      logger: { warn: () => {} },
+      clock: { now: () => new Date("2026-01-01T00:10:00.000Z") },
+    });
+
+    const result = await service.inspectActiveGame({
+      guildId: "guild-1",
+      targetDiscordId: "target-1",
+      lastState: "IN_GAME",
+      currentGameId: "12345",
+      lastInGameNotifiedAt: new Date("2026-01-01T00:00:00.000Z"),
+      inGameNotifyIntervalMs: 5 * 60_000,
+    });
+
+    assertEquals(result, {
+      status: "ok",
+      account,
+      activeGame,
+      notificationIntent: { kind: "progress", activeGame },
+      stateTransition: {
+        state: {
+          lastState: "IN_GAME",
+          currentGameId: "12345",
+          lastInGameNotifiedAt: new Date("2026-01-01T00:10:00.000Z"),
+          lastCheckedAt: new Date("2026-01-01T00:10:00.000Z"),
+        },
+        messageIdField: "currentNotificationMessageId",
+      },
+    });
+  });
+
   test("結果取得待ちの試合がMatch-v5に未反映のとき、rankとOP.GGを解決せずmatch nullを返す", async () => {
     const calls: string[] = [];
     const service = createMatchTrackingInspectionService({
@@ -270,9 +317,6 @@ describe("services/match_tracking.ts", () => {
       notificationIntent: null,
       stateTransition: {
         state: {
-          lastState: "IDLE",
-          currentGameId: null,
-          currentMatchId: null,
           pendingResultMatchId: "JP1_12345",
           pendingResultNotificationMessageId: null,
           pendingResultStartedAt: null,
@@ -362,9 +406,6 @@ describe("services/match_tracking.ts", () => {
       },
       stateTransition: {
         state: {
-          lastState: "IDLE",
-          currentGameId: null,
-          currentMatchId: null,
           pendingResultMatchId: null,
           pendingResultNotificationMessageId: null,
           pendingResultStartedAt: null,

--- a/api/src/services/match_tracking.test.ts
+++ b/api/src/services/match_tracking.test.ts
@@ -133,7 +133,22 @@ describe("services/match_tracking.ts", () => {
       currentGameId: null,
     });
 
-    assertEquals(result, { status: "ok", account, activeGame });
+    assertEquals(result, {
+      status: "ok",
+      account,
+      activeGame,
+      notificationIntent: { kind: "started", activeGame },
+      stateTransition: {
+        state: {
+          lastState: "IN_GAME",
+          currentGameId: "12345",
+          currentMatchId: null,
+          gameStartedAt: new Date("2023-11-14T22:13:20.000Z"),
+          lastCheckedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+        messageIdField: "currentNotificationMessageId",
+      },
+    });
     assertEquals(calls, [
       "account:target-1",
       "activeGame:jp1:puuid-1",
@@ -188,6 +203,7 @@ describe("services/match_tracking.ts", () => {
         resolveAndSave: () => Promise.resolve(null),
       },
       logger: { warn: () => {} },
+      clock: { now: () => new Date("2026-01-01T00:05:00.000Z") },
     });
 
     const result = await service.inspectActiveGame({
@@ -197,7 +213,13 @@ describe("services/match_tracking.ts", () => {
       currentGameId: "12345",
     });
 
-    assertEquals(result, { status: "ok", account, activeGame });
+    assertEquals(result, {
+      status: "ok",
+      account,
+      activeGame,
+      notificationIntent: null,
+      stateTransition: null,
+    });
     assertEquals(calls, []);
   });
 
@@ -230,6 +252,7 @@ describe("services/match_tracking.ts", () => {
         },
       },
       logger: { warn: () => {} },
+      clock: { now: () => new Date("2026-01-01T00:05:00.000Z") },
     });
 
     const result = await service.inspectResult({
@@ -244,6 +267,19 @@ describe("services/match_tracking.ts", () => {
       match: null,
       rankSummary: null,
       opggDetail: null,
+      notificationIntent: null,
+      stateTransition: {
+        state: {
+          lastState: "IDLE",
+          currentGameId: null,
+          currentMatchId: null,
+          pendingResultMatchId: "JP1_12345",
+          pendingResultNotificationMessageId: null,
+          pendingResultStartedAt: null,
+          lastCheckedAt: new Date("2026-01-01T00:05:00.000Z"),
+        },
+        messageIdField: null,
+      },
     });
     assertEquals(calls, ["match:asia:JP1_12345"]);
   });
@@ -314,6 +350,28 @@ describe("services/match_tracking.ts", () => {
         after: afterSnapshot,
       },
       opggDetail,
+      notificationIntent: {
+        kind: "result",
+        match,
+        rankSummary: {
+          queueType: "RANKED_SOLO_5x5",
+          before: beforeSnapshot,
+          after: afterSnapshot,
+        },
+        opggDetail,
+      },
+      stateTransition: {
+        state: {
+          lastState: "IDLE",
+          currentGameId: null,
+          currentMatchId: null,
+          pendingResultMatchId: null,
+          pendingResultNotificationMessageId: null,
+          pendingResultStartedAt: null,
+          lastCheckedAt: new Date("2026-01-01T00:05:00.000Z"),
+        },
+        messageIdField: null,
+      },
     });
     assertEquals(calls, [
       "match:asia:JP1_12345",

--- a/api/src/services/match_tracking.ts
+++ b/api/src/services/match_tracking.ts
@@ -1,7 +1,9 @@
 import type {
   ActiveGame,
   LeagueEntry,
+  MatchTrackingNotificationIntent,
   MatchTrackingRankSummary,
+  MatchTrackingStateTransition,
   MatchWatcherState,
   OpggMatchDetail,
   RankSnapshotPayload,
@@ -47,12 +49,19 @@ export type InspectMatchWatcherActiveGameInput = {
   targetDiscordId: string;
   lastState: MatchWatcherState;
   currentGameId: string | null;
+  currentNotificationMessageId?: string | null;
+  gameStartedAt?: Date | null;
+  lastInGameNotifiedAt?: Date | null;
+  notificationLastInGameNotifiedAt?: Date | null;
+  inGameNotifyIntervalMs?: number;
 };
 export type InspectMatchWatcherActiveGameResult =
   | {
     status: "ok";
     account: RiotAccount;
     activeGame: ActiveGame | null;
+    notificationIntent: MatchTrackingNotificationIntent | null;
+    stateTransition: MatchTrackingStateTransition | null;
   }
   | {
     status: "riot_account_not_found";
@@ -62,6 +71,9 @@ export type InspectMatchWatcherResultInput = {
   guildId: string;
   targetDiscordId: string;
   matchId: string;
+  messageId?: string | null;
+  startedAt?: Date | null;
+  resultFetchTimeoutMs?: number;
 };
 export type InspectMatchWatcherResult =
   | {
@@ -70,6 +82,8 @@ export type InspectMatchWatcherResult =
     match: RiotMatch | null;
     rankSummary: MatchTrackingRankSummary | null;
     opggDetail: OpggMatchDetail | null;
+    notificationIntent: MatchTrackingNotificationIntent | null;
+    stateTransition: MatchTrackingStateTransition | null;
   }
   | {
     status: "riot_account_not_found";
@@ -111,6 +125,98 @@ function shouldCapturePendingRankSnapshots(
 ) {
   const currentGameId = String(activeGame.gameId);
   return input.lastState !== "IN_GAME" || input.currentGameId !== currentGameId;
+}
+
+function matchIdForGame(
+  account: Pick<RiotAccount, "platform">,
+  gameId: string,
+) {
+  return `${account.platform.toUpperCase()}_${gameId}`;
+}
+
+function shouldNotifySince(
+  lastNotifiedAt: Date | null | undefined,
+  intervalMs: number | undefined,
+  now: Date,
+) {
+  if (intervalMs === undefined) return false;
+  if (!lastNotifiedAt) return true;
+  return now.getTime() - lastNotifiedAt.getTime() >= intervalMs;
+}
+
+function isResultFetchTimedOut(
+  startedAt: Date | null | undefined,
+  timeoutMs: number | undefined,
+  now: Date,
+) {
+  if (!startedAt || timeoutMs === undefined) return false;
+  return now.getTime() - startedAt.getTime() >= timeoutMs;
+}
+
+function activeGameStateTransition(
+  input: InspectMatchWatcherActiveGameInput,
+  activeGame: ActiveGame | null,
+  account: RiotAccount,
+): {
+  notificationIntent: MatchTrackingNotificationIntent | null;
+  stateTransition: MatchTrackingStateTransition | null;
+} {
+  if (!activeGame) {
+    if (input.lastState !== "IN_GAME" || !input.currentGameId) {
+      if (input.lastState === "IDLE" && input.currentGameId === null) {
+        return { notificationIntent: null, stateTransition: null };
+      }
+      return {
+        notificationIntent: null,
+        stateTransition: {
+          state: {
+            lastState: "IDLE",
+            currentGameId: null,
+            currentNotificationMessageId: null,
+          },
+          messageIdField: null,
+        },
+      };
+    }
+
+    const matchId = matchIdForGame(account, input.currentGameId);
+    return {
+      notificationIntent: { kind: "resultPending", matchId },
+      stateTransition: {
+        state: {
+          lastState: "IDLE",
+          currentGameId: null,
+          currentMatchId: null,
+          currentNotificationMessageId: null,
+          pendingResultMatchId: matchId,
+          pendingResultStartedAt: input.gameStartedAt ?? null,
+          gameStartedAt: null,
+          lastInGameNotifiedAt: null,
+        },
+        messageIdField: "pendingResultNotificationMessageId",
+      },
+    };
+  }
+
+  const currentGameId = String(activeGame.gameId);
+  const started = input.lastState !== "IN_GAME" ||
+    input.currentGameId !== currentGameId;
+  if (started) {
+    return {
+      notificationIntent: { kind: "started", activeGame },
+      stateTransition: {
+        state: {
+          lastState: "IN_GAME",
+          currentGameId,
+          currentMatchId: null,
+          gameStartedAt: new Date(activeGame.gameStartTime),
+        },
+        messageIdField: "currentNotificationMessageId",
+      },
+    };
+  }
+
+  return { notificationIntent: null, stateTransition: null };
 }
 
 export function createMatchTrackingInspectionService(
@@ -176,10 +282,39 @@ export function createMatchTrackingInspectionService(
       await capturePendingRankSnapshots(input, account, activeGame);
     }
 
+    let { notificationIntent, stateTransition } = activeGameStateTransition(
+      input,
+      activeGame,
+      account,
+    );
+    if (
+      activeGame && !notificationIntent &&
+      shouldNotifySince(
+        input.notificationLastInGameNotifiedAt ??
+          input.lastInGameNotifiedAt,
+        input.inGameNotifyIntervalMs,
+        clock.now(),
+      )
+    ) {
+      notificationIntent = { kind: "progress", activeGame };
+      stateTransition = {
+        state: {
+          lastState: "IN_GAME",
+          currentGameId: String(activeGame.gameId),
+        },
+        messageIdField: "currentNotificationMessageId",
+      };
+    }
+    if (stateTransition) {
+      stateTransition.state.lastCheckedAt = clock.now();
+    }
+
     return {
       status: "ok",
       account,
       activeGame,
+      notificationIntent,
+      stateTransition,
     };
   }
 
@@ -278,6 +413,35 @@ export function createMatchTrackingInspectionService(
       };
     }
 
+    if (
+      isResultFetchTimedOut(
+        input.startedAt,
+        input.resultFetchTimeoutMs,
+        clock.now(),
+      )
+    ) {
+      return {
+        status: "ok",
+        account,
+        match: null,
+        rankSummary: null,
+        opggDetail: null,
+        notificationIntent: { kind: "timeout", matchId: input.matchId },
+        stateTransition: {
+          state: {
+            lastState: "IDLE",
+            currentGameId: null,
+            currentMatchId: null,
+            pendingResultMatchId: null,
+            pendingResultNotificationMessageId: null,
+            pendingResultStartedAt: null,
+            lastCheckedAt: clock.now(),
+          },
+          messageIdField: null,
+        },
+      };
+    }
+
     const match = await dependencies.riotApi.getMatchById(
       account.region,
       input.matchId,
@@ -289,6 +453,19 @@ export function createMatchTrackingInspectionService(
         match: null,
         rankSummary: null,
         opggDetail: null,
+        notificationIntent: null,
+        stateTransition: {
+          state: {
+            lastState: "IDLE",
+            currentGameId: null,
+            currentMatchId: null,
+            pendingResultMatchId: input.matchId,
+            pendingResultNotificationMessageId: input.messageId ?? null,
+            pendingResultStartedAt: input.startedAt ?? null,
+            lastCheckedAt: clock.now(),
+          },
+          messageIdField: null,
+        },
       };
     }
 
@@ -309,6 +486,24 @@ export function createMatchTrackingInspectionService(
       match,
       rankSummary,
       opggDetail,
+      notificationIntent: {
+        kind: "result",
+        match,
+        rankSummary,
+        opggDetail,
+      },
+      stateTransition: {
+        state: {
+          lastState: "IDLE",
+          currentGameId: null,
+          currentMatchId: null,
+          pendingResultMatchId: null,
+          pendingResultNotificationMessageId: null,
+          pendingResultStartedAt: null,
+          lastCheckedAt: clock.now(),
+        },
+        messageIdField: null,
+      },
     };
   }
 

--- a/api/src/services/match_tracking.ts
+++ b/api/src/services/match_tracking.ts
@@ -157,6 +157,7 @@ function activeGameStateTransition(
   input: InspectMatchWatcherActiveGameInput,
   activeGame: ActiveGame | null,
   account: RiotAccount,
+  now: Date,
 ): {
   notificationIntent: MatchTrackingNotificationIntent | null;
   stateTransition: MatchTrackingStateTransition | null;
@@ -210,6 +211,7 @@ function activeGameStateTransition(
           currentGameId,
           currentMatchId: null,
           gameStartedAt: new Date(activeGame.gameStartTime),
+          lastInGameNotifiedAt: now,
         },
         messageIdField: "currentNotificationMessageId",
       },
@@ -264,6 +266,7 @@ export function createMatchTrackingInspectionService(
   async function inspectActiveGame(
     input: InspectMatchWatcherActiveGameInput,
   ): Promise<InspectMatchWatcherActiveGameResult> {
+    const now = clock.now();
     const account = await dependencies.dbActions.getRiotAccountByDiscordId(
       input.targetDiscordId,
     );
@@ -286,6 +289,7 @@ export function createMatchTrackingInspectionService(
       input,
       activeGame,
       account,
+      now,
     );
     if (
       activeGame && !notificationIntent &&
@@ -293,7 +297,7 @@ export function createMatchTrackingInspectionService(
         input.notificationLastInGameNotifiedAt ??
           input.lastInGameNotifiedAt,
         input.inGameNotifyIntervalMs,
-        clock.now(),
+        now,
       )
     ) {
       notificationIntent = { kind: "progress", activeGame };
@@ -301,12 +305,13 @@ export function createMatchTrackingInspectionService(
         state: {
           lastState: "IN_GAME",
           currentGameId: String(activeGame.gameId),
+          lastInGameNotifiedAt: now,
         },
         messageIdField: "currentNotificationMessageId",
       };
     }
     if (stateTransition) {
-      stateTransition.state.lastCheckedAt = clock.now();
+      stateTransition.state.lastCheckedAt = now;
     }
 
     return {
@@ -403,6 +408,7 @@ export function createMatchTrackingInspectionService(
   async function inspectResult(
     input: InspectMatchWatcherResultInput,
   ): Promise<InspectMatchWatcherResult> {
+    const now = clock.now();
     const account = await dependencies.dbActions.getRiotAccountByDiscordId(
       input.targetDiscordId,
     );
@@ -417,7 +423,7 @@ export function createMatchTrackingInspectionService(
       isResultFetchTimedOut(
         input.startedAt,
         input.resultFetchTimeoutMs,
-        clock.now(),
+        now,
       )
     ) {
       return {
@@ -429,13 +435,10 @@ export function createMatchTrackingInspectionService(
         notificationIntent: { kind: "timeout", matchId: input.matchId },
         stateTransition: {
           state: {
-            lastState: "IDLE",
-            currentGameId: null,
-            currentMatchId: null,
             pendingResultMatchId: null,
             pendingResultNotificationMessageId: null,
             pendingResultStartedAt: null,
-            lastCheckedAt: clock.now(),
+            lastCheckedAt: now,
           },
           messageIdField: null,
         },
@@ -456,13 +459,10 @@ export function createMatchTrackingInspectionService(
         notificationIntent: null,
         stateTransition: {
           state: {
-            lastState: "IDLE",
-            currentGameId: null,
-            currentMatchId: null,
             pendingResultMatchId: input.matchId,
             pendingResultNotificationMessageId: input.messageId ?? null,
             pendingResultStartedAt: input.startedAt ?? null,
-            lastCheckedAt: clock.now(),
+            lastCheckedAt: now,
           },
           messageIdField: null,
         },
@@ -494,13 +494,10 @@ export function createMatchTrackingInspectionService(
       },
       stateTransition: {
         state: {
-          lastState: "IDLE",
-          currentGameId: null,
-          currentMatchId: null,
           pendingResultMatchId: null,
           pendingResultNotificationMessageId: null,
           pendingResultStartedAt: null,
-          lastCheckedAt: clock.now(),
+          lastCheckedAt: now,
         },
         messageIdField: null,
       },

--- a/bot/src/api_client.test.ts
+++ b/bot/src/api_client.test.ts
@@ -423,6 +423,58 @@ describe("apiClient", () => {
         }],
       });
     });
+
+    test("監視処理用Active Game検査のstate transitionを復元するとき、未指定の日付フィールドをnullに変換しない", async () => {
+      const account = {
+        discordId: "target-1",
+        puuid: "puuid-1",
+        gameName: "Teemo",
+        tagLine: "JP1",
+        platform: "jp1",
+        region: "asia",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: null,
+      };
+      const rpc = createRpcClientStub([
+        response({
+          account,
+          activeGame: null,
+          notificationIntent: null,
+          stateTransition: {
+            state: {
+              lastState: "IN_GAME",
+              currentGameId: "12345",
+              lastCheckedAt: "2026-01-01T00:05:00.000Z",
+            },
+            messageIdField: "currentNotificationMessageId",
+          },
+        }),
+      ]);
+      const client = createApiClient({ rpcClient: rpc.rpcClient });
+
+      const result = await client.inspectMatchWatcherActiveGame(
+        "guild-1",
+        "target-1",
+        { lastState: "IDLE", currentGameId: null },
+      );
+
+      assertEquals(result.success, true);
+      if (!result.success) return;
+      assertEquals(
+        result.stateTransition?.state.lastCheckedAt,
+        new Date(
+          "2026-01-01T00:05:00.000Z",
+        ),
+      );
+      assertEquals(
+        "gameStartedAt" in (result.stateTransition?.state ?? {}),
+        false,
+      );
+      assertEquals(
+        "lastInGameNotifiedAt" in (result.stateTransition?.state ?? {}),
+        false,
+      );
+    });
   });
 
   describe("Riot API facade", () => {

--- a/bot/src/api_clients/match_watchers.ts
+++ b/bot/src/api_clients/match_watchers.ts
@@ -1,9 +1,12 @@
 import type {
   ActiveGame,
   MatchRankSnapshot,
+  MatchTrackingNotificationIntent,
   MatchTrackingRankSummary,
+  MatchTrackingStateTransition,
   MatchWatcher,
   MatchWatcherState,
+  MatchWatcherStatePatch,
   OpggMatchDetail,
   RiotAccount,
   RiotMatch,
@@ -64,7 +67,13 @@ function parseRiotAccount(
 }
 
 export type InspectMatchWatcherActiveGameResult =
-  | { success: true; account: RiotAccount; activeGame: ActiveGame | null }
+  | {
+    success: true;
+    account: RiotAccount;
+    activeGame: ActiveGame | null;
+    notificationIntent: MatchTrackingNotificationIntent | null;
+    stateTransition: MatchTrackingStateTransition | null;
+  }
   | { success: false; error: string };
 export type InspectMatchWatcherResultResult =
   | {
@@ -73,6 +82,8 @@ export type InspectMatchWatcherResultResult =
     match: RiotMatch | null;
     rankSummary: MatchTrackingRankSummary | null;
     opggDetail: OpggMatchDetail | null;
+    notificationIntent: MatchTrackingNotificationIntent | null;
+    stateTransition: MatchTrackingStateTransition | null;
   }
   | { success: false; error: string };
 
@@ -116,6 +127,51 @@ function parseOpggMatchDetail(
   return {
     ...detail,
     providerCreatedAt: new Date(detail.providerCreatedAt),
+  };
+}
+
+function parseMatchWatcherStatePatch(
+  state: MatchWatcherStatePatch,
+): MatchWatcherStatePatch {
+  return {
+    ...state,
+    pendingResultStartedAt: dateOrNull(state.pendingResultStartedAt),
+    gameStartedAt: dateOrNull(state.gameStartedAt),
+    lastCheckedAt: dateOrNull(state.lastCheckedAt),
+    lastInGameNotifiedAt: dateOrNull(state.lastInGameNotifiedAt),
+  };
+}
+
+function parseMatchTrackingStateTransition(
+  transition:
+    | (Omit<MatchTrackingStateTransition, "state"> & {
+      state: MatchWatcherStatePatch;
+    })
+    | null,
+): MatchTrackingStateTransition | null {
+  if (!transition) return null;
+  return {
+    ...transition,
+    state: parseMatchWatcherStatePatch(transition.state),
+  };
+}
+
+function parseMatchTrackingNotificationIntent(
+  intent: MatchTrackingNotificationIntent | null,
+  parsed: {
+    match?: RiotMatch | null;
+    rankSummary?: MatchTrackingRankSummary | null;
+    opggDetail?: OpggMatchDetail | null;
+  } = {},
+): MatchTrackingNotificationIntent | null {
+  if (!intent) return null;
+  if (intent.kind !== "result") return intent;
+  if (!parsed.match) return intent;
+  return {
+    kind: "result",
+    match: parsed.match,
+    rankSummary: parsed.rankSummary ?? null,
+    opggDetail: parsed.opggDetail ?? null,
   };
 }
 
@@ -219,6 +275,11 @@ export function createMatchWatchersApiClient(
     state: {
       lastState: MatchWatcherState;
       currentGameId: string | null;
+      currentNotificationMessageId?: string | null;
+      gameStartedAt?: Date | null;
+      lastInGameNotifiedAt?: Date | null;
+      notificationLastInGameNotifiedAt?: Date | null;
+      inGameNotifyIntervalMs?: number;
     },
   ): Promise<InspectMatchWatcherActiveGameResult> {
     return await resultFromRequest(
@@ -233,10 +294,20 @@ export function createMatchWatchersApiClient(
         const body = await res.json() as {
           account: Parameters<typeof parseRiotAccount>[0];
           activeGame: ActiveGame | null;
+          notificationIntent: MatchTrackingNotificationIntent | null;
+          stateTransition: Parameters<
+            typeof parseMatchTrackingStateTransition
+          >[0];
         };
         return {
           account: parseRiotAccount(body.account),
           activeGame: body.activeGame,
+          notificationIntent: parseMatchTrackingNotificationIntent(
+            body.notificationIntent,
+          ),
+          stateTransition: parseMatchTrackingStateTransition(
+            body.stateTransition,
+          ),
         };
       },
       async (res) => {
@@ -252,7 +323,12 @@ export function createMatchWatchersApiClient(
   async function inspectMatchWatcherResult(
     guildId: string,
     targetDiscordId: string,
-    payload: { matchId: string },
+    payload: {
+      matchId: string;
+      messageId?: string | null;
+      startedAt?: Date | null;
+      resultFetchTimeoutMs?: number;
+    },
   ): Promise<InspectMatchWatcherResultResult> {
     return await resultFromRequest(
       () =>
@@ -267,12 +343,25 @@ export function createMatchWatchersApiClient(
           match: RiotMatch | null;
           rankSummary: Parameters<typeof parseMatchTrackingRankSummary>[0];
           opggDetail: Parameters<typeof parseOpggMatchDetail>[0];
+          notificationIntent: MatchTrackingNotificationIntent | null;
+          stateTransition: Parameters<
+            typeof parseMatchTrackingStateTransition
+          >[0];
         };
+        const rankSummary = parseMatchTrackingRankSummary(body.rankSummary);
+        const opggDetail = parseOpggMatchDetail(body.opggDetail);
         return {
           account: parseRiotAccount(body.account),
           match: body.match,
-          rankSummary: parseMatchTrackingRankSummary(body.rankSummary),
-          opggDetail: parseOpggMatchDetail(body.opggDetail),
+          rankSummary,
+          opggDetail,
+          notificationIntent: parseMatchTrackingNotificationIntent(
+            body.notificationIntent,
+            { match: body.match, rankSummary, opggDetail },
+          ),
+          stateTransition: parseMatchTrackingStateTransition(
+            body.stateTransition,
+          ),
         };
       },
       async (res) => {

--- a/bot/src/api_clients/match_watchers.ts
+++ b/bot/src/api_clients/match_watchers.ts
@@ -133,13 +133,20 @@ function parseOpggMatchDetail(
 function parseMatchWatcherStatePatch(
   state: MatchWatcherStatePatch,
 ): MatchWatcherStatePatch {
-  return {
-    ...state,
-    pendingResultStartedAt: dateOrNull(state.pendingResultStartedAt),
-    gameStartedAt: dateOrNull(state.gameStartedAt),
-    lastCheckedAt: dateOrNull(state.lastCheckedAt),
-    lastInGameNotifiedAt: dateOrNull(state.lastInGameNotifiedAt),
-  };
+  const parsed: MatchWatcherStatePatch = { ...state };
+  if ("pendingResultStartedAt" in state) {
+    parsed.pendingResultStartedAt = dateOrNull(state.pendingResultStartedAt);
+  }
+  if ("gameStartedAt" in state) {
+    parsed.gameStartedAt = dateOrNull(state.gameStartedAt);
+  }
+  if ("lastCheckedAt" in state) {
+    parsed.lastCheckedAt = dateOrNull(state.lastCheckedAt);
+  }
+  if ("lastInGameNotifiedAt" in state) {
+    parsed.lastInGameNotifiedAt = dateOrNull(state.lastInGameNotifiedAt);
+  }
+  return parsed;
 }
 
 function parseMatchTrackingStateTransition(

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -3704,7 +3704,7 @@ describe("match_tracking.ts", () => {
     );
   });
 
-  test("同一matchIdの結果取得待ちが複数guildにあるとき、1回の処理ではRiot試合取得を共有しつつ各guildの通知と状態更新を継続する", async () => {
+  test("同一matchIdの結果取得待ちが複数guildにあるとき、guildごとのBackend Result検査で通知と状態更新を継続する", async () => {
     const { client, editSpy } = clientWithSend();
     using _getWatchersStub = stub(
       apiClient,
@@ -3749,8 +3749,8 @@ describe("match_tracking.ts", () => {
 
     await matchTracker.processMatchWatchers(client);
 
-    assertSpyCalls(getAccountStub, 1);
-    assertSpyCalls(matchStub, 1);
+    assertSpyCalls(getAccountStub, 2);
+    assertSpyCalls(matchStub, 2);
     assertSpyCalls(editSpy, 2);
     assertSpyCalls(updateStub, 2);
     assertEquals(updateStub.calls[0].args[0], "guild-1");

--- a/bot/src/features/match_tracking.test.ts
+++ b/bot/src/features/match_tracking.test.ts
@@ -374,6 +374,8 @@ describe("match_tracking.ts", () => {
           success: true as const,
           account: accountResult.account,
           activeGame,
+          notificationIntent: null,
+          stateTransition: null,
         };
       },
     );
@@ -383,6 +385,26 @@ describe("match_tracking.ts", () => {
       async (_guildId, targetDiscordId, payload) => {
         const accountResult = await apiClient.getRiotAccount(targetDiscordId);
         if (!accountResult.success) return accountResult;
+
+        if (
+          payload.startedAt &&
+          payload.resultFetchTimeoutMs !== undefined &&
+          Date.now() - payload.startedAt.getTime() >=
+            payload.resultFetchTimeoutMs
+        ) {
+          return {
+            success: true as const,
+            account: accountResult.account,
+            match: null,
+            rankSummary: null,
+            opggDetail: null,
+            notificationIntent: {
+              kind: "timeout" as const,
+              matchId: payload.matchId,
+            },
+            stateTransition: null,
+          };
+        }
 
         const match = await apiClient.getMatchById(
           accountResult.account.region,
@@ -395,6 +417,8 @@ describe("match_tracking.ts", () => {
             match: null,
             rankSummary: null,
             opggDetail: null,
+            notificationIntent: null,
+            stateTransition: null,
           };
         }
 
@@ -480,12 +504,22 @@ describe("match_tracking.ts", () => {
           })
           : { success: true as const, detail: null };
 
+        const resolvedOpggDetail = opggDetail.success
+          ? opggDetail.detail
+          : null;
         return {
           success: true as const,
           account: accountResult.account,
           match,
           rankSummary,
-          opggDetail: opggDetail.success ? opggDetail.detail : null,
+          opggDetail: resolvedOpggDetail,
+          notificationIntent: {
+            kind: "result" as const,
+            match,
+            rankSummary,
+            opggDetail: resolvedOpggDetail,
+          },
+          stateTransition: null,
         };
       },
     );

--- a/bot/src/features/match_tracking_service.test.ts
+++ b/bot/src/features/match_tracking_service.test.ts
@@ -100,6 +100,13 @@ describe("match_tracking_service.ts", () => {
             match,
             rankSummary: null,
             opggDetail: null,
+            notificationIntent: {
+              kind: "result" as const,
+              match,
+              rankSummary: null,
+              opggDetail: null,
+            },
+            stateTransition: null,
           });
         },
         updateMatchWatcherState: (...args) => {
@@ -149,7 +156,12 @@ describe("match_tracking_service.ts", () => {
     assertEquals(resultInspectionCalls, [[
       "guild-1",
       "target-1",
-      { matchId: "JP1_12345" },
+      {
+        matchId: "JP1_12345",
+        messageId: "message-existing",
+        startedAt: new Date("2026-01-01T00:00:00Z"),
+        resultFetchTimeoutMs: 10 * 60_000,
+      },
     ]]);
     assertEquals(activeGameInspectionCalls, []);
     assertEquals(renderedMatches.length, 1);
@@ -206,6 +218,8 @@ describe("match_tracking_service.ts", () => {
               updatedAt: null,
             },
             activeGame: null,
+            notificationIntent: null,
+            stateTransition: null,
           });
         },
         inspectMatchWatcherResult: () => {

--- a/bot/src/features/match_tracking_service.test.ts
+++ b/bot/src/features/match_tracking_service.test.ts
@@ -184,6 +184,265 @@ describe("match_tracking_service.ts", () => {
     ]]);
   });
 
+  test("gameId変更後に旧試合結果が取得できたとき、BackendのResult transitionで新試合状態を消さない", async () => {
+    const stateUpdates: unknown[] = [];
+    const now = new Date("2026-01-01T00:05:00Z");
+    const targetWatcher = watcher({
+      lastState: "IN_GAME",
+      currentGameId: "12345",
+      currentNotificationMessageId: "message-active-old",
+      gameStartedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    const account = {
+      discordId: "target-1",
+      puuid: "puuid-1",
+      gameName: "Teemo",
+      tagLine: "JP1",
+      platform: "jp1" as const,
+      region: "asia" as const,
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: null,
+    };
+    const nextActiveGame = {
+      gameId: 67890,
+      gameType: "MATCHED_GAME",
+      gameStartTime: now.getTime(),
+      mapId: 11,
+      gameMode: "CLASSIC",
+      gameQueueConfigId: 420,
+      participants: [{
+        puuid: "puuid-1",
+        championId: 17,
+        teamId: 100,
+      }],
+    };
+    const previousMatch = {
+      metadata: {
+        matchId: "JP1_12345",
+        participants: ["puuid-1"],
+      },
+      info: {
+        gameId: 12345,
+        gameCreation: 1_700_000_000_000,
+        gameDuration: 1800,
+        gameMode: "CLASSIC",
+        gameType: "MATCHED_GAME",
+        mapId: 11,
+        queueId: 420,
+        participants: [{
+          puuid: "puuid-1",
+          championId: 17,
+          championName: "Teemo",
+          teamId: 100,
+          win: true,
+          kills: 10,
+          deaths: 2,
+          assists: 8,
+          totalMinionsKilled: 180,
+          neutralMinionsKilled: 12,
+          goldEarned: 12345,
+        }],
+      },
+    };
+    const service = createMatchTrackingService({
+      apiClient: {
+        getEnabledMatchWatchers: () =>
+          Promise.resolve({
+            success: true as const,
+            watchers: [targetWatcher],
+          }),
+        getRiotAccount: () =>
+          Promise.resolve({ success: true as const, account }),
+        inspectMatchWatcherActiveGame: () =>
+          Promise.resolve({
+            success: true as const,
+            account,
+            activeGame: nextActiveGame,
+            notificationIntent: {
+              kind: "started" as const,
+              activeGame: nextActiveGame,
+            },
+            stateTransition: null,
+          }),
+        inspectMatchWatcherResult: () =>
+          Promise.resolve({
+            success: true as const,
+            account,
+            match: previousMatch,
+            rankSummary: null,
+            opggDetail: null,
+            notificationIntent: {
+              kind: "result" as const,
+              match: previousMatch,
+              rankSummary: null,
+              opggDetail: null,
+            },
+            stateTransition: {
+              state: {
+                lastState: "IDLE" as const,
+                currentGameId: null,
+                currentMatchId: null,
+                pendingResultMatchId: null,
+                pendingResultNotificationMessageId: null,
+                pendingResultStartedAt: null,
+                lastCheckedAt: now,
+              },
+              messageIdField: null,
+            },
+          }),
+        updateMatchWatcherState: (...args) => {
+          stateUpdates.push(args);
+          return Promise.resolve({ success: true as const });
+        },
+      },
+      notifier: {
+        sendOrEditWatcherMessage: () => Promise.resolve("message-new"),
+      },
+      renderer: {
+        activeGame: () => Promise.resolve(new EmbedBuilder()),
+        resultPending: () => new EmbedBuilder(),
+        resultFetchTimeout: () => new EmbedBuilder(),
+        matchResult: () => Promise.resolve(new EmbedBuilder()),
+      },
+      clock: { now: () => now },
+      logger: {
+        warn: () => {},
+        error: () => {},
+      },
+      config: {
+        pollIntervalMs: 60_000,
+        inGameNotifyIntervalMs: 300_000,
+        resultFetchTimeoutMs: 10 * 60_000,
+        riotLongWindowLimit: 100,
+        riotLongWindowMs: 120_000,
+      },
+    });
+
+    await service.processMatchWatchers();
+
+    const finalState = stateUpdates.at(-1) as [
+      string,
+      string,
+      Record<string, unknown>,
+    ];
+    assertEquals(finalState[2].lastState, "IN_GAME");
+    assertEquals(finalState[2].currentGameId, "67890");
+    assertEquals(finalState[2].currentNotificationMessageId, "message-new");
+    assertEquals(finalState[2].pendingResultMatchId, null);
+  });
+
+  test("同一targetとmatchIdでもguildごとに異なるmessageIdでBackend Result検査を行う", async () => {
+    const resultInspectionCalls: unknown[] = [];
+    const targetWatchers = [
+      watcher({
+        guildId: "guild-1",
+        lastState: "FETCHING_RESULT",
+        currentMatchId: "JP1_12345",
+        currentNotificationMessageId: "message-existing-1",
+        gameStartedAt: new Date("2026-01-01T00:00:00Z"),
+      }),
+      watcher({
+        guildId: "guild-2",
+        channelId: "channel-2",
+        lastState: "FETCHING_RESULT",
+        currentMatchId: "JP1_12345",
+        currentNotificationMessageId: "message-existing-2",
+        gameStartedAt: new Date("2026-01-01T00:01:00Z"),
+      }),
+    ];
+    const account = {
+      discordId: "target-1",
+      puuid: "puuid-1",
+      gameName: "Teemo",
+      tagLine: "JP1",
+      platform: "jp1" as const,
+      region: "asia" as const,
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: null,
+    };
+    const service = createMatchTrackingService({
+      apiClient: {
+        getEnabledMatchWatchers: () =>
+          Promise.resolve({
+            success: true as const,
+            watchers: targetWatchers,
+          }),
+        getRiotAccount: () =>
+          Promise.resolve({ success: true as const, account }),
+        inspectMatchWatcherActiveGame: () => {
+          throw new Error("inspectMatchWatcherActiveGame should not be called");
+        },
+        inspectMatchWatcherResult: (...args) => {
+          resultInspectionCalls.push(args);
+          return Promise.resolve({
+            success: true as const,
+            account,
+            match: null,
+            rankSummary: null,
+            opggDetail: null,
+            notificationIntent: null,
+            stateTransition: null,
+          });
+        },
+        updateMatchWatcherState: () =>
+          Promise.resolve({ success: true as const }),
+      },
+      notifier: {
+        sendOrEditWatcherMessage: () => Promise.resolve(null),
+      },
+      renderer: {
+        activeGame: () => {
+          throw new Error("renderer.activeGame should not be called");
+        },
+        resultPending: () => {
+          throw new Error("renderer.resultPending should not be called");
+        },
+        resultFetchTimeout: () => {
+          throw new Error("renderer.resultFetchTimeout should not be called");
+        },
+        matchResult: () => {
+          throw new Error("renderer.matchResult should not be called");
+        },
+      },
+      clock: {
+        now: () => new Date("2026-01-01T00:05:00Z"),
+      },
+      logger: {
+        warn: () => {},
+        error: () => {},
+      },
+      config: {
+        pollIntervalMs: 60_000,
+        inGameNotifyIntervalMs: 300_000,
+        resultFetchTimeoutMs: 10 * 60_000,
+        riotLongWindowLimit: 100,
+        riotLongWindowMs: 120_000,
+      },
+    });
+
+    await service.processMatchWatchers();
+
+    assertEquals(resultInspectionCalls, [[
+      "guild-1",
+      "target-1",
+      {
+        matchId: "JP1_12345",
+        messageId: "message-existing-1",
+        startedAt: new Date("2026-01-01T00:00:00Z"),
+        resultFetchTimeoutMs: 10 * 60_000,
+      },
+    ], [
+      "guild-2",
+      "target-1",
+      {
+        matchId: "JP1_12345",
+        messageId: "message-existing-2",
+        startedAt: new Date("2026-01-01T00:01:00Z"),
+        resultFetchTimeoutMs: 10 * 60_000,
+      },
+    ]]);
+  });
+
   test("watcher単位処理で例外が発生したとき、後続のwatcher処理を継続する", async () => {
     const inspectionCalls: string[] = [];
     const errors: unknown[] = [];

--- a/bot/src/features/match_tracking_service.test.ts
+++ b/bot/src/features/match_tracking_service.test.ts
@@ -184,6 +184,141 @@ describe("match_tracking_service.ts", () => {
     ]]);
   });
 
+  test("BackendのResult検査がmatchだけを返す旧形式のとき、結果通知として処理してpendingを解除する", async () => {
+    const renderedMatches: unknown[] = [];
+    const notifications: unknown[] = [];
+    const stateUpdates: unknown[] = [];
+    const targetWatcher = watcher({
+      lastState: "FETCHING_RESULT",
+      currentMatchId: "JP1_12345",
+      currentNotificationMessageId: "message-existing",
+      gameStartedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    const account = {
+      discordId: "target-1",
+      puuid: "puuid-1",
+      gameName: "Teemo",
+      tagLine: "JP1",
+      platform: "jp1" as const,
+      region: "asia" as const,
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: null,
+    };
+    const match = {
+      metadata: {
+        matchId: "JP1_12345",
+        participants: ["puuid-1"],
+      },
+      info: {
+        gameId: 12345,
+        gameCreation: 1_700_000_000_000,
+        gameDuration: 1800,
+        gameMode: "CLASSIC",
+        gameType: "MATCHED_GAME",
+        mapId: 11,
+        queueId: 420,
+        participants: [{
+          puuid: "puuid-1",
+          championId: 17,
+          championName: "Teemo",
+          teamId: 100,
+          win: true,
+          kills: 10,
+          deaths: 2,
+          assists: 8,
+          totalMinionsKilled: 180,
+          neutralMinionsKilled: 12,
+          goldEarned: 12345,
+        }],
+      },
+    };
+    const service = createMatchTrackingService({
+      apiClient: {
+        getEnabledMatchWatchers: () =>
+          Promise.resolve({
+            success: true as const,
+            watchers: [targetWatcher],
+          }),
+        getRiotAccount: () => {
+          throw new Error("getRiotAccount should not be called");
+        },
+        inspectMatchWatcherActiveGame: () => {
+          throw new Error("inspectMatchWatcherActiveGame should not be called");
+        },
+        inspectMatchWatcherResult: () =>
+          Promise.resolve({
+            success: true as const,
+            account,
+            match,
+            rankSummary: null,
+            opggDetail: null,
+            notificationIntent: null,
+            stateTransition: null,
+          }),
+        updateMatchWatcherState: (...args) => {
+          stateUpdates.push(args);
+          return Promise.resolve({ success: true as const });
+        },
+      },
+      notifier: {
+        sendOrEditWatcherMessage: (...args) => {
+          notifications.push(args);
+          return Promise.resolve("message-result");
+        },
+      },
+      renderer: {
+        activeGame: () => {
+          throw new Error("renderer.activeGame should not be called");
+        },
+        resultPending: () => {
+          throw new Error("renderer.resultPending should not be called");
+        },
+        resultFetchTimeout: () => {
+          throw new Error("renderer.resultFetchTimeout should not be called");
+        },
+        matchResult: (...args) => {
+          renderedMatches.push(args);
+          return Promise.resolve(new EmbedBuilder());
+        },
+      },
+      clock: {
+        now: () => new Date("2026-01-01T00:05:00Z"),
+      },
+      logger: {
+        warn: () => {},
+        error: () => {},
+      },
+      config: {
+        pollIntervalMs: 60_000,
+        inGameNotifyIntervalMs: 300_000,
+        resultFetchTimeoutMs: 10 * 60_000,
+        riotLongWindowLimit: 100,
+        riotLongWindowMs: 120_000,
+      },
+    });
+
+    await service.processMatchWatchers();
+
+    assertEquals(renderedMatches.length, 1);
+    assertEquals(notifications.length, 1);
+    assertEquals(stateUpdates, [[
+      "guild-1",
+      "target-1",
+      {
+        lastState: "IDLE",
+        currentGameId: null,
+        currentMatchId: null,
+        currentNotificationMessageId: null,
+        pendingResultMatchId: null,
+        pendingResultNotificationMessageId: null,
+        pendingResultStartedAt: null,
+        gameStartedAt: null,
+        lastInGameNotifiedAt: null,
+        lastCheckedAt: new Date("2026-01-01T00:05:00Z"),
+      },
+    ]]);
+  });
+
   test("gameId変更後に旧試合結果が取得できたとき、BackendのResult transitionで新試合状態を消さない", async () => {
     const stateUpdates: unknown[] = [];
     const now = new Date("2026-01-01T00:05:00Z");

--- a/bot/src/features/match_tracking_service.test.ts
+++ b/bot/src/features/match_tracking_service.test.ts
@@ -331,6 +331,120 @@ describe("match_tracking_service.ts", () => {
     assertEquals(finalState[2].pendingResultMatchId, null);
   });
 
+  test("試合終了直後にpending通知IDが確定したとき、そのIDでBackendのResult検査と状態更新を行う", async () => {
+    const resultInspectionCalls: unknown[] = [];
+    const stateUpdates: unknown[] = [];
+    const now = new Date("2026-01-01T00:05:00Z");
+    const targetWatcher = watcher({
+      lastState: "IN_GAME",
+      currentGameId: "12345",
+      currentNotificationMessageId: null,
+      gameStartedAt: new Date("2026-01-01T00:00:00Z"),
+    });
+    const account = {
+      discordId: "target-1",
+      puuid: "puuid-1",
+      gameName: "Teemo",
+      tagLine: "JP1",
+      platform: "jp1" as const,
+      region: "asia" as const,
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: null,
+    };
+    const service = createMatchTrackingService({
+      apiClient: {
+        getEnabledMatchWatchers: () =>
+          Promise.resolve({
+            success: true as const,
+            watchers: [targetWatcher],
+          }),
+        getRiotAccount: () =>
+          Promise.resolve({ success: true as const, account }),
+        inspectMatchWatcherActiveGame: () =>
+          Promise.resolve({
+            success: true as const,
+            account,
+            activeGame: null,
+            notificationIntent: {
+              kind: "resultPending" as const,
+              matchId: "JP1_12345",
+            },
+            stateTransition: null,
+          }),
+        inspectMatchWatcherResult: (...args) => {
+          resultInspectionCalls.push(args);
+          return Promise.resolve({
+            success: true as const,
+            account,
+            match: null,
+            rankSummary: null,
+            opggDetail: null,
+            notificationIntent: null,
+            stateTransition: null,
+          });
+        },
+        updateMatchWatcherState: (...args) => {
+          stateUpdates.push(args);
+          return Promise.resolve({ success: true as const });
+        },
+      },
+      notifier: {
+        sendOrEditWatcherMessage: () => Promise.resolve("message-pending-new"),
+      },
+      renderer: {
+        activeGame: () => {
+          throw new Error("renderer.activeGame should not be called");
+        },
+        resultPending: () => new EmbedBuilder(),
+        resultFetchTimeout: () => new EmbedBuilder(),
+        matchResult: () => {
+          throw new Error("renderer.matchResult should not be called");
+        },
+      },
+      clock: { now: () => now },
+      logger: {
+        warn: () => {},
+        error: () => {},
+      },
+      config: {
+        pollIntervalMs: 60_000,
+        inGameNotifyIntervalMs: 300_000,
+        resultFetchTimeoutMs: 10 * 60_000,
+        riotLongWindowLimit: 100,
+        riotLongWindowMs: 120_000,
+      },
+    });
+
+    await service.processMatchWatchers();
+
+    assertEquals(resultInspectionCalls, [[
+      "guild-1",
+      "target-1",
+      {
+        matchId: "JP1_12345",
+        messageId: "message-pending-new",
+        startedAt: new Date("2026-01-01T00:00:00Z"),
+        resultFetchTimeoutMs: 10 * 60_000,
+      },
+    ]]);
+    assertEquals(stateUpdates.at(-1), [
+      "guild-1",
+      "target-1",
+      {
+        lastState: "IDLE",
+        currentGameId: null,
+        currentMatchId: null,
+        currentNotificationMessageId: null,
+        gameStartedAt: null,
+        lastInGameNotifiedAt: null,
+        pendingResultMatchId: "JP1_12345",
+        pendingResultNotificationMessageId: "message-pending-new",
+        pendingResultStartedAt: new Date("2026-01-01T00:00:00Z"),
+        lastCheckedAt: now,
+      },
+    ]);
+  });
+
   test("同一targetとmatchIdでもguildごとに異なるmessageIdでBackend Result検査を行う", async () => {
     const resultInspectionCalls: unknown[] = [];
     const targetWatchers = [

--- a/bot/src/features/match_tracking_service.ts
+++ b/bot/src/features/match_tracking_service.ts
@@ -610,7 +610,7 @@ async function tryFetchAndNotifyResult(
     });
     return { status: "cleared" as const, messageId };
   }
-  if (!match || notificationIntent?.kind !== "result") {
+  if (!match || (notificationIntent && notificationIntent.kind !== "result")) {
     await setWatcherState(dependencies, watcher, {
       ...currentState,
       ...resultTransitionStateForCurrentState(

--- a/bot/src/features/match_tracking_service.ts
+++ b/bot/src/features/match_tracking_service.ts
@@ -403,13 +403,35 @@ async function inspectActiveGameForWatcher(
   return result;
 }
 
+function resultInspectionCacheKey(
+  watcher: MatchWatcher,
+  matchId: string,
+  resultFetchTimeoutMs: number,
+) {
+  return JSON.stringify({
+    guildId: watcher.guildId,
+    targetDiscordId: watcher.targetDiscordId,
+    matchId,
+    messageId: watcher.pendingResultNotificationMessageId ??
+      watcher.currentNotificationMessageId ??
+      null,
+    startedAt: (watcher.pendingResultStartedAt ?? watcher.gameStartedAt)
+      ?.toISOString() ?? null,
+    resultFetchTimeoutMs,
+  });
+}
+
 async function inspectResultForWatcher(
   dependencies: MatchTrackingServiceDependencies,
   context: MatchWatcherProcessingContext,
   watcher: MatchWatcher,
   matchId: string,
 ) {
-  const cacheKey = `${watcher.targetDiscordId}:${matchId}`;
+  const cacheKey = resultInspectionCacheKey(
+    watcher,
+    matchId,
+    dependencies.config.resultFetchTimeoutMs,
+  );
   let promise = context.resultInspectionsByTargetAndMatchId.get(cacheKey);
   if (!promise) {
     promise = dependencies.apiClient.inspectMatchWatcherResult(
@@ -516,6 +538,23 @@ async function setWatcherState(
   }
 }
 
+function resultTransitionStateForCurrentState(
+  currentState: WatcherState,
+  state: Partial<WatcherState> | undefined,
+): Partial<WatcherState> {
+  if (!state || currentState.lastState !== "IN_GAME") return state ?? {};
+  const {
+    lastState: _lastState,
+    currentGameId: _currentGameId,
+    currentMatchId: _currentMatchId,
+    currentNotificationMessageId: _currentNotificationMessageId,
+    gameStartedAt: _gameStartedAt,
+    lastInGameNotifiedAt: _lastInGameNotifiedAt,
+    ...resultState
+  } = state;
+  return resultState;
+}
+
 async function tryFetchAndNotifyResult(
   dependencies: MatchTrackingServiceDependencies,
   watcher: MatchWatcher,
@@ -561,11 +600,15 @@ async function tryFetchAndNotifyResult(
     );
     await setWatcherState(dependencies, watcher, {
       ...currentState,
-      ...(stateTransition?.state ?? {
-        pendingResultMatchId: null,
-        pendingResultNotificationMessageId: null,
-        pendingResultStartedAt: null,
-      }),
+      ...resultTransitionStateForCurrentState(
+        currentState,
+        stateTransition
+          ?.state ?? {
+          pendingResultMatchId: null,
+          pendingResultNotificationMessageId: null,
+          pendingResultStartedAt: null,
+        },
+      ),
       currentMatchId: null,
       lastCheckedAt: dependencies.clock.now(),
     });
@@ -574,12 +617,16 @@ async function tryFetchAndNotifyResult(
   if (!match || notificationIntent?.kind !== "result") {
     await setWatcherState(dependencies, watcher, {
       ...currentState,
-      ...(stateTransition?.state ?? {
-        pendingResultMatchId: pending.matchId,
-        pendingResultNotificationMessageId: pending.messageId,
-        pendingResultStartedAt: pending.startedAt,
-        currentMatchId: null,
-      }),
+      ...resultTransitionStateForCurrentState(
+        currentState,
+        stateTransition
+          ?.state ?? {
+          pendingResultMatchId: pending.matchId,
+          pendingResultNotificationMessageId: pending.messageId,
+          pendingResultStartedAt: pending.startedAt,
+          currentMatchId: null,
+        },
+      ),
       lastCheckedAt: dependencies.clock.now(),
     });
     return { status: "pending" as const, messageId: pending.messageId };
@@ -598,12 +645,16 @@ async function tryFetchAndNotifyResult(
   );
   await setWatcherState(dependencies, watcher, {
     ...currentState,
-    ...(stateTransition?.state ?? {
-      currentMatchId: null,
-      pendingResultMatchId: null,
-      pendingResultNotificationMessageId: null,
-      pendingResultStartedAt: null,
-    }),
+    ...resultTransitionStateForCurrentState(
+      currentState,
+      stateTransition
+        ?.state ?? {
+        currentMatchId: null,
+        pendingResultMatchId: null,
+        pendingResultNotificationMessageId: null,
+        pendingResultStartedAt: null,
+      },
+    ),
     lastCheckedAt: dependencies.clock.now(),
   });
   return { status: "cleared" as const, messageId };

--- a/bot/src/features/match_tracking_service.ts
+++ b/bot/src/features/match_tracking_service.ts
@@ -405,18 +405,15 @@ async function inspectActiveGameForWatcher(
 
 function resultInspectionCacheKey(
   watcher: MatchWatcher,
-  matchId: string,
+  pending: PendingResult,
   resultFetchTimeoutMs: number,
 ) {
   return JSON.stringify({
     guildId: watcher.guildId,
     targetDiscordId: watcher.targetDiscordId,
-    matchId,
-    messageId: watcher.pendingResultNotificationMessageId ??
-      watcher.currentNotificationMessageId ??
-      null,
-    startedAt: (watcher.pendingResultStartedAt ?? watcher.gameStartedAt)
-      ?.toISOString() ?? null,
+    matchId: pending.matchId,
+    messageId: pending.messageId ?? null,
+    startedAt: pending.startedAt?.toISOString() ?? null,
     resultFetchTimeoutMs,
   });
 }
@@ -425,11 +422,11 @@ async function inspectResultForWatcher(
   dependencies: MatchTrackingServiceDependencies,
   context: MatchWatcherProcessingContext,
   watcher: MatchWatcher,
-  matchId: string,
+  pending: PendingResult,
 ) {
   const cacheKey = resultInspectionCacheKey(
     watcher,
-    matchId,
+    pending,
     dependencies.config.resultFetchTimeoutMs,
   );
   let promise = context.resultInspectionsByTargetAndMatchId.get(cacheKey);
@@ -438,10 +435,9 @@ async function inspectResultForWatcher(
       watcher.guildId,
       watcher.targetDiscordId,
       {
-        matchId,
-        messageId: watcher.pendingResultNotificationMessageId ??
-          watcher.currentNotificationMessageId,
-        startedAt: watcher.pendingResultStartedAt ?? watcher.gameStartedAt,
+        matchId: pending.matchId,
+        messageId: pending.messageId,
+        startedAt: pending.startedAt,
         resultFetchTimeoutMs: dependencies.config.resultFetchTimeoutMs,
       },
     );
@@ -566,7 +562,7 @@ async function tryFetchAndNotifyResult(
     dependencies,
     context,
     watcher,
-    pending.matchId,
+    pending,
   );
   if (!result.success) {
     dependencies.logger.warn("match_tracking.riot_account_not_found", {

--- a/bot/src/features/match_tracking_service.ts
+++ b/bot/src/features/match_tracking_service.ts
@@ -6,7 +6,6 @@ import {
   currentStateFromWatcher,
   hasResultFetchTimedOut as hasResultFetchTimedOutWithConfig,
   isAfterDate,
-  isResultFetchTimedOut as isResultFetchTimedOutWithConfig,
   matchIdForGame,
   matchIdParts,
   newerDate,
@@ -389,6 +388,9 @@ async function inspectActiveGameForWatcher(
       {
         lastState: watcher.lastState,
         currentGameId: watcher.currentGameId,
+        currentNotificationMessageId: watcher.currentNotificationMessageId,
+        gameStartedAt: watcher.gameStartedAt,
+        lastInGameNotifiedAt: watcher.lastInGameNotifiedAt,
       },
     );
     context.activeGameInspectionsByTargetAndState.set(cacheKey, promise);
@@ -413,7 +415,13 @@ async function inspectResultForWatcher(
     promise = dependencies.apiClient.inspectMatchWatcherResult(
       watcher.guildId,
       watcher.targetDiscordId,
-      { matchId },
+      {
+        matchId,
+        messageId: watcher.pendingResultNotificationMessageId ??
+          watcher.currentNotificationMessageId,
+        startedAt: watcher.pendingResultStartedAt ?? watcher.gameStartedAt,
+        resultFetchTimeoutMs: dependencies.config.resultFetchTimeoutMs,
+      },
     );
     context.resultInspectionsByTargetAndMatchId.set(cacheKey, promise);
   }
@@ -452,17 +460,6 @@ function hasResultFetchTimedOut(
   now: Date,
 ) {
   return hasResultFetchTimedOutWithConfig(watcher, timeoutMs, now);
-}
-
-function isResultFetchTimedOut(
-  dependencies: MatchTrackingServiceDependencies,
-  startedAt: Date,
-) {
-  return isResultFetchTimedOutWithConfig(
-    startedAt,
-    dependencies.config.resultFetchTimeoutMs,
-    dependencies.clock.now(),
-  );
 }
 
 async function activeGameTargetDetails(
@@ -526,30 +523,6 @@ async function tryFetchAndNotifyResult(
   pending: PendingResult,
   currentState: WatcherState = currentStateFromWatcher(watcher),
 ) {
-  if (
-    pending.startedAt && isResultFetchTimedOut(dependencies, pending.startedAt)
-  ) {
-    dependencies.logger.warn("match_tracking.fetch_result_timeout", {
-      guildId: watcher.guildId,
-      targetDiscordId: watcher.targetDiscordId,
-      matchId: pending.matchId,
-    });
-    const messageId = await dependencies.notifier.sendOrEditWatcherMessage(
-      watcher,
-      pending.messageId,
-      dependencies.renderer.resultFetchTimeout(watcher, pending.matchId),
-    );
-    await setWatcherState(dependencies, watcher, {
-      ...currentState,
-      pendingResultMatchId: null,
-      pendingResultNotificationMessageId: null,
-      pendingResultStartedAt: null,
-      currentMatchId: null,
-      lastCheckedAt: dependencies.clock.now(),
-    });
-    return { status: "cleared" as const, messageId };
-  }
-
   const result = await inspectResultForWatcher(
     dependencies,
     context,
@@ -564,14 +537,49 @@ async function tryFetchAndNotifyResult(
     });
     return { status: "pending" as const, messageId: pending.messageId };
   }
-  const { account, match, rankSummary, opggDetail } = result;
-  if (!match) {
+  const {
+    account,
+    match,
+    rankSummary,
+    opggDetail,
+    notificationIntent,
+    stateTransition,
+  } = result;
+  if (notificationIntent?.kind === "timeout") {
+    dependencies.logger.warn("match_tracking.fetch_result_timeout", {
+      guildId: watcher.guildId,
+      targetDiscordId: watcher.targetDiscordId,
+      matchId: pending.matchId,
+    });
+    const messageId = await dependencies.notifier.sendOrEditWatcherMessage(
+      watcher,
+      pending.messageId,
+      dependencies.renderer.resultFetchTimeout(
+        watcher,
+        notificationIntent.matchId,
+      ),
+    );
     await setWatcherState(dependencies, watcher, {
       ...currentState,
-      pendingResultMatchId: pending.matchId,
-      pendingResultNotificationMessageId: pending.messageId,
-      pendingResultStartedAt: pending.startedAt,
+      ...(stateTransition?.state ?? {
+        pendingResultMatchId: null,
+        pendingResultNotificationMessageId: null,
+        pendingResultStartedAt: null,
+      }),
       currentMatchId: null,
+      lastCheckedAt: dependencies.clock.now(),
+    });
+    return { status: "cleared" as const, messageId };
+  }
+  if (!match || notificationIntent?.kind !== "result") {
+    await setWatcherState(dependencies, watcher, {
+      ...currentState,
+      ...(stateTransition?.state ?? {
+        pendingResultMatchId: pending.matchId,
+        pendingResultNotificationMessageId: pending.messageId,
+        pendingResultStartedAt: pending.startedAt,
+        currentMatchId: null,
+      }),
       lastCheckedAt: dependencies.clock.now(),
     });
     return { status: "pending" as const, messageId: pending.messageId };
@@ -590,10 +598,12 @@ async function tryFetchAndNotifyResult(
   );
   await setWatcherState(dependencies, watcher, {
     ...currentState,
-    currentMatchId: null,
-    pendingResultMatchId: null,
-    pendingResultNotificationMessageId: null,
-    pendingResultStartedAt: null,
+    ...(stateTransition?.state ?? {
+      currentMatchId: null,
+      pendingResultMatchId: null,
+      pendingResultNotificationMessageId: null,
+      pendingResultStartedAt: null,
+    }),
     lastCheckedAt: dependencies.clock.now(),
   });
   return { status: "cleared" as const, messageId };
@@ -645,7 +655,17 @@ async function processWatcher(
         account,
         watcher.currentGameId,
       );
-      const matchId = matchIdForGame(account, watcher.currentGameId);
+      const resultPendingIntent = activeGameResult.notificationIntent?.kind ===
+          "resultPending"
+        ? activeGameResult.notificationIntent
+        : {
+          kind: "resultPending" as const,
+          matchId: matchIdForGame(
+            account,
+            watcher.currentGameId,
+          ),
+        };
+      const matchId = resultPendingIntent.matchId;
       const messageId = await dependencies.notifier.sendOrEditWatcherMessage(
         watcher,
         resultNotificationMessageId(activeNotificationGroup, watcher),


### PR DESCRIPTION
## 概要

Closes #106

- match tracking inspection API の応答に `notificationIntent` と `stateTransition` を追加
- Backend use case 側で `started` / `progress` / `resultPending` / `result` / `timeout` の通知種別と状態遷移方針を返すよう整理
- Bot は Backend が返した result/timeout/resultPending intent を優先しつつ、Discord送信・編集と送信後messageId反映、既存の通知統合ロジックを継続
- Active Game / Result inspection client と境界テストを追加・更新

## 背景

#107 / #108 で Riot / Match-v5 / rank snapshot / OP.GG の取得順序は Backend use case へ寄せ済みでしたが、通知種別と結果取得timeout、state更新方針の一部が Bot 側に残っていました。

このPRでは既存 endpoint を維持したまま、Backend 応答に通知 intent と state transition を含め、Bot が配送後の messageId を反映する段階移行形にしています。

## 検証

- `deno task quality` 成功