### PR TITLE
fix: Bot起動失敗のreason分類とCompose品質検証を追加する

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - name: Validate Docker Compose configuration
+        run: docker compose --env-file .env.example --profile "*" config --quiet --no-env-resolution
       - name: Set up Deno
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,7 +24,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Validate Docker Compose configuration
-        run: docker compose --env-file .env.example --profile "*" config --quiet --no-env-resolution
+        run: |
+          touch .env .env.dev
+          docker compose --env-file .env.example --profile "*" config --quiet --no-env-resolution
       - name: Set up Deno
         uses: denoland/setup-deno@v2
         with:

--- a/bot/src/deploy-commands.test.ts
+++ b/bot/src/deploy-commands.test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertFalse, assertRejects } from "@std/assert";
+import {
+  assertEquals,
+  assertFalse,
+  assertRejects,
+  assertStrictEquals,
+} from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import {
   ApplicationIntegrationType,
@@ -8,6 +13,7 @@ import {
 } from "discord.js";
 import type { Command } from "./types.ts";
 import {
+  CommandDeploymentError,
   type CommandRestClient,
   runCommandDeployment,
   runCommandDeploymentEntrypoint,
@@ -64,17 +70,18 @@ describe("slash command deployment", () => {
       }],
     };
 
-    await assertRejects(
+    const error = await assertRejects(
       () =>
         syncApplicationCommands({
           rest,
           clientId: "client-id",
           loadResult,
         }),
-      Error,
+      CommandDeploymentError,
       "Command loading failed: broken.ts (IMPORT_FAILED): failed",
     );
 
+    assertEquals(error.code, "COMMAND_LOAD_FAILED");
     assertEquals(rest.getCalls, []);
     assertEquals(rest.putCalls, []);
   });
