### PR TITLE
test(db): migration適用済みSQLiteでrepository統合テストを整備する

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,8 @@ Backend APIは既定で `http://localhost:8000` に公開されます。
 | `db:generate`           | Drizzle migrationを生成します。                                               |
 | `db:migrate`            | Drizzle migrationを適用します。                                               |
 
+`test:all` と `test:target` は、migration済み一時SQLite fileを作るrepository integration testのため `--allow-read`、`--allow-write`、`--allow-sys`、`--allow-ffi` を指定します。外部サービスへ接続する `--allow-net` は持たず、GitHub Actionsの `quality` も同じroot taskを実行します。
+
 ## Docker
 
 ### Development

--- a/TESTING_STYLE.md
+++ b/TESTING_STYLE.md
@@ -12,7 +12,7 @@
 deno task test:all
 ```
 
-`test:all` は `.env.example` を読み込み、coverage を出力します。Docker 内で同じ検証を行う場合は次を使います。
+`test:all` は `.env.example` を読み込み、coverage を出力します。一時SQLite DBを使うrepository integration testのため、通常テストtaskはread/write/sys/ffi権限を持ちますが、network権限は持ちません。Docker 内で同じ検証を行う場合は次を使います。
 
 対象を絞る場合も、秘密情報を含む `.env` ではなく `.env.example` を読むtaskを使います。
 
@@ -26,16 +26,17 @@ docker compose --profile dev run --rm dev deno task test:all
 
 ## 2. テスト分類
 
-| 分類            | 対象                                        | 配置                               | 主な依存の扱い                                             |
-| --------------- | ------------------------------------------- | ---------------------------------- | ---------------------------------------------------------- |
-| Unit            | 純粋関数、helper、formatter、ロール管理など | 対象ファイルと同階層の `*.test.ts` | 直接依存のみ stub / spy                                    |
-| Hono route      | API route handler                           | `api/src/routes/*.test.ts`         | DB action、Riot API、RSO などを stub                       |
-| Bot command     | slash command handler                       | `bot/src/commands/*.test.ts`       | `apiClient`、messages、helper を stub                      |
-| API client      | Bot の API 境界                             | `bot/src/api_client.test.ts`       | 注入したHono RPC clientの呼び出しをstub / fake             |
-| DB action       | Drizzle query / transaction                 | `api/src/db/actions.test.ts`       | `createDb` で接続先を分離し、一時SQLite DBまたはfakeを使用 |
-| Integration     | Bot / API / DB の連携                       | 将来 `tests/integration/`          | Discord / Riot など外部サービスは mock                     |
-| Live external   | 実際の Riot API 疎通                        | `api/src/*.live.test.ts`           | 明示 opt-in。通常の `test:all` では skip                   |
-| Message catalog | 多言語メッセージ整合性                      | `messages/src/*.test.ts`           | 一時ディレクトリや環境変数を stub                          |
+| 分類                   | 対象                                        | 配置                               | 主な依存の扱い                                 |
+| ---------------------- | ------------------------------------------- | ---------------------------------- | ---------------------------------------------- |
+| Unit                   | 純粋関数、helper、formatter、ロール管理など | 対象ファイルと同階層の `*.test.ts` | 直接依存のみ stub / spy                        |
+| Hono route             | API route handler                           | `api/src/routes/*.test.ts`         | DB action、Riot API、RSO などを stub           |
+| Bot command            | slash command handler                       | `bot/src/commands/*.test.ts`       | `apiClient`、messages、helper を stub          |
+| API client             | Bot の API 境界                             | `bot/src/api_client.test.ts`       | 注入したHono RPC clientの呼び出しをstub / fake |
+| DB action              | 設定値、純粋なdomain分岐                    | `api/src/db/actions.test.ts`       | DB query chainは模倣せず、直接依存だけをfake化 |
+| Repository integration | migration、制約、transaction、repository    | `api/src/db/*.integration.test.ts` | migration済みのテスト別一時SQLite DBを使用     |
+| Integration            | Bot / API / DB の連携                       | 将来 `tests/integration/`          | Discord / Riot など外部サービスは mock         |
+| Live external          | 実際の Riot API 疎通                        | `api/src/*.live.test.ts`           | 明示 opt-in。通常の `test:all` では skip       |
+| Message catalog        | 多言語メッセージ整合性                      | `messages/src/*.test.ts`           | 一時ディレクトリや環境変数を stub              |
 
 ## 3. Deno とテストライブラリ
 
@@ -310,9 +311,11 @@ type ApiClientResult<T> =
 
 `api/src/db/index.ts` の `createDb({ url, logger })` はDB接続、Drizzle DB、`close` を返します。`createDbActions(db, config)` は接続と設定を引数で受け取り、default connection / actionsはcomposition rootで生成されます。
 
-`api/src/db/actions.test.ts` では、`file::memory:` の接続をテストごとに生成して接続先の分離を検証し、transactionの順序やTTLなどDB action固有の分岐にはfake transactionも使います。実DBを使うテストでは接続を終了し、テスト間で状態を共有しません。
+Repositoryの永続化動作は `api/src/db/integration_test_harness.ts` の `createMigratedTestDatabase` を使います。harnessはテストごとに隔離した一時SQLite fileを作り、productionと同じ `createDb`、全migration、`createDbActions` を順に適用します。`await using` または `dispose` でnative clientを閉じ、一時directoryを確実に削除してください。
 
-route testでは `createApp({ dbActions })` へテスト用actionを注入し、DB action自体を検証する場合以外はDB実体へ触れません。
+Migration自体の検証は `migrations.integration.test.ts`、migration適用後のrepository動作は `repositories.integration.test.ts` に分けます。後者ではquery builderの呼出順ではなく、commit後のtable状態、foreign key、unique、cascade、rollback、再操作可能性をassertします。`actions.test.ts` のunit testは環境設定やDBを必要としない分岐に限定し、Drizzle chainを再実装するfakeは追加しません。
+
+このharnessは #113/#114/#117 のreal Hono appを使う縦断テストでも再利用し、`actions` をapplicationへ注入できます。route単体の責務だけを検証する場合は従来どおりDB実体を使わず、`createApp({ dbActions })` へ直接依存のstubを渡します。
 
 DB action 以外の route test では、DB 実体に触れず `dbActions` を stub してください。
 

--- a/TESTING_STYLE.md
+++ b/TESTING_STYLE.md
@@ -311,7 +311,7 @@ type ApiClientResult<T> =
 
 `api/src/db/index.ts` の `createDb({ url, logger })` はDB接続、Drizzle DB、`close` を返します。`createDbActions(db, config)` は接続と設定を引数で受け取り、default connection / actionsはcomposition rootで生成されます。
 
-Repositoryの永続化動作は `api/src/db/integration_test_harness.ts` の `createMigratedTestDatabase` を使います。harnessはテストごとに隔離した一時SQLite fileを作り、productionと同じ `createDb`、全migration、`createDbActions` を順に適用します。`await using` または `dispose` でnative clientを閉じ、一時directoryを確実に削除してください。
+Repositoryの永続化動作は `api/src/db/integration_test_harness.ts` の `createMigratedTestDatabase` を使います。harnessはテストごとに隔離した一時SQLite fileを作り、productionと同じ `createDb`、全migration、`createDbActions` を順に適用します。Migration後はproduction接続と同じくforeign key enforcementが有効であることを検証し、test側だけのPRAGMA設定でproductionとの差を隠しません。`await using` または `dispose` でnative clientを閉じ、一時directoryを確実に削除してください。
 
 Migration自体の検証は `migrations.integration.test.ts`、migration適用後のrepository動作は `repositories.integration.test.ts` に分けます。後者ではquery builderの呼出順ではなく、commit後のtable状態、foreign key、unique、cascade、rollback、再操作可能性をassertします。`actions.test.ts` のunit testは環境設定やDBを必要としない分岐に限定し、Drizzle chainを再実装するfakeは追加しません。
 

--- a/api/deno.json
+++ b/api/deno.json
@@ -16,6 +16,7 @@
     "@hono/zod-validator": "jsr:@hono/zod-validator@^0.7.2",
     "@libsql/client": "npm:@libsql/client@^0.15.15",
     "@std/assert": "jsr:@std/assert@^1.0.14",
+    "@std/path": "jsr:@std/path@^1.1.2",
     "@std/testing": "jsr:@std/testing@^1.0.15",
     "drizzle-orm": "npm:drizzle-orm@^0.44.5",
     "drizzle-zod": "npm:drizzle-zod@^0.8.3",

--- a/api/src/db/actions.test.ts
+++ b/api/src/db/actions.test.ts
@@ -1,325 +1,61 @@
+import { assertEquals } from "@std/assert";
 import { describe, test } from "@std/testing/bdd";
-import { assert, assertEquals, assertRejects } from "@std/assert";
-import { createDbActions } from "./actions.ts";
-import { createDb } from "./index.ts";
-import type { MatchRankSnapshot } from "./schema.ts";
-import { MatchWatcherLimitError } from "../errors.ts";
+import { createDbActionsConfigFromEnv } from "./actions.ts";
 
-function createFakeDbWithTransaction(fakeTx: unknown) {
+function env(values: Record<string, string | undefined>) {
   return {
-    transaction: async (callback: (tx: unknown) => Promise<unknown>) =>
-      await callback(fakeTx),
-  } as never;
+    get(name: string) {
+      return values[name];
+    },
+  };
 }
 
-async function createUsersTable(connection: ReturnType<typeof createDb>) {
-  await connection.client.execute(`
-    CREATE TABLE users (
-      discord_id text PRIMARY KEY NOT NULL,
-      riot_id text,
-      created_at integer NOT NULL,
-      updated_at integer
-    )
-  `);
-}
+describe("createDbActionsConfigFromEnv", () => {
+  test("DB action設定が未指定のとき、既定の監視上限とsnapshot TTLを返す", () => {
+    // Arrange
+    const environment = env({});
 
-describe("db/actions.ts", () => {
-  describe("createDbActions", () => {
-    test("DB接続先を指定してactionsを生成するとき、指定したDBだけを更新する", async () => {
-      // Arrange
-      const connectionA = createDb({ url: "file::memory:", logger: false });
-      try {
-        const connectionB = createDb({ url: "file::memory:", logger: false });
-        try {
-          await createUsersTable(connectionA);
-          await createUsersTable(connectionB);
-          const actionsA = createDbActions(connectionA.db);
-          const actionsB = createDbActions(connectionB.db);
+    // Act
+    const config = createDbActionsConfigFromEnv(environment);
 
-          // Act
-          await actionsA.upsertUser("user-a");
-          await actionsB.upsertUser("user-b");
-          const resultA = await connectionA.client.execute(
-            "SELECT discord_id FROM users ORDER BY discord_id",
-          );
-          const resultB = await connectionB.client.execute(
-            "SELECT discord_id FROM users ORDER BY discord_id",
-          );
-
-          // Assert
-          assertEquals(resultA.rows.map((row) => row.discord_id), ["user-a"]);
-          assertEquals(resultB.rows.map((row) => row.discord_id), ["user-b"]);
-        } finally {
-          connectionB.close();
-        }
-      } finally {
-        connectionA.close();
-      }
+    // Assert
+    assertEquals(config, {
+      matchWatcherMaxEnabledPerGuild: 20,
+      pendingRankSnapshotTtlMs: 6 * 60 * 60 * 1_000,
     });
   });
 
-  describe("upsertPendingRankSnapshots", () => {
-    test("beforeスナップショットを一時保存するとき、期限切れのpendingスナップショットを先に削除する", async () => {
-      // Arrange
-      const events: string[] = [];
-      const fakeTx = {
-        delete: () => ({
-          where: () => ({
-            execute: () => {
-              events.push("delete-expired");
-              return Promise.resolve();
-            },
-          }),
-        }),
-        insert: () => ({
-          values: () => {
-            events.push("insert-pending");
-            return {
-              onConflictDoUpdate: () => ({
-                execute: () => Promise.resolve(),
-              }),
-            };
-          },
-        }),
-      };
-      const dbActions = createDbActions(createFakeDbWithTransaction(fakeTx));
-
-      // Act
-      await dbActions.upsertPendingRankSnapshots({
-        platform: "jp1",
-        gameId: "12345",
-        puuid: "puuid-1",
-        snapshots: [{
-          queueType: "RANKED_SOLO_5x5",
-          tier: "EMERALD",
-          rank: "IV",
-          leaguePoints: 2,
-          wins: 10,
-          losses: 8,
-          fetchedAt: new Date("2026-01-01T00:00:00.000Z"),
-        }],
-      });
-
-      // Assert
-      assertEquals(events, ["delete-expired", "insert-pending"]);
+  test("正の数値を指定したとき、DB action設定へ反映する", () => {
+    // Arrange
+    const environment = env({
+      MATCH_WATCH_MAX_ENABLED_PER_GUILD: "5",
+      PENDING_RANK_SNAPSHOT_TTL_MS: "30000",
     });
 
-    test("TTLを指定してbeforeスナップショットを保存するとき、指定TTLでexpiresAtを設定する", async () => {
-      // Arrange
-      let expiresAt: Date | undefined;
-      const fakeTx = {
-        delete: () => ({
-          where: () => ({
-            execute: () => Promise.resolve(),
-          }),
-        }),
-        insert: () => ({
-          values: (payload: { expiresAt: Date }) => {
-            expiresAt = payload.expiresAt;
-            return {
-              onConflictDoUpdate: () => ({
-                execute: () => Promise.resolve(),
-              }),
-            };
-          },
-        }),
-      };
-      const dbActions = createDbActions(createFakeDbWithTransaction(fakeTx), {
-        pendingRankSnapshotTtlMs: 1_000,
-      });
+    // Act
+    const config = createDbActionsConfigFromEnv(environment);
 
-      // Act
-      await dbActions.upsertPendingRankSnapshots({
-        platform: "jp1",
-        gameId: "12345",
-        puuid: "puuid-1",
-        snapshots: [{
-          queueType: "RANKED_SOLO_5x5",
-          tier: "EMERALD",
-          rank: "IV",
-          leaguePoints: 2,
-          wins: 10,
-          losses: 8,
-          fetchedAt: new Date("2026-01-01T00:00:00.000Z"),
-        }],
-      });
-
-      // Assert
-      assertEquals(expiresAt, new Date("2026-01-01T00:00:01.000Z"));
+    // Assert
+    assertEquals(config, {
+      matchWatcherMaxEnabledPerGuild: 5,
+      pendingRankSnapshotTtlMs: 30_000,
     });
   });
 
-  describe("finalizeMatchRankSnapshots", () => {
-    test("pendingスナップショットが消費済みの試合を再確定するとき、保存済みbeforeスナップショットを返す", async () => {
-      // Arrange
-      const existingBefore: MatchRankSnapshot = {
-        id: 1,
-        matchId: "JP1_12345",
-        platform: "jp1",
-        puuid: "puuid-1",
-        queueType: "RANKED_SOLO_5x5",
-        phase: "before",
-        tier: "EMERALD",
-        rank: "IV",
-        leaguePoints: 2,
-        wins: 10,
-        losses: 8,
-        fetchedAt: new Date("2026-01-01T00:00:00.000Z"),
-      };
-      const fakeTx = {
-        query: {
-          pendingMatchRankSnapshots: {
-            findMany: () => Promise.resolve([]),
-          },
-          matchRankSnapshots: {
-            findMany: () => Promise.resolve([existingBefore]),
-          },
-        },
-        insert: () => ({
-          values: (payload: unknown) => ({
-            onConflictDoNothing: () => ({
-              execute: () => Promise.resolve(),
-            }),
-            onConflictDoUpdate: () => ({
-              returning: () =>
-                Promise.resolve([{
-                  id: 2,
-                  ...(payload as Omit<MatchRankSnapshot, "id">),
-                }]),
-            }),
-          }),
-        }),
-        delete: () => ({
-          where: () => ({
-            execute: () => Promise.resolve(),
-          }),
-        }),
-      };
-      const dbActions = createDbActions(createFakeDbWithTransaction(fakeTx));
-
-      // Act
-      const result = await dbActions.finalizeMatchRankSnapshots({
-        matchId: "JP1_12345",
-        platform: "jp1",
-        gameId: "12345",
-        puuid: "puuid-1",
-        snapshots: [{
-          queueType: "RANKED_SOLO_5x5",
-          tier: "EMERALD",
-          rank: "IV",
-          leaguePoints: 19,
-          wins: 11,
-          losses: 8,
-          fetchedAt: new Date("2026-01-01T00:10:00.000Z"),
-        }],
-      });
-
-      // Assert
-      assertEquals(result.before, [existingBefore]);
-      assertEquals(result.after[0].phase, "after");
-      assertEquals(result.after[0].leaguePoints, 19);
+  test("0以下または数値でない値を指定したとき、安全な既定値へ戻す", () => {
+    // Arrange
+    const environment = env({
+      MATCH_WATCH_MAX_ENABLED_PER_GUILD: "0",
+      PENDING_RANK_SNAPSHOT_TTL_MS: "invalid",
     });
-  });
 
-  describe("linkUserWithRiotId", () => {
-    test("既存ユーザーへRiot IDを紐づけるとき、updatedAtも更新する", async () => {
-      // Arrange
-      let updateSet: { riotId: string; updatedAt?: Date } | undefined;
-      const fakeDb = {
-        insert: () => ({
-          values: () => ({
-            onConflictDoUpdate: (
-              config: { set: { riotId: string; updatedAt?: Date } },
-            ) => {
-              updateSet = config.set;
-              return { execute: () => Promise.resolve() };
-            },
-          }),
-        }),
-      } as never;
-      const dbActions = createDbActions(fakeDb);
+    // Act
+    const config = createDbActionsConfigFromEnv(environment);
 
-      // Act
-      await dbActions.linkUserWithRiotId("user-1", "riot-puuid-1");
-
-      // Assert
-      assertEquals(updateSet?.riotId, "riot-puuid-1");
-      assert(updateSet?.updatedAt instanceof Date);
-    });
-  });
-
-  describe("upsertRiotAccount", () => {
-    test("既存ユーザーへRiotアカウントを紐づけるとき、users.updatedAtも更新する", async () => {
-      // Arrange
-      const updateSets: Array<{ riotId?: string; updatedAt?: Date }> = [];
-      const fakeTx = {
-        insert: () => ({
-          values: () => ({
-            onConflictDoUpdate: (
-              config: { set: { riotId?: string; updatedAt?: Date } },
-            ) => {
-              updateSets.push(config.set);
-              return { execute: () => Promise.resolve() };
-            },
-          }),
-        }),
-      };
-      const dbActions = createDbActions(createFakeDbWithTransaction(fakeTx));
-
-      // Act
-      await dbActions.upsertRiotAccount({
-        discordId: "user-1",
-        puuid: "riot-puuid-1",
-        gameName: "Teemo",
-        tagLine: "JP1",
-        platform: "jp1",
-        region: "asia",
-      });
-
-      // Assert
-      assertEquals(updateSets[0].riotId, "riot-puuid-1");
-      assert(updateSets[0].updatedAt instanceof Date);
-    });
-  });
-
-  describe("upsertMatchWatcher", () => {
-    test("監視上限を指定して新規対象を追加するとき、指定上限を超える場合はエラーにする", async () => {
-      // Arrange
-      const fakeTx = {
-        insert: () => ({
-          values: () => ({
-            onConflictDoNothing: () => ({
-              execute: () => Promise.resolve(),
-            }),
-            onConflictDoUpdate: () => ({
-              execute: () => Promise.resolve(),
-            }),
-          }),
-        }),
-        query: {
-          riotAccounts: {
-            findFirst: () => Promise.resolve({ discordId: "target-2" }),
-          },
-          matchWatchers: {
-            findMany: () => Promise.resolve([{ targetDiscordId: "target-1" }]),
-          },
-        },
-      };
-      const dbActions = createDbActions(createFakeDbWithTransaction(fakeTx), {
-        matchWatcherMaxEnabledPerGuild: 1,
-      });
-
-      // Act & Assert
-      await assertRejects(
-        () =>
-          dbActions.upsertMatchWatcher({
-            guildId: "guild-1",
-            targetDiscordId: "target-2",
-            requesterId: "requester-1",
-            channelId: "channel-1",
-          }),
-        MatchWatcherLimitError,
-      );
+    // Assert
+    assertEquals(config, {
+      matchWatcherMaxEnabledPerGuild: 20,
+      pendingRankSnapshotTtlMs: 6 * 60 * 60 * 1_000,
     });
   });
 });

--- a/api/src/db/integration_test_harness.ts
+++ b/api/src/db/integration_test_harness.ts
@@ -1,0 +1,64 @@
+import { migrate } from "drizzle-orm/libsql/migrator";
+import {
+  createDbActions,
+  type DbActions,
+  type DbActionsConfig,
+} from "./actions.ts";
+import { createDb, type DatabaseConnection } from "./index.ts";
+
+export const migrationsFolder = decodeURIComponent(
+  new URL("../../../drizzle", import.meta.url).pathname,
+);
+
+export type MigratedTestDatabase =
+  & Pick<
+    DatabaseConnection,
+    "client" | "db"
+  >
+  & {
+    actions: DbActions;
+    databasePath: string;
+    dispose: () => Promise<void>;
+    [Symbol.asyncDispose]: () => Promise<void>;
+  };
+
+export async function createMigratedTestDatabase(
+  config: Partial<DbActionsConfig> = {},
+): Promise<MigratedTestDatabase> {
+  const temporaryDirectory = await Deno.makeTempDir({
+    prefix: "adteemo-repository-test-",
+  });
+  const databasePath = `${temporaryDirectory}/database.sqlite`;
+  const connection = createDb({
+    url: `file:${databasePath}`,
+    logger: false,
+  });
+  let disposed = false;
+
+  const dispose = async () => {
+    if (disposed) return;
+    disposed = true;
+
+    try {
+      connection.close();
+    } finally {
+      await Deno.remove(temporaryDirectory, { recursive: true });
+    }
+  };
+
+  try {
+    await migrate(connection.db, { migrationsFolder });
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
+
+  return {
+    client: connection.client,
+    db: connection.db,
+    actions: createDbActions(connection.db, config),
+    databasePath,
+    dispose,
+    [Symbol.asyncDispose]: dispose,
+  };
+}

--- a/api/src/db/integration_test_harness.ts
+++ b/api/src/db/integration_test_harness.ts
@@ -1,4 +1,5 @@
 import { migrate } from "drizzle-orm/libsql/migrator";
+import { toFileUrl } from "@std/path";
 import {
   createDbActions,
   type DbActions,
@@ -30,7 +31,7 @@ export async function createMigratedTestDatabase(
   });
   const databasePath = `${temporaryDirectory}/database.sqlite`;
   const connection = createDb({
-    url: `file:${databasePath}`,
+    url: toFileUrl(databasePath).href,
     logger: false,
   });
   let disposed = false;

--- a/api/src/db/integration_test_harness.ts
+++ b/api/src/db/integration_test_harness.ts
@@ -49,6 +49,14 @@ export async function createMigratedTestDatabase(
 
   try {
     await migrate(connection.db, { migrationsFolder });
+    const foreignKeySettings = await connection.client.execute(
+      "PRAGMA foreign_keys",
+    );
+    if (Number(foreignKeySettings.rows[0]?.foreign_keys) !== 1) {
+      throw new Error(
+        "Migrated test database requires foreign key enforcement",
+      );
+    }
   } catch (error) {
     await dispose();
     throw error;

--- a/api/src/db/integration_test_harness.ts
+++ b/api/src/db/integration_test_harness.ts
@@ -1,5 +1,5 @@
 import { migrate } from "drizzle-orm/libsql/migrator";
-import { toFileUrl } from "@std/path";
+import { fromFileUrl, join, toFileUrl } from "@std/path";
 import {
   createDbActions,
   type DbActions,
@@ -7,8 +7,8 @@ import {
 } from "./actions.ts";
 import { createDb, type DatabaseConnection } from "./index.ts";
 
-export const migrationsFolder = decodeURIComponent(
-  new URL("../../../drizzle", import.meta.url).pathname,
+export const migrationsFolder = fromFileUrl(
+  new URL("../../../drizzle", import.meta.url),
 );
 
 export type MigratedTestDatabase =
@@ -29,7 +29,7 @@ export async function createMigratedTestDatabase(
   const temporaryDirectory = await Deno.makeTempDir({
     prefix: "adteemo-repository-test-",
   });
-  const databasePath = `${temporaryDirectory}/database.sqlite`;
+  const databasePath = join(temporaryDirectory, "database.sqlite");
   const connection = createDb({
     url: toFileUrl(databasePath).href,
     logger: false,

--- a/api/src/db/migrations.integration.test.ts
+++ b/api/src/db/migrations.integration.test.ts
@@ -1,0 +1,140 @@
+import { migrate } from "drizzle-orm/libsql/migrator";
+import { is } from "drizzle-orm";
+import {
+  type AnySQLiteTable,
+  getTableConfig,
+  SQLiteTable,
+} from "drizzle-orm/sqlite-core";
+import { assertEquals, assertRejects } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import {
+  createMigratedTestDatabase,
+  migrationsFolder,
+} from "./integration_test_harness.ts";
+import * as schema from "./schema.ts";
+
+const applicationTables = (Object.values(schema) as unknown[]).filter(
+  (value): value is AnySQLiteTable => is(value, SQLiteTable),
+);
+
+function sorted(values: string[]) {
+  return values.toSorted((left, right) => left.localeCompare(right));
+}
+
+describe("SQLite migrations", () => {
+  test("空の一時SQLite DBへ全migrationを適用すると、journalの全entryが記録され再適用しても重複しない", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    const journal = JSON.parse(
+      await Deno.readTextFile(
+        new URL("../../../drizzle/meta/_journal.json", import.meta.url),
+      ),
+    ) as { entries: unknown[] };
+
+    // Act
+    await migrate(database.db, { migrationsFolder });
+    const applied = await database.client.execute(
+      "SELECT hash, created_at FROM __drizzle_migrations ORDER BY created_at",
+    );
+
+    // Assert
+    assertEquals(applied.rows.length, journal.entries.length);
+  });
+
+  test("全migrationを適用したとき、schema定義とtable・column・index・foreign keyが一致する", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    const expectedTables = applicationTables.map((table) =>
+      getTableConfig(table).name
+    );
+
+    // Act
+    const tableRows = await database.client.execute(`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'table'
+        AND name NOT LIKE 'sqlite_%'
+        AND name != '__drizzle_migrations'
+      ORDER BY name
+    `);
+    const indexRows = await database.client.execute(`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'index'
+        AND sql IS NOT NULL
+        AND tbl_name != '__drizzle_migrations'
+      ORDER BY name
+    `);
+
+    // Assert
+    assertEquals(
+      tableRows.rows.map((row) => String(row.name)),
+      sorted(expectedTables),
+    );
+
+    const expectedIndexes = applicationTables.flatMap((table) => {
+      const config = getTableConfig(table);
+      return [
+        ...config.indexes.map((index) => index.config.name),
+        ...config.columns.flatMap((column) =>
+          column.isUnique && column.uniqueName ? [column.uniqueName] : []
+        ),
+      ];
+    });
+    assertEquals(
+      indexRows.rows.map((row) => String(row.name)),
+      sorted(expectedIndexes),
+    );
+
+    for (const table of applicationTables) {
+      const config = getTableConfig(table);
+      const columns = await database.client.execute(
+        `PRAGMA table_info("${config.name}")`,
+      );
+      assertEquals(
+        sorted(columns.rows.map((row) => String(row.name))),
+        sorted(config.columns.map((column) => column.name)),
+        `${config.name}のcolumnがschema定義と一致しません`,
+      );
+
+      const foreignKeys = await database.client.execute(
+        `PRAGMA foreign_key_list("${config.name}")`,
+      );
+      const actualForeignKeys = foreignKeys.rows.map((row) => ({
+        from: String(row.from),
+        onDelete: String(row.on_delete).toLowerCase(),
+        onUpdate: String(row.on_update).toLowerCase(),
+        table: String(row.table),
+        to: String(row.to),
+      })).toSorted((left, right) => left.from.localeCompare(right.from));
+      const expectedForeignKeys = config.foreignKeys.flatMap((foreignKey) => {
+        const reference = foreignKey.reference();
+        return reference.columns.map((column, index) => ({
+          from: column.name,
+          onDelete: foreignKey.onDelete ?? "no action",
+          onUpdate: foreignKey.onUpdate ?? "no action",
+          table: getTableConfig(reference.foreignTable).name,
+          to: reference.foreignColumns[index].name,
+        }));
+      }).toSorted((left, right) => left.from.localeCompare(right.from));
+      assertEquals(
+        actualForeignKeys,
+        expectedForeignKeys,
+        `${config.name}のforeign keyがschema定義と一致しません`,
+      );
+    }
+  });
+
+  test("一時SQLite DBを破棄すると、native clientを閉じてtemp fileを削除する", async () => {
+    // Arrange
+    const database = await createMigratedTestDatabase();
+    const databasePath = database.databasePath;
+    await Deno.stat(databasePath);
+
+    // Act
+    await database.dispose();
+
+    // Assert
+    await assertRejects(() => Deno.stat(databasePath), Deno.errors.NotFound);
+  });
+});

--- a/api/src/db/migrations.integration.test.ts
+++ b/api/src/db/migrations.integration.test.ts
@@ -22,6 +22,22 @@ function sorted(values: string[]) {
 }
 
 describe("SQLite migrations", () => {
+  test("production DB factoryでmigrationを適用すると、foreign key enforcementが有効である", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+
+    // Act
+    const foreignKeySettings = await database.client.execute(
+      "PRAGMA foreign_keys",
+    );
+
+    // Assert
+    assertEquals(
+      Number(foreignKeySettings.rows[0]?.foreign_keys),
+      1,
+    );
+  });
+
   test("空の一時SQLite DBへ全migrationを適用すると、journalの全entryが記録され再適用しても重複しない", async () => {
     // Arrange
     await using database = await createMigratedTestDatabase();

--- a/api/src/db/repositories.integration.test.ts
+++ b/api/src/db/repositories.integration.test.ts
@@ -349,7 +349,43 @@ describe("migration適用済みSQLiteでのrepository integration", () => {
     );
   });
 
-  test("participant途中保存でforeign key違反になると、matchを含めてrollbackし次のtransactionを実行できる", async () => {
+  test("別処理でmatch行だけが作成済みでも、全participantを保存して再送時は重複しない", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    await database.actions.upsertUser("user-1");
+    await database.actions.upsertUser("user-2");
+    await database.actions.upsertExternalMatchDetail({
+      matchId: "match-existing",
+      provider: "opgg",
+      providerRegion: "jp",
+      providerMatchId: "existing",
+      detailUrl: "https://example.com/matches/existing",
+      providerCreatedAt: new Date("2026-07-21T00:00:00.000Z"),
+      averageTier: null,
+    });
+    const input = {
+      matchId: "match-existing",
+      participants: [
+        participant("user-1", "Top"),
+        participant("user-2", "Jungle"),
+      ],
+    };
+
+    // Act
+    const first = await database.actions.createMatchWithParticipants(input);
+    const second = await database.actions.createMatchWithParticipants(input);
+    const savedParticipants = await database.db.select().from(
+      matchParticipants,
+    );
+
+    // Assert
+    assertEquals(first.created, true);
+    assertEquals(first.participants.length, 2);
+    assertEquals(second.created, false);
+    assertEquals(savedParticipants.length, 2);
+  });
+
+  test("participant一括保存でforeign key違反になると、matchを含めてrollbackし次のtransactionを実行できる", async () => {
     // Arrange
     await using database = await createMigratedTestDatabase();
     await database.actions.upsertUser("user-1");

--- a/api/src/db/repositories.integration.test.ts
+++ b/api/src/db/repositories.integration.test.ts
@@ -1,0 +1,410 @@
+import { eq } from "drizzle-orm";
+import { assert, assertEquals, assertFalse, assertRejects } from "@std/assert";
+import { describe, test } from "@std/testing/bdd";
+import { MatchWatcherLimitError, RecordNotFoundError } from "../errors.ts";
+import { createMigratedTestDatabase } from "./integration_test_harness.ts";
+import {
+  customGameEvents,
+  guilds,
+  matches,
+  matchParticipants,
+  matchRankSnapshots,
+  matchWatchers,
+  pendingMatchRankSnapshots,
+  riotAccounts,
+  users,
+} from "./schema.ts";
+
+function riotAccount(discordId: string, puuid = `puuid-${discordId}`) {
+  return {
+    discordId,
+    puuid,
+    gameName: `Teemo-${discordId}`,
+    tagLine: "JP1",
+    platform: "jp1" as const,
+    region: "asia" as const,
+  };
+}
+
+function participant(
+  userId: string,
+  lane: "Top" | "Jungle" = "Top",
+) {
+  return {
+    userId,
+    team: lane === "Top" ? "BLUE" : "RED",
+    win: lane === "Top",
+    lane,
+    kills: 1,
+    deaths: 2,
+    assists: 3,
+    cs: 100,
+    gold: 10_000,
+  };
+}
+
+describe("migration適用済みSQLiteでのrepository integration", () => {
+  test("2つのharnessを並列に作成して更新すると、DB状態を共有しない", async () => {
+    // Arrange
+    await using databaseA = await createMigratedTestDatabase();
+    await using databaseB = await createMigratedTestDatabase();
+
+    // Act
+    await Promise.all([
+      databaseA.actions.upsertUser("user-a"),
+      databaseB.actions.upsertUser("user-b"),
+    ]);
+    const [usersA, usersB] = await Promise.all([
+      databaseA.db.select().from(users),
+      databaseB.db.select().from(users),
+    ]);
+
+    // Assert
+    assertEquals(usersA.map((user) => user.discordId), ["user-a"]);
+    assertEquals(usersB.map((user) => user.discordId), ["user-b"]);
+  });
+
+  test("同じcanonical Riot accountを再upsertすると、unique identityを増やさず表示情報を更新する", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    await database.actions.upsertRiotAccount(riotAccount("user-1"));
+
+    // Act
+    await database.actions.upsertRiotAccount({
+      ...riotAccount("user-1"),
+      gameName: "RenamedTeemo",
+      tagLine: "NEW",
+    });
+    const accounts = await database.db.select().from(riotAccounts);
+    const [user] = await database.db.select().from(users);
+
+    // Assert
+    assertEquals(accounts.length, 1);
+    assertEquals(accounts[0].discordId, "user-1");
+    assertEquals(accounts[0].puuid, "puuid-user-1");
+    assertEquals(accounts[0].gameName, "RenamedTeemo");
+    assertEquals(accounts[0].tagLine, "NEW");
+    assertEquals(user.riotId, "puuid-user-1");
+    assert(user.updatedAt instanceof Date);
+  });
+
+  test("legacy Riot IDを既存ユーザーへ再リンクすると、値とupdatedAtを実DBで更新する", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    await database.actions.linkUserWithRiotId("user-1", "puuid-before");
+
+    // Act
+    await database.actions.linkUserWithRiotId("user-1", "puuid-after");
+    const saved = await database.db.query.users.findFirst({
+      where: eq(users.discordId, "user-1"),
+    });
+
+    // Assert
+    assertEquals(saved?.riotId, "puuid-after");
+    assert(saved?.updatedAt instanceof Date);
+  });
+
+  test("同じcreatorとtargetを別guild・channelへ保存すると、取得とcascadeがguild境界を越えない", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    await database.actions.upsertRiotAccount(riotAccount("target-1"));
+    await database.actions.createCustomGameEvent({
+      name: "Guild A event",
+      guildId: "guild-a",
+      creatorId: "target-1",
+      discordScheduledEventId: "event-a",
+      recruitmentMessageId: "message-a",
+      scheduledStartAt: new Date("2026-08-01T10:00:00.000Z"),
+    });
+    await database.actions.createCustomGameEvent({
+      name: "Guild B event",
+      guildId: "guild-b",
+      creatorId: "target-1",
+      discordScheduledEventId: "event-b",
+      recruitmentMessageId: "message-b",
+      scheduledStartAt: new Date("2026-08-02T10:00:00.000Z"),
+    });
+    await database.actions.upsertMatchWatcher({
+      guildId: "guild-a",
+      targetDiscordId: "target-1",
+      requesterId: "requester-a",
+      channelId: "channel-a",
+    });
+    await database.actions.upsertMatchWatcher({
+      guildId: "guild-b",
+      targetDiscordId: "target-1",
+      requesterId: "requester-b",
+      channelId: "channel-b",
+    });
+
+    // Act
+    const guildAWatchers = await database.actions
+      .getEnabledMatchWatchersByGuild("guild-a");
+    await database.db.delete(guilds).where(eq(guilds.id, "guild-a"));
+    const remainingEvents = await database.db.select().from(customGameEvents);
+    const remainingWatchers = await database.db.select().from(matchWatchers);
+
+    // Assert
+    assertEquals(guildAWatchers.map((watcher) => watcher.channelId), [
+      "channel-a",
+    ]);
+    assertEquals(remainingEvents.map((event) => event.guildId), ["guild-b"]);
+    assertEquals(
+      remainingWatchers.map((watcher) => ({
+        guildId: watcher.guildId,
+        channelId: watcher.channelId,
+      })),
+      [{ guildId: "guild-b", channelId: "channel-b" }],
+    );
+  });
+
+  test("親recordがないeventを直接保存すると、foreign key違反になり次のrepository操作は成功する", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+
+    // Act & Assert
+    await assertRejects(() =>
+      database.db.insert(customGameEvents).values({
+        name: "orphan event",
+        guildId: "missing-guild",
+        creatorId: "missing-user",
+        discordScheduledEventId: "orphan-event",
+        recruitmentMessageId: "orphan-message",
+        scheduledStartAt: new Date("2026-08-01T10:00:00.000Z"),
+      }).execute()
+    );
+    await database.actions.upsertUser("user-after-fk-error");
+    const saved = await database.db.query.users.findFirst({
+      where: eq(users.discordId, "user-after-fk-error"),
+    });
+    assertEquals(saved?.discordId, "user-after-fk-error");
+  });
+
+  test("pending rank snapshotを保存すると、TTLをDB状態へ反映し次回操作で期限切れだけを削除する", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase({
+      pendingRankSnapshotTtlMs: 1_000,
+    });
+    const expiredFetchedAt = new Date("2026-01-01T00:00:00.000Z");
+    await database.actions.upsertPendingRankSnapshots({
+      platform: "jp1",
+      gameId: "expired-game",
+      puuid: "expired-puuid",
+      snapshots: [{
+        queueType: "RANKED_SOLO_5x5",
+        tier: "EMERALD",
+        rank: "IV",
+        leaguePoints: 2,
+        wins: 10,
+        losses: 8,
+        fetchedAt: expiredFetchedAt,
+      }],
+    });
+    const expired = await database.db.query.pendingMatchRankSnapshots
+      .findFirst();
+
+    // Act
+    await database.actions.upsertPendingRankSnapshots({
+      platform: "jp1",
+      gameId: "active-game",
+      puuid: "active-puuid",
+      snapshots: [{
+        queueType: "RANKED_SOLO_5x5",
+        tier: "DIAMOND",
+        rank: "IV",
+        leaguePoints: 10,
+        wins: 20,
+        losses: 10,
+        fetchedAt: new Date("2099-01-01T00:00:00.000Z"),
+      }],
+    });
+    const remaining = await database.db.select().from(
+      pendingMatchRankSnapshots,
+    );
+
+    // Assert
+    assertEquals(
+      expired?.expiresAt,
+      new Date("2026-01-01T00:00:01.000Z"),
+    );
+    assertEquals(remaining.map((snapshot) => snapshot.gameId), [
+      "active-game",
+    ]);
+  });
+
+  test("pending snapshotを試合へ確定して再実行すると、保存済みbeforeを再利用しafterだけを更新する", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    await database.actions.upsertPendingRankSnapshots({
+      platform: "jp1",
+      gameId: "12345",
+      puuid: "puuid-1",
+      snapshots: [{
+        queueType: "RANKED_SOLO_5x5",
+        tier: "EMERALD",
+        rank: "IV",
+        leaguePoints: 2,
+        wins: 10,
+        losses: 8,
+        fetchedAt: new Date("2099-01-01T00:00:00.000Z"),
+      }],
+    });
+    const input = {
+      matchId: "JP1_12345",
+      platform: "jp1" as const,
+      gameId: "12345",
+      puuid: "puuid-1",
+      snapshots: [{
+        queueType: "RANKED_SOLO_5x5" as const,
+        tier: "EMERALD",
+        rank: "IV",
+        leaguePoints: 19,
+        wins: 11,
+        losses: 8,
+        fetchedAt: new Date("2099-01-01T00:10:00.000Z"),
+      }],
+    };
+    const first = await database.actions.finalizeMatchRankSnapshots(input);
+
+    // Act
+    const second = await database.actions.finalizeMatchRankSnapshots({
+      ...input,
+      snapshots: [{ ...input.snapshots[0], leaguePoints: 21 }],
+    });
+    const saved = await database.db.select().from(matchRankSnapshots);
+
+    // Assert
+    assertEquals(first.before.length, 1);
+    assertEquals(second.before, first.before);
+    assertEquals(second.after[0].leaguePoints, 21);
+    assertEquals(saved.length, 2);
+  });
+
+  test("監視上限を超えてwatcherを追加すると、errorを返してtransaction内の途中recordも残さない", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase({
+      matchWatcherMaxEnabledPerGuild: 1,
+    });
+    await database.actions.upsertRiotAccount(riotAccount("target-1"));
+    await database.actions.upsertRiotAccount(riotAccount("target-2"));
+    await database.actions.upsertMatchWatcher({
+      guildId: "guild-1",
+      targetDiscordId: "target-1",
+      requesterId: "requester-1",
+      channelId: "channel-1",
+    });
+
+    // Act & Assert
+    await assertRejects(
+      () =>
+        database.actions.upsertMatchWatcher({
+          guildId: "guild-1",
+          targetDiscordId: "target-2",
+          requesterId: "requester-rolled-back",
+          channelId: "channel-2",
+        }),
+      MatchWatcherLimitError,
+    );
+    const watchers = await database.actions.getEnabledMatchWatchersByGuild(
+      "guild-1",
+    );
+    const rolledBackRequester = await database.db.query.users.findFirst({
+      where: eq(users.discordId, "requester-rolled-back"),
+    });
+    assertEquals(watchers.map((watcher) => watcher.targetDiscordId), [
+      "target-1",
+    ]);
+    assertEquals(rolledBackRequester, undefined);
+  });
+
+  test("matchと全participantを保存して同じmatchを再送すると、1回分だけcommitする", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    await database.actions.upsertUser("user-1");
+    await database.actions.upsertUser("user-2");
+    const input = {
+      matchId: "match-1",
+      participants: [
+        participant("user-1", "Top"),
+        participant("user-2", "Jungle"),
+      ],
+    };
+
+    // Act
+    const first = await database.actions.createMatchWithParticipants(input);
+    const second = await database.actions.createMatchWithParticipants(input);
+    const savedMatches = await database.db.select().from(matches);
+    const savedParticipants = await database.db.select().from(
+      matchParticipants,
+    );
+
+    // Assert
+    assertEquals(first.created, true);
+    assertEquals(second.created, false);
+    assertEquals(savedMatches.map((match) => match.id), ["match-1"]);
+    assertEquals(
+      savedParticipants.map((savedParticipant) => savedParticipant.userId)
+        .toSorted(),
+      ["user-1", "user-2"],
+    );
+  });
+
+  test("participant途中保存でforeign key違反になると、matchを含めてrollbackし次のtransactionを実行できる", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    await database.actions.upsertUser("user-1");
+    const input = {
+      matchId: "match-rollback",
+      participants: [
+        participant("user-1", "Top"),
+        participant("missing-user", "Jungle"),
+      ],
+    };
+
+    // Act & Assert
+    await assertRejects(() =>
+      database.actions.createMatchWithParticipants(input)
+    );
+    assertEquals(
+      await database.db.select().from(matches).where(
+        eq(matches.id, input.matchId),
+      ),
+      [],
+    );
+    assertEquals(
+      await database.db.select().from(matchParticipants),
+      [],
+    );
+
+    await database.actions.upsertUser("missing-user");
+    const retried = await database.actions.createMatchWithParticipants(input);
+    assertEquals(retried.created, true);
+    assertEquals(retried.participants.length, 2);
+  });
+
+  test("単体participant保存時、not foundは専用errorにしDB failureとは区別する", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    await database.db.insert(matches).values({ id: "match-1" });
+
+    // Act & Assert
+    await assertRejects(
+      () =>
+        database.actions.createMatchParticipant({
+          matchId: "match-1",
+          ...participant("missing-user"),
+        }),
+      RecordNotFoundError,
+    );
+
+    await database.actions.upsertUser("user-1");
+    await database.client.execute("DROP TABLE match_participants");
+    const databaseError = await assertRejects(() =>
+      database.actions.createMatchParticipant({
+        matchId: "match-1",
+        ...participant("user-1"),
+      })
+    );
+    assertFalse(databaseError instanceof RecordNotFoundError);
+  });
+});

--- a/api/src/db/repositories.integration.test.ts
+++ b/api/src/db/repositories.integration.test.ts
@@ -385,6 +385,74 @@ describe("migration適用済みSQLiteでのrepository integration", () => {
     assertEquals(savedParticipants.length, 2);
   });
 
+  test("単体participantだけが保存済みのmatchへ全participantを保存すると、不足分だけ追加して再送時は重複しない", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    await database.actions.upsertUser("user-1");
+    await database.actions.upsertUser("user-2");
+    await database.db.insert(matches).values({ id: "match-partial" });
+    await database.actions.createMatchParticipant({
+      matchId: "match-partial",
+      ...participant("user-1", "Top"),
+    });
+    const input = {
+      matchId: "match-partial",
+      participants: [
+        participant("user-1", "Top"),
+        participant("user-2", "Jungle"),
+      ],
+    };
+
+    // Act
+    const first = await database.actions.createMatchWithParticipants(input);
+    const second = await database.actions.createMatchWithParticipants(input);
+    const savedParticipants = await database.db.select().from(
+      matchParticipants,
+    );
+
+    // Assert
+    assertEquals(first.created, true);
+    assertEquals(
+      first.participants.map((savedParticipant) => savedParticipant.userId)
+        .toSorted(),
+      ["user-1", "user-2"],
+    );
+    assertEquals(second.created, false);
+    assertEquals(
+      savedParticipants.map((savedParticipant) => savedParticipant.userId)
+        .toSorted(),
+      ["user-1", "user-2"],
+    );
+  });
+
+  test("同じuserIdを複数participantとして保存すると、入力を拒否してmatchもparticipantも作成しない", async () => {
+    // Arrange
+    await using database = await createMigratedTestDatabase();
+    await database.actions.upsertUser("user-1");
+    const input = {
+      matchId: "match-duplicate-user",
+      participants: [
+        participant("user-1", "Top"),
+        participant("user-1", "Jungle"),
+      ],
+    };
+
+    // Act & Assert
+    await assertRejects(() =>
+      database.actions.createMatchWithParticipants(input)
+    );
+    assertEquals(
+      await database.db.select().from(matches).where(
+        eq(matches.id, input.matchId),
+      ),
+      [],
+    );
+    assertEquals(
+      await database.db.select().from(matchParticipants),
+      [],
+    );
+  });
+
   test("participant一括保存でforeign key違反になると、matchを含めてrollbackし次のtransactionを実行できる", async () => {
     // Arrange
     await using database = await createMigratedTestDatabase();

--- a/api/src/db/repositories/matches.ts
+++ b/api/src/db/repositories/matches.ts
@@ -39,10 +39,55 @@ type RankSnapshotPayload = {
   fetchedAt?: Date;
 };
 
+type MatchParticipantPayload = Omit<
+  z.infer<typeof matchParticipantInsertSchema>,
+  "id" | "matchId"
+>;
+
 export function createMatchesRepository(
   database: Database,
   config: Pick<DbActionsConfig, "pendingRankSnapshotTtlMs">,
 ) {
+  async function createMatchWithParticipants(input: {
+    matchId: string;
+    participants: MatchParticipantPayload[];
+  }) {
+    return await database.transaction(async (tx) => {
+      const [createdMatch] = await tx.insert(matches).values({
+        id: input.matchId,
+      }).onConflictDoNothing().returning({ id: matches.id });
+
+      if (!createdMatch) {
+        const savedParticipants = await tx.query.matchParticipants.findMany({
+          where: eq(matchParticipants.matchId, input.matchId),
+        });
+        return {
+          created: false as const,
+          matchId: input.matchId,
+          participants: savedParticipants,
+        };
+      }
+
+      const savedParticipants = [];
+      for (const participant of input.participants) {
+        const payload = matchParticipantInsertSchema.parse({
+          ...participant,
+          matchId: input.matchId,
+        });
+        const [savedParticipant] = await tx.insert(matchParticipants).values(
+          payload,
+        ).returning();
+        savedParticipants.push(savedParticipant);
+      }
+
+      return {
+        created: true as const,
+        matchId: input.matchId,
+        participants: savedParticipants,
+      };
+    });
+  }
+
   async function createMatchParticipant(
     participantData: z.infer<typeof matchParticipantInsertSchema>,
   ) {
@@ -322,6 +367,7 @@ export function createMatchesRepository(
   }
 
   return {
+    createMatchWithParticipants,
     createMatchParticipant,
     upsertPendingRankSnapshots,
     finalizeMatchRankSnapshots,

--- a/api/src/db/repositories/matches.ts
+++ b/api/src/db/repositories/matches.ts
@@ -61,24 +61,24 @@ export function createMatchesRepository(
         const savedParticipants = await tx.query.matchParticipants.findMany({
           where: eq(matchParticipants.matchId, input.matchId),
         });
-        return {
-          created: false as const,
-          matchId: input.matchId,
-          participants: savedParticipants,
-        };
+        if (savedParticipants.length > 0 || input.participants.length === 0) {
+          return {
+            created: false as const,
+            matchId: input.matchId,
+            participants: savedParticipants,
+          };
+        }
       }
 
-      const savedParticipants = [];
-      for (const participant of input.participants) {
-        const payload = matchParticipantInsertSchema.parse({
+      const payloads = input.participants.map((participant) =>
+        matchParticipantInsertSchema.parse({
           ...participant,
           matchId: input.matchId,
-        });
-        const [savedParticipant] = await tx.insert(matchParticipants).values(
-          payload,
-        ).returning();
-        savedParticipants.push(savedParticipant);
-      }
+        })
+      );
+      const savedParticipants = payloads.length === 0
+        ? []
+        : await tx.insert(matchParticipants).values(payloads).returning();
 
       return {
         created: true as const,

--- a/api/src/db/repositories/matches.ts
+++ b/api/src/db/repositories/matches.ts
@@ -18,6 +18,24 @@ import {
 } from "../schema.ts";
 
 const matchParticipantInsertSchema = createInsertSchema(matchParticipants);
+const matchParticipantPayloadSchema = matchParticipantInsertSchema.omit({
+  id: true,
+  matchId: true,
+});
+const matchParticipantsPayloadSchema = z.array(matchParticipantPayloadSchema)
+  .superRefine((participants, context) => {
+    const userIds = new Set<string>();
+    participants.forEach((participant, index) => {
+      if (userIds.has(participant.userId)) {
+        context.addIssue({
+          code: "custom",
+          message: "Participant userId must be unique within a match",
+          path: [index, "userId"],
+        });
+      }
+      userIds.add(participant.userId);
+    });
+  });
 const externalMatchDetailInsertSchema = createInsertSchema(
   externalMatchDetails,
 );
@@ -39,10 +57,7 @@ type RankSnapshotPayload = {
   fetchedAt?: Date;
 };
 
-type MatchParticipantPayload = Omit<
-  z.infer<typeof matchParticipantInsertSchema>,
-  "id" | "matchId"
->;
+type MatchParticipantPayload = z.infer<typeof matchParticipantPayloadSchema>;
 
 export function createMatchesRepository(
   database: Database,
@@ -52,30 +67,40 @@ export function createMatchesRepository(
     matchId: string;
     participants: MatchParticipantPayload[];
   }) {
+    const participants = matchParticipantsPayloadSchema.parse(
+      input.participants,
+    );
+
     return await database.transaction(async (tx) => {
       const [createdMatch] = await tx.insert(matches).values({
         id: input.matchId,
       }).onConflictDoNothing().returning({ id: matches.id });
 
-      if (!createdMatch) {
-        const savedParticipants = await tx.query.matchParticipants.findMany({
+      const existingParticipants = createdMatch
+        ? []
+        : await tx.query.matchParticipants.findMany({
           where: eq(matchParticipants.matchId, input.matchId),
         });
-        if (savedParticipants.length > 0 || input.participants.length === 0) {
-          return {
-            created: false as const,
+      const existingUserIds = new Set(
+        existingParticipants.map((participant) => participant.userId),
+      );
+
+      const payloads = participants
+        .filter((participant) => !existingUserIds.has(participant.userId))
+        .map((participant) =>
+          matchParticipantInsertSchema.parse({
+            ...participant,
             matchId: input.matchId,
-            participants: savedParticipants,
-          };
-        }
+          })
+        );
+      if (!createdMatch && payloads.length === 0) {
+        return {
+          created: false as const,
+          matchId: input.matchId,
+          participants: existingParticipants,
+        };
       }
 
-      const payloads = input.participants.map((participant) =>
-        matchParticipantInsertSchema.parse({
-          ...participant,
-          matchId: input.matchId,
-        })
-      );
       const savedParticipants = payloads.length === 0
         ? []
         : await tx.insert(matchParticipants).values(payloads).returning();
@@ -83,7 +108,7 @@ export function createMatchesRepository(
       return {
         created: true as const,
         matchId: input.matchId,
-        participants: savedParticipants,
+        participants: [...existingParticipants, ...savedParticipants],
       };
     });
   }

--- a/api/src/test_utils.ts
+++ b/api/src/test_utils.ts
@@ -41,6 +41,8 @@ export function createTestDependencies(
         ),
       getEventStartingTodayByCreatorId: () =>
         unexpectedDependencyCall("dbActions.getEventStartingTodayByCreatorId"),
+      createMatchWithParticipants: () =>
+        unexpectedDependencyCall("dbActions.createMatchWithParticipants"),
       createMatchParticipant: () =>
         unexpectedDependencyCall("dbActions.createMatchParticipant"),
       upsertPendingRankSnapshots: () =>

--- a/deno.json
+++ b/deno.json
@@ -8,8 +8,8 @@
     "fmt:check": "deno fmt --check",
     "lint": "deno lint",
     "check": "deno check api/src/app.ts bot/src/main.ts messages/src/main.ts lib/logger/mod.ts",
-    "test:all": "deno test --allow-env --allow-read --allow-sys --allow-ffi --env-file=.env.example --ignore=api/src/riot_api.live.test.ts --coverage -q",
-    "test:target": "deno test --allow-env --allow-read --allow-sys --allow-ffi --env-file=.env.example -q",
+    "test:all": "deno test --allow-env --allow-read --allow-write --allow-sys --allow-ffi --env-file=.env.example --ignore=api/src/riot_api.live.test.ts --coverage -q",
+    "test:target": "deno test --allow-env --allow-read --allow-write --allow-sys --allow-ffi --env-file=.env.example -q",
     "test:riot-live": "RIOT_LIVE_TEST=1 deno test --allow-env --allow-net --env-file=.env api/src/riot_api.live.test.ts",
     "test:allcov": "deno task test:all",
     "quality": {

--- a/deno.lock
+++ b/deno.lock
@@ -801,6 +801,7 @@
           "jsr:@hono/hono@^4.9.6",
           "jsr:@hono/zod-validator@~0.7.2",
           "jsr:@std/assert@^1.0.14",
+          "jsr:@std/path@^1.1.2",
           "jsr:@std/testing@^1.0.15",
           "npm:@libsql/client@~0.15.15",
           "npm:drizzle-orm@~0.44.5",

--- a/scripts/quality-configuration.test.ts
+++ b/scripts/quality-configuration.test.ts
@@ -139,6 +139,12 @@ describe("test tasks", () => {
       fullTask as string,
       "--ignore=api/src/riot_api.live.test.ts",
     );
+    for (const task of [targetTask as string, fullTask as string]) {
+      assertStringIncludes(task, "--allow-read");
+      assertStringIncludes(task, "--allow-write");
+      assertStringIncludes(task, "--allow-sys");
+      assertStringIncludes(task, "--allow-ffi");
+    }
     assertEquals((targetTask as string).includes("--allow-net"), false);
     assertEquals((fullTask as string).includes("--allow-net"), false);
   });


### PR DESCRIPTION
## 概要

- productionと同じDB factory・migration・repositoryを使う一時SQLite harnessを追加
- migration後DBとschemaのtable・column・index・foreign key整合を検証
- FK、cascade、Riot account再upsert、guild/channel分離、transaction rollback、idempotency、not foundとDB failureの区別を実DB状態で検証
- Drizzle query chainを模倣していた重複unit testを整理
- native libsqlに必要なtest task権限とテスト方針文書を同期

## 背景

既存のrepository testはquery builderやtransaction chainのfakeが中心で、実SQLiteの制約、migrationとschemaの不一致、rollback後の状態を検出できませんでした。Issue #113/#114/#117で必要になる実DB fixtureを先に共用化します。

## 影響

- 通常テストは一時SQLite fileを作るためwrite/sys/ffi権限を使用します
- network権限は追加していません
- matches repositoryにmatchと全participantを単一transactionで保存する一括APIを追加しています
- record-matchのAPI/Bot接続自体は#113の後続範囲です

## 検証

- `deno task quality`
  - 60 tests / 513 steps passed
- `git diff --check`
- Riot live testは外部接続不要のため未実行

Closes #124