@@ -82,17 +89,18 @@ describe("slash command deployment", () => {
   test("有効commandが0件のとき、全削除を防いでDiscord RESTを呼ばない", async () => {
     const rest = new FakeRest();
 
-    await assertRejects(
+    const error = await assertRejects(
       () =>
         syncApplicationCommands({
           rest,
           clientId: "client-id",
           loadResult: loaded(),
         }),
-      Error,
+      CommandDeploymentError,
       "No enabled commands",
     );
 
+    assertEquals(error.code, "NO_ENABLED_COMMANDS");
     assertEquals(rest.getCalls, []);
     assertEquals(rest.putCalls, []);
   });
@@ -330,22 +338,73 @@ describe("slash command deployment", () => {
     assertEquals(rest.putCalls.length, 1);
   });
 
+  test("Discord GETが失敗したとき、元の失敗をcauseに持つcurrent取得errorを返す", async () => {
+    // Arrange
+    const getFailure = new Error("raw provider response body from GET");
+    const rest: CommandRestClient = {
+      get: () => Promise.reject(getFailure),
+      put: () => Promise.resolve([]),
+    };
+
+    // Act
+    const error = await assertRejects(
+      () =>
+        syncApplicationCommands({
+          rest,
+          clientId: "client-id",
+          loadResult: loaded(command("health")),
+        }),
+      CommandDeploymentError,
+      "Failed to fetch current Discord commands",
+    );
+
+    // Assert
+    assertEquals(error.code, "DISCORD_CURRENT_FETCH_FAILED");
+    assertStrictEquals(error.cause, getFailure);
+  });
+
+  test("Discord PUTが失敗したとき、元の失敗をcauseに持つpublish errorを返す", async () => {
+    // Arrange
+    const putFailure = new Error("raw provider response body from PUT");
+    const rest: CommandRestClient = {
+      get: () => Promise.resolve([]),
+      put: () => Promise.reject(putFailure),
+    };
+
+    // Act
+    const error = await assertRejects(
+      () =>
+        syncApplicationCommands({
+          rest,
+          clientId: "client-id",
+          loadResult: loaded(command("health")),
+        }),
+      CommandDeploymentError,
+      "Failed to publish Discord commands",
+    );
+
+    // Assert
+    assertEquals(error.code, "DISCORD_PUBLISH_FAILED");
+    assertStrictEquals(error.cause, putFailure);
+  });
+
   test("DiscordのPUT応答が期待件数とnameに一致しないとき、配備成功にしない", async () => {
     const expected = command("health");
     const rest = new FakeRest([], [command("unexpected").data.toJSON()]);
 
-    await assertRejects(
+    const error = await assertRejects(
       () =>
         syncApplicationCommands({
           rest,
           clientId: "client-id",
           loadResult: loaded(expected),
         }),
-      Error,
-      "Expected: [1:health], Published: [1:unexpected], " +
-        "Added: [health], Removed: [unexpected], Updated: []",
+      CommandDeploymentError,
+      "Discord publish result validation failed",
     );
 
+    assertEquals(error.code, "PUBLISH_RESULT_VALIDATION_FAILED");
+    assertEquals(error.cause instanceof Error, true);
     assertEquals(rest.putCalls.length, 1);
   });
 
@@ -356,18 +415,73 @@ describe("slash command deployment", () => {
       [command("health", "stale description").data.toJSON()],
     );
 
-    await assertRejects(
+    const error = await assertRejects(
       () =>
         syncApplicationCommands({
           rest,
           clientId: "client-id",
           loadResult: loaded(expected),
         }),
-      Error,
-      "Added: [], Removed: [], Updated: [health]",
+      CommandDeploymentError,
+      "Discord publish result validation failed",
     );
 
+    assertEquals(error.code, "PUBLISH_RESULT_VALIDATION_FAILED");
     assertEquals(rest.putCalls.length, 1);
+  });
+
+  test("deploy設定が不足しているとき、configuration errorとして同期前に失敗する", async () => {
+    // Arrange
+    const rest = new FakeRest([]);
+
+    // Act
+    const error = await assertRejects(
+      () =>
+        runCommandDeployment({
+          env: { get: () => undefined },
+          loadCommands: () => Promise.resolve(loaded(command("health"))),
+          createRest: () => rest,
+          logger: { info() {}, warn() {}, error() {} },
+          correlationId: () => "deployment-correlation-id",
+        }),
+      CommandDeploymentError,
+      "DISCORD_TOKEN and DISCORD_CLIENT_ID are required",
+    );
+
+    // Assert
+    assertEquals(error.code, "MISSING_CONFIGURATION");
+    assertEquals(rest.getCalls, []);
+  });
+
+  test("command loaderがrejectしたとき、元の失敗をcauseに持つload errorを返す", async () => {
+    // Arrange
+    const loadFailure = new Error("raw command import failure");
+    const rest = new FakeRest([]);
+
+    // Act
+    const error = await assertRejects(
+      () =>
+        runCommandDeployment({
+          env: {
+            get(name) {
+              if (name === "DISCORD_TOKEN") return "secret-token";
+              if (name === "DISCORD_CLIENT_ID") return "client-id";
+              return undefined;
+            },
+          },
+          loadCommands: () => Promise.reject(loadFailure),
+          createRest: () => rest,
+          logger: { info() {}, warn() {}, error() {} },
+          correlationId: () => "deployment-correlation-id",
+        }),
+      CommandDeploymentError,
+      "Failed to load slash commands",
+    );
+
+    // Assert
+    assertEquals(error.code, "COMMAND_LOAD_FAILED");
+    assertStrictEquals(error.cause, loadFailure);
+    assertEquals(rest.getCalls, []);
   });
 
   test("通常のdeploy entrypointは全件load成功後だけ同期処理を実行する", async () => {
@@ -404,41 +518,131 @@ describe("slash command deployment", () => {
     assertFalse(JSON.stringify(infoEvents).includes("secret-token"));
   });
 
-  test("deploy entrypointが失敗するとき、fatalを1回記録してexitCodeを1にする", async () => {
-    const failure = new Error("deployment failed");
-    const errors: Array<{
-      event: string;
-      context?: Record<string, unknown>;
-      error?: unknown;
-    }> = [];
-    const exitCodes: number[] = [];
-    const receivedCorrelationIds: string[] = [];
-
-    await runCommandDeploymentEntrypoint({
-      runCommandDeployment: (correlationId) => {
-        receivedCorrelationIds.push(correlationId);
-        return Promise.reject(failure);
+  describe("runCommandDeploymentEntrypoint", () => {
+    const knownFailures = [
+      {
+        label: "設定不足",
+        code: "MISSING_CONFIGURATION",
+        reason: "configuration_invalid",
+        errorCategory: "validation",
       },
-      logger: {
-        info() {},
-        warn() {},
-        error(event, context, error) {
-          errors.push({ event, context, error });
-        },
-      },
-      correlationId: () => "fatal-correlation-id",
-      setExitCode: (code) => exitCodes.push(code),
-    });
-
-    assertEquals(errors, [{
-      event: "command.deploy.failed",
-      context: {
-        correlationId: "fatal-correlation-id",
+      {
+        label: "command load失敗",
+        code: "COMMAND_LOAD_FAILED",
+        reason: "command_load_failed",
         errorCategory: "unexpected",
       },
-      error: failure,
-    }]);
-    assertEquals(exitCodes, [1]);
-    assertEquals(receivedCorrelationIds, ["fatal-correlation-id"]);
+      {
+        label: "有効command空集合",
+        code: "NO_ENABLED_COMMANDS",
+        reason: "no_enabled_commands",
+        errorCategory: "validation",
+      },
+      {
+        label: "Discord current取得失敗",
+        code: "DISCORD_CURRENT_FETCH_FAILED",
+        reason: "discord_current_fetch_failed",
+        errorCategory: "remote_api",
+      },
+      {
+        label: "Discord publish失敗",
+        code: "DISCORD_PUBLISH_FAILED",
+        reason: "discord_publish_failed",
+        errorCategory: "remote_api",
+      },
+      {
+        label: "publish結果検証失敗",
+        code: "PUBLISH_RESULT_VALIDATION_FAILED",
+        reason: "publish_result_validation_failed",
+        errorCategory: "remote_api",
+      },
+    ] as const;
+
+    for (const knownFailure of knownFailures) {
+      test(`${knownFailure.label}のとき、固定reasonでfatalを記録してexitCodeを1にする`, async () => {
+        // Arrange
+        const failure = new CommandDeploymentError(
+          knownFailure.code,
+          "raw credential and provider response body",
+        );
+        const errors: Array<{
+          event: string;
+          context?: Record<string, unknown>;
+          error?: unknown;
+        }> = [];
+        const exitCodes: number[] = [];
+        const receivedCorrelationIds: string[] = [];
+
+        // Act
+        await runCommandDeploymentEntrypoint({
+          runCommandDeployment: (correlationId) => {
+            receivedCorrelationIds.push(correlationId);
+            return Promise.reject(failure);
+          },
+          logger: {
+            info() {},
+            warn() {},
+            error(event, context, error) {
+              errors.push({ event, context, error });
+            },
+          },
+          correlationId: () => "fatal-correlation-id",
+          setExitCode: (code) => exitCodes.push(code),
+        });
+
+        // Assert
+        assertEquals(errors, [{
+          event: "command.deploy.failed",
+          context: {
+            correlationId: "fatal-correlation-id",
+            errorCategory: knownFailure.errorCategory,
+            reason: knownFailure.reason,
+          },
+          error: failure,
+        }]);
+        assertFalse(
+          JSON.stringify(errors[0].context).includes("provider response body"),
+        );
+        assertEquals(exitCodes, [1]);
+        assertEquals(receivedCorrelationIds, ["fatal-correlation-id"]);
+      });
+    }
+
+    test("未知の配備例外のとき、unexpectedへfallbackしてログ記録後にexitCodeを1にする", async () => {
+      // Arrange
+      const failure = new Error("unknown deployment failure");
+      const errors: Array<{
+        event: string;
+        context?: Record<string, unknown>;
+        error?: unknown;
+      }> = [];
+      const exitCodes: number[] = [];
+
+      // Act
+      await runCommandDeploymentEntrypoint({
+        runCommandDeployment: () => Promise.reject(failure),
+        logger: {
+          info() {},
+          warn() {},
+          error(event, context, error) {
+            errors.push({ event, context, error });
+          },
+        },
+        correlationId: () => "fatal-correlation-id",
+        setExitCode: (code) => exitCodes.push(code),
+      });
+
+      // Assert
+      assertEquals(errors, [{
+        event: "command.deploy.failed",
+        context: {
+          correlationId: "fatal-correlation-id",
+          errorCategory: "unexpected",
+          reason: "unexpected",
+        },
+        error: failure,
+      }]);
+      assertEquals(exitCodes, [1]);
+    });
   });
 });

--- a/bot/src/deploy-commands.ts
+++ b/bot/src/deploy-commands.ts
@@ -31,6 +31,23 @@ export type CommandSyncResult = {
   diff: CommandDiff;
 };
 
+export class CommandDeploymentError extends Error {
+  constructor(
+    readonly code:
+      | "MISSING_CONFIGURATION"
+      | "COMMAND_LOAD_FAILED"
+      | "NO_ENABLED_COMMANDS"
+      | "DISCORD_CURRENT_FETCH_FAILED"
+      | "DISCORD_PUBLISH_FAILED"
+      | "PUBLISH_RESULT_VALIDATION_FAILED",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "CommandDeploymentError";
+  }
+}
+
 interface SyncApplicationCommandsOptions {
   rest: CommandRestClient;
   clientId: string;
@@ -230,14 +247,16 @@ export async function syncApplicationCommands(
   options: SyncApplicationCommandsOptions,
 ): Promise<CommandSyncResult> {
   if (!options.loadResult.ok) {
-    throw new Error(
+    throw new CommandDeploymentError(
+      "COMMAND_LOAD_FAILED",
       `Command loading failed: ${
         formatCommandLoadErrors(options.loadResult.errors)
       }`,
     );
   }
   if (options.loadResult.commands.length === 0) {
-    throw new Error(
+    throw new CommandDeploymentError(
+      "NO_ENABLED_COMMANDS",
       "No enabled commands; refusing to replace Discord commands",
     );
   }
@@ -256,17 +275,43 @@ export async function syncApplicationCommands(
     ? Routes.applicationGuildCommands(options.clientId, options.guildId)
     : Routes.applicationCommands(options.clientId);
 
-  const response = await options.rest.get(route);
-  if (!Array.isArray(response)) {
-    throw new Error("Discord returned an invalid command list");
+  let diff: CommandDiff;
+  try {
+    const response = await options.rest.get(route);
+    if (!Array.isArray(response)) {
+      throw new Error("Discord returned an invalid command list");
+    }
+    diff = commandDiff(response, desired, guildScoped);
+  } catch (error) {
+    throw new CommandDeploymentError(
+      "DISCORD_CURRENT_FETCH_FAILED",
+      "Failed to fetch current Discord commands",
+      { cause: error },
+    );
   }
-  const diff = commandDiff(response, desired, guildScoped);
   if (!hasDiff(diff)) {
     return { status: "unchanged", expectedNames, diff };
   }
 
-  const published = await options.rest.put(route, { body: desired });
-  validatePublishedCommands(published, desired, guildScoped);
+  let published: unknown;
+  try {
+    published = await options.rest.put(route, { body: desired });
+  } catch (error) {
+    throw new CommandDeploymentError(
+      "DISCORD_PUBLISH_FAILED",
+      "Failed to publish Discord commands",
+      { cause: error },
+    );
+  }
+  try {
+    validatePublishedCommands(published, desired, guildScoped);
+  } catch (error) {
+    throw new CommandDeploymentError(
+      "PUBLISH_RESULT_VALIDATION_FAILED",
+      "Discord publish result validation failed",
+      { cause: error },
+    );
+  }
   return { status: "updated", expectedNames, diff };
 }
 
@@ -312,11 +357,23 @@ export async function runCommandDeployment(
   const clientId = dependencies.env.get("DISCORD_CLIENT_ID");
   const guildId = dependencies.env.get("DISCORD_GUILD_ID") || undefined;
   if (!token || !clientId) {
-    throw new Error("DISCORD_TOKEN and DISCORD_CLIENT_ID are required");
+    throw new CommandDeploymentError(
+      "MISSING_CONFIGURATION",
+      "DISCORD_TOKEN and DISCORD_CLIENT_ID are required",
+    );
   }
 
   const correlationId = dependencies.correlationId();
-  const loadResult = await dependencies.loadCommands();
+  let loadResult: CommandLoadResult;
+  try {
+    loadResult = await dependencies.loadCommands();
+  } catch (error) {
+    throw new CommandDeploymentError(
+      "COMMAND_LOAD_FAILED",
+      "Failed to load slash commands",
+      { cause: error },
+    );
+  }
   const expectedCount = loadResult.ok ? loadResult.commands.length : 0;
   dependencies.logger.info("command.deploy.started", {
     correlationId,
@@ -337,6 +394,49 @@ export async function runCommandDeployment(
     diff: result.diff,
   });
   return result;
+}
+
+function classifyCommandDeploymentFailure(error: unknown): {
+  reason:
+    | "configuration_invalid"
+    | "command_load_failed"
+    | "no_enabled_commands"
+    | "discord_current_fetch_failed"
+    | "discord_publish_failed"
+    | "publish_result_validation_failed"
+    | "unexpected";
+  errorCategory: "validation" | "remote_api" | "unexpected";
+} {
+  if (!(error instanceof CommandDeploymentError)) {
+    return { reason: "unexpected", errorCategory: "unexpected" };
+  }
+
+  switch (error.code) {
+    case "MISSING_CONFIGURATION":
+      return {
+        reason: "configuration_invalid",
+        errorCategory: "validation",
+      };
+    case "COMMAND_LOAD_FAILED":
+      return { reason: "command_load_failed", errorCategory: "unexpected" };
+    case "NO_ENABLED_COMMANDS":
+      return { reason: "no_enabled_commands", errorCategory: "validation" };
+    case "DISCORD_CURRENT_FETCH_FAILED":
+      return {
+        reason: "discord_current_fetch_failed",
+        errorCategory: "remote_api",
+      };
+    case "DISCORD_PUBLISH_FAILED":
+      return {
+        reason: "discord_publish_failed",
+        errorCategory: "remote_api",
+      };
+    case "PUBLISH_RESULT_VALIDATION_FAILED":
+      return {
+        reason: "publish_result_validation_failed",
+        errorCategory: "remote_api",
+      };
+  }
 }
 
 const defaultEntrypointDependencies: CommandDeploymentEntrypointDependencies = {
@@ -360,11 +460,13 @@ export async function runCommandDeploymentEntrypoint(
   try {
     await dependencies.runCommandDeployment(correlationId);
   } catch (error) {
+    const failure = classifyCommandDeploymentFailure(error);
     dependencies.logger.error(
       "command.deploy.failed",
       {
         correlationId,
-        errorCategory: "unexpected",
+        errorCategory: failure.errorCategory,
+        reason: failure.reason,
       },
       error,
     );

--- a/bot/src/main.test.ts
+++ b/bot/src/main.test.ts
@@ -96,22 +96,52 @@ describe("Main Bot Logic", () => {
       assertStrictEquals(startupClient.commands, existing);
     });
 
-    test("Discord loginがrejectしたとき、startup promiseもrejectする", async () => {
+    test("command loaderがrejectしたとき、元の失敗をcauseに持つ型付きstartup errorを返す", async () => {
+      // Arrange
+      const loadFailure = new Error("raw command import failure");
+      const startupClient = {
+        commands: new Collection<string, Command>(),
+        login: () => Promise.resolve("token"),
+      };
+
+      // Act
+      const error = await assertRejects(
+        () =>
+          startBot({
+            env: validEnv,
+            client: startupClient as never,
+            loadCommands: () => Promise.reject(loadFailure),
+          }),
+        BotStartupError,
+        "Failed to load slash commands",
+      );
+
+      // Assert
+      assertEquals(error.code, "COMMAND_LOAD_FAILED");
+      assertStrictEquals(error.cause, loadFailure);
+      assertEquals(startupClient.commands.size, 0);
+    });
+
+    test("Discord loginがrejectしたとき、元の失敗をcauseに持つ型付きstartup errorを返す", async () => {
       const loginError = new Error("Discord authentication failed");
       const startupClient = {
         commands: new Collection<string, Command>(),
         login: () => Promise.reject(loginError),
       };
 
-      const error = await assertRejects(() =>
-        startBot({
-          env: validEnv,
-          client: startupClient as never,
-          loadCommands: () => Promise.resolve({ ok: true, commands: [] }),
-        })
+      const error = await assertRejects(
+        () =>
+          startBot({
+            env: validEnv,
+            client: startupClient as never,
+            loadCommands: () => Promise.resolve({ ok: true, commands: [] }),
+          }),
+        BotStartupError,
+        "Discord login failed",
       );
 
-      assertStrictEquals(error, loginError);
+      assertEquals(error.code, "DISCORD_LOGIN_FAILED");
+      assertStrictEquals(error.cause, loginError);
     });
 
     test("loginが完了するまでstartup promiseを完了扱いにしない", async () => {
@@ -159,38 +189,111 @@ describe("Main Bot Logic", () => {
     });
   });
 
-  test("entrypointでstartupが失敗するとき、fatalを1回記録してexitCodeを1にする", async () => {
-    const failure = new BotStartupError(
-      "MISSING_CONFIGURATION",
-      "DISCORD_TOKEN is required",
-    );
-    const errors: Array<{
-      event: string;
-      context?: Record<string, unknown>;
-      error?: unknown;
-    }> = [];
-    const exitCodes: number[] = [];
-
-    await runBotEntrypoint({
-      startBot: () => Promise.reject(failure),
-      logger: {
-        error(event, context, error) {
-          errors.push({ event, context, error });
-        },
-      },
-      correlationId: () => "startup-correlation-id",
-      setExitCode: (code) => exitCodes.push(code),
-    });
-
-    assertEquals(errors, [{
-      event: "bot.start.failed",
-      context: {
-        correlationId: "startup-correlation-id",
+  describe("runBotEntrypoint", () => {
+    const knownFailures = [
+      {
+        label: "設定不足",
+        code: "MISSING_CONFIGURATION",
+        reason: "configuration_invalid",
         errorCategory: "validation",
       },
-      error: failure,
-    }]);
-    assertEquals(exitCodes, [1]);
+      {
+        label: "service credential不正",
+        code: "INVALID_SERVICE_CREDENTIAL",
+        reason: "service_credential_invalid",
+        errorCategory: "validation",
+      },
+      {
+        label: "command load失敗",
+        code: "COMMAND_LOAD_FAILED",
+        reason: "command_load_failed",
+        errorCategory: "unexpected",
+      },
+      {
+        label: "Discord login失敗",
+        code: "DISCORD_LOGIN_FAILED",
+        reason: "discord_login_failed",
+        errorCategory: "remote_api",
+      },
+    ] as const;
+
+    for (const knownFailure of knownFailures) {
+      test(`${knownFailure.label}のとき、固定reasonでfatalを記録してexitCodeを1にする`, async () => {
+        // Arrange
+        const failure = new BotStartupError(
+          knownFailure.code,
+          "raw credential and provider response body",
+        );
+        const errors: Array<{
+          event: string;
+          context?: Record<string, unknown>;
+          error?: unknown;
+        }> = [];
+        const exitCodes: number[] = [];
+
+        // Act
+        await runBotEntrypoint({
+          startBot: () => Promise.reject(failure),
+          logger: {
+            error(event, context, error) {
+              errors.push({ event, context, error });
+            },
+          },
+          correlationId: () => "startup-correlation-id",
+          setExitCode: (code) => exitCodes.push(code),
+        });
+
+        // Assert
+        assertEquals(errors, [{
+          event: "bot.start.failed",
+          context: {
+            correlationId: "startup-correlation-id",
+            errorCategory: knownFailure.errorCategory,
+            reason: knownFailure.reason,
+          },
+          error: failure,
+        }]);
+        assertFalse(
+          JSON.stringify(errors[0].context).includes("provider response body"),
+        );
+        assertEquals(exitCodes, [1]);
+      });
+    }
+
+    test("未知のstartup例外のとき、unexpectedへfallbackしてログ記録後にexitCodeを1にする", async () => {
+      // Arrange
+      const failure = new Error("unknown failure with raw credential");
+      const errors: Array<{
+        event: string;
+        context?: Record<string, unknown>;
+        error?: unknown;
+      }> = [];
+      const exitCodes: number[] = [];
+
+      // Act
+      await runBotEntrypoint({
+        startBot: () => Promise.reject(failure),
+        logger: {
+          error(event, context, error) {
+            errors.push({ event, context, error });
+          },
+        },
+        correlationId: () => "startup-correlation-id",
+        setExitCode: (code) => exitCodes.push(code),
+      });
+
+      // Assert
+      assertEquals(errors, [{
+        event: "bot.start.failed",
+        context: {
+          correlationId: "startup-correlation-id",
+          errorCategory: "unexpected",
+          reason: "unexpected",
+        },
+        error: failure,
+      }]);
+      assertEquals(exitCodes, [1]);
+    });
   });
 
   describe("handleInteractionCreate", () => {

--- a/bot/src/main.ts
+++ b/bot/src/main.ts
@@ -264,7 +264,8 @@ export class BotStartupError extends Error {
     readonly code:
       | "MISSING_CONFIGURATION"
       | "INVALID_SERVICE_CREDENTIAL"
-      | "COMMAND_LOAD_FAILED",
+      | "COMMAND_LOAD_FAILED"
+      | "DISCORD_LOGIN_FAILED",
     message: string,
     options?: ErrorOptions,
   ) {
@@ -348,7 +349,16 @@ export async function startBot(
     );
   }
 
-  const loadResult = await dependencies.loadCommands();
+  let loadResult: Awaited<ReturnType<typeof loadCommands>>;
+  try {
+    loadResult = await dependencies.loadCommands();
+  } catch (error) {
+    throw new BotStartupError(
+      "COMMAND_LOAD_FAILED",
+      "Failed to load slash commands",
+      { cause: error },
+    );
+  }
   if (!loadResult.ok) {
     throw new BotStartupError(
       "COMMAND_LOAD_FAILED",
@@ -368,7 +378,46 @@ export async function startBot(
     publicRpcClient,
   }));
   dependencies.client.commands = nextCommands;
-  await dependencies.client.login(discordToken);
+  try {
+    await dependencies.client.login(discordToken);
+  } catch (error) {
+    throw new BotStartupError(
+      "DISCORD_LOGIN_FAILED",
+      "Discord login failed",
+      { cause: error },
+    );
+  }
+}
+
+function classifyBotStartupFailure(error: unknown): {
+  reason:
+    | "configuration_invalid"
+    | "service_credential_invalid"
+    | "command_load_failed"
+    | "discord_login_failed"
+    | "unexpected";
+  errorCategory: "validation" | "remote_api" | "unexpected";
+} {
+  if (!(error instanceof BotStartupError)) {
+    return { reason: "unexpected", errorCategory: "unexpected" };
+  }
+
+  switch (error.code) {
+    case "MISSING_CONFIGURATION":
+      return {
+        reason: "configuration_invalid",
+        errorCategory: "validation",
+      };
+    case "INVALID_SERVICE_CREDENTIAL":
+      return {
+        reason: "service_credential_invalid",
+        errorCategory: "validation",
+      };
+    case "COMMAND_LOAD_FAILED":
+      return { reason: "command_load_failed", errorCategory: "unexpected" };
+    case "DISCORD_LOGIN_FAILED":
+      return { reason: "discord_login_failed", errorCategory: "remote_api" };
+  }
 }
 
 const defaultEntrypointDependencies: BotEntrypointDependencies = {
@@ -387,14 +436,13 @@ export async function runBotEntrypoint(
   try {
     await dependencies.startBot();
   } catch (error) {
+    const failure = classifyBotStartupFailure(error);
     dependencies.logger.error(
       "bot.start.failed",
       {
         correlationId,
-        errorCategory: error instanceof BotStartupError &&
-            error.code !== "COMMAND_LOAD_FAILED"
-          ? "validation"
-          : "unexpected",
+        errorCategory: failure.errorCategory,
+        reason: failure.reason,
       },
       error,
     );

--- a/scripts/quality-configuration.test.ts
+++ b/scripts/quality-configuration.test.ts
@@ -1,40 +1,39 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertFalse,
+  assertStringIncludes,
+} from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
 import { parse } from "@std/yaml";
 
 const root = new URL("../", import.meta.url);
 
+interface WorkflowStep {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+}
+
+interface WorkflowJob {
+  name?: string;
+  permissions?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
 interface QualityWorkflow {
   on: {
-    pull_request: null;
-    push: {
-      branches: string[];
-    };
+    pull_request?: unknown;
+    push?: { branches?: string[] };
+    [event: string]: unknown;
   };
-  permissions: {
-    contents: string;
-  };
-  concurrency: {
-    group: string;
-    "cancel-in-progress": boolean;
-  };
-  jobs: {
-    quality: {
-      name: string;
-      "runs-on": string;
-      "timeout-minutes": number;
-      steps: Array<{
-        name: string;
-        uses?: string;
-        run?: string;
-        with?: Record<string, unknown>;
-      }>;
-    };
-  };
+  permissions: Record<string, string>;
+  jobs: Record<string, WorkflowJob>;
 }
 
 describe("quality workflow", () => {
-  test("Pull Requestとmain pushのとき、固定job qualityがfrozen lockfileで品質確認を実行する", async () => {
+  test("Pull Requestとmain pushのとき、read-onlyのquality jobが固定Denoで品質確認を実行する", async () => {
     // Arrange
     const workflow = parse(
       await Deno.readTextFile(
@@ -44,45 +43,69 @@ describe("quality workflow", () => {
 
     // Act
     const quality = workflow.jobs.quality;
-    const usesSecret = JSON.stringify(workflow).includes("secrets.");
+    const steps = quality?.steps ?? [];
+    const denoSetup = steps.find((step) =>
+      step.uses?.startsWith("denoland/setup-deno@")
+    );
+    const frozenInstallIndex = steps.findIndex((step) =>
+      /\bdeno install\b[^\n]*--frozen(?:=true)?(?:\s|$)/.test(step.run ?? "")
+    );
+    const qualityIndex = steps.findIndex((step) =>
+      step.run?.split(/\r?\n/).some((line) =>
+        line.trim() === "deno task quality"
+      )
+    );
+    const serialized = JSON.stringify(workflow);
 
     // Assert
-    assertEquals(workflow.on, {
-      pull_request: null,
-      push: { branches: ["main"] },
-    });
-    assertEquals(workflow.permissions, { contents: "read" });
-    assertEquals(workflow.concurrency, {
-      group: "${{ github.workflow }}-${{ github.ref }}",
-      "cancel-in-progress": true,
-    });
-    assertEquals(quality.name, "quality");
-    assertEquals(quality["runs-on"], "ubuntu-latest");
-    assertEquals(quality["timeout-minutes"], 15);
-    assertEquals(quality.steps, [
-      {
-        name: "Checkout repository",
-        uses: "actions/checkout@v7",
-        with: { "persist-credentials": false },
-      },
-      {
-        name: "Set up Deno",
-        uses: "denoland/setup-deno@v2",
-        with: {
-          "deno-version-file": ".dvmrc",
-          cache: true,
-        },
-      },
-      {
-        name: "Install locked dependencies",
-        run: "deno install --frozen=true",
-      },
-      {
-        name: "Run quality checks",
-        run: "deno task quality",
-      },
-    ]);
-    assertEquals(usesSecret, false);
+    assert("pull_request" in workflow.on);
+    assert(workflow.on.push?.branches?.includes("main"));
+    assert(quality);
+    assertEquals(quality.name ?? "quality", "quality");
+    assertEquals(workflow.permissions.contents, "read");
+    assertFalse(Object.values(workflow.permissions).includes("write"));
+    assertFalse(Object.values(quality.permissions ?? {}).includes("write"));
+    assertEquals(denoSetup?.with?.["deno-version-file"], ".dvmrc");
+    assert(frozenInstallIndex >= 0);
+    assert(qualityIndex > frozenInstallIndex);
+    assertFalse(/"secrets":|\$\{\{[^}]*\bsecrets\b/.test(serialized));
+    assertFalse(serialized.includes("test:riot-live"));
+    assertFalse(serialized.includes("RIOT_LIVE_TEST"));
+    assertFalse(serialized.includes("riot_api.live.test.ts"));
+  });
+
+  test("quality jobを実行するとき、secretやservice起動なしで全Compose profileをparseする", async () => {
+    // Arrange
+    const workflow = parse(
+      await Deno.readTextFile(
+        new URL(".github/workflows/quality.yml", root),
+      ),
+    ) as unknown as QualityWorkflow;
+
+    // Act
+    const runCommands = (workflow.jobs.quality?.steps ?? [])
+      .map((step) => step.run ?? "")
+      .join("\n");
+    const composeCommand =
+      runCommands.split(/\r?\n/).find((line) =>
+        line.trimStart().startsWith("docker compose ") &&
+        line.includes(" config")
+      ) ?? "";
+
+    // Assert
+    assertStringIncludes(composeCommand, "--env-file .env.example");
+    assert(/--profile\s+(?:"\*"|'\*'|\*)/.test(composeCommand));
+    assertStringIncludes(composeCommand, "config");
+    assertStringIncludes(composeCommand, "--quiet");
+    assertStringIncludes(composeCommand, "--no-env-resolution");
+    assertFalse(
+      /\bdocker[^\n]*\b(?:build|buildx|pull)\b/.test(runCommands),
+    );
+    assertFalse(
+      /\bdocker compose[^\n]*\b(?:create|restart|run|start|up)\b/.test(
+        runCommands,
+      ),
+    );
   });
 });
 

--- a/scripts/quality-configuration.test.ts
+++ b/scripts/quality-configuration.test.ts
@@ -85,14 +85,24 @@ describe("quality workflow", () => {
     // Act
     const runCommands = (workflow.jobs.quality?.steps ?? [])
       .map((step) => step.run ?? "")
-      .join("\n");
-    const composeCommand =
-      runCommands.split(/\r?\n/).find((line) =>
-        line.trimStart().startsWith("docker compose ") &&
-        line.includes(" config")
-      ) ?? "";
+      .join("\n")
+      .replace(/\\\r?\n/g, " ");
+    const commandLines = runCommands.split(/\r?\n/);
+    const envPlaceholderIndex = commandLines.findIndex((line) => {
+      const commandParts = line.trim().split(/\s+/);
+      return commandParts[0] === "touch" &&
+        commandParts.includes(".env") &&
+        commandParts.includes(".env.dev");
+    });
+    const composeCommandIndex = commandLines.findIndex((line) =>
+      line.trimStart().startsWith("docker compose ") &&
+      line.includes(" config")
+    );
+    const composeCommand = commandLines[composeCommandIndex] ?? "";
 
     // Assert
+    assert(envPlaceholderIndex >= 0);
+    assert(composeCommandIndex > envPlaceholderIndex);
     assertStringIncludes(composeCommand, "--env-file .env.example");
     assert(/--profile\s+(?:"\*"|'\*'|\*)/.test(composeCommand));
     assertStringIncludes(composeCommand, "config");


### PR DESCRIPTION
## 概要

- Bot起動とslash command配備の失敗を、固定された`reason`と適切な`errorCategory`で識別できるようにする
- quality workflowのconfiguration testを要求上の不変条件だけへ絞る
- secret・image build・service起動なしで全Docker Compose profileをparseするCI検証を追加する

## 背景・原因

shared loggerはADR 0002に従いraw `Error.message`やstack、任意のError propertyを保存しないため、従来の起動・配備ログだけでは失敗段階を判別できませんでした。またquality workflowのテストはstep配列全体を複製しており、表示名やaction versionなど契約外の変更にも追従が必要でした。

## 変更内容

### #136

- Bot起動を設定、service credential、command load、Discord loginの固定reasonへ分類
- command配備を設定、command load、空集合拒否、Discord current取得、publish、publish結果検証の固定reasonへ分類
- 元のErrorを`cause`またはlogger第3引数で維持し、structured contextにはraw message、stack、credential、provider bodyを追加しない
- 未知例外を`unexpected`へfallbackし、ログ記録後にexit code 1を設定
- 各failure pathとsafe contextをテスト

### #137

- PR/main trigger、read-only permissions、stable quality job、`.dvmrc`、frozen install後のquality実行、secret/live test不使用だけをconfiguration testで検査
- step表示名、runner、timeout、action version、配列全体の完全一致を廃止
- CIでgitignore対象の`.env`と`.env.dev`を空のplaceholderとして一時作成し、`.env.example`と`--no-env-resolution`を使って全profileを`docker compose config --quiet`で検証
- workflow testをYAMLの複数行commandにも耐える形にし、placeholder作成がCompose検証より前であることを検査
- image build/pullやcontainer/service起動をworkflow testで拒否

## 影響

本番ログから主要failure stageを安全に判別でき、workflowの契約を変えない保守変更でconfiguration testが壊れにくくなります。通常CIは外部serviceやrepository secretへ接続しません。

## 検証

- `deno task quality`: 56 tests / 496 steps、成功
- 空の`.env` / `.env.dev`だけを置いた一時project directoryで全Compose profileのparseに成功
- `git diff --check`: 成功
- GitHub Actions `quality`: 成功（[run 29650463414](https://github.com/akgm3i/ADTeemo/actions/runs/29650463414)）

## リスク

Compose検証は設定のparseだけを対象とし、image build、container起動、実service間接続までは検証しません。

Closes #136
Closes #